### PR TITLE
base operator functions implementations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ fix-all:
 .PHONY: check-all
 check-all:
 	$(UV) run ruff check
-	$(UV) run mypy
+	$(UV) run mypy src tests
 	$(UV) run pytest
 	$(PYTHON) scripts/verify_format.py
 	$(HELM) lint --strict helm/jupyter-k8s
@@ -44,7 +44,7 @@ check-all:
 run-all:
 	$(UV) run ruff format
 	$(UV) run ruff check --fix
-	$(UV) run mypy
+	$(UV) run mypy src tests
 	$(UV) run pytest
 	$(HELM) lint --strict helm/jupyter-k8s
 
@@ -67,7 +67,7 @@ apply-crd:
 # Delete CRD
 .PHONY: delete-crd
 delete-crd:
-	$(KUBECLT) --kubeconfig=$(KUBECONFIG) delete crd servers.jupyter.org --ignore-not-found=true
+	$(KUBECLT) --kubeconfig=$(KUBECONFIG) delete crd jupyterservers.servers.jupyter.org --ignore-not-found=true
 
 # Build and install Helm chart locally
 .PHONY: local-deploy
@@ -78,7 +78,9 @@ local-deploy: local-dev-setup
 	$(MAKE) apply-crd
 	$(HELM) upgrade --install jupyter-k8s helm/jupyter-k8s \
 		--namespace $(NAMESPACE) --create-namespace \
-		--kubeconfig $(KUBECONFIG)
+		--kubeconfig $(KUBECONFIG) \
+		--set image.repository=$(IMAGE_NAME) \
+		--set image.tag=$(IMAGE_TAG)
 
 # Run basic tests with the CRD on the running cluster
 .PHONY: operator-tests
@@ -91,9 +93,60 @@ operator-tests:
 	$(KUBECLT) --kubeconfig=$(KUBECONFIG) get JupyterServer
 	@echo "JupyterServer successfully retrieved"
 	@echo ""
+	@echo "Waiting for operator to process the resource..."
+	@sleep 5
+	@echo "Checking if deployment was created..."
+	$(KUBECLT) --kubeconfig=$(KUBECONFIG) get deployment jupyter-sample-notebook
+	@echo "Deployment found!"
+	@echo ""
+	@echo "Waiting for deployment to be ready..."
+	$(KUBECLT) --kubeconfig=$(KUBECONFIG) wait --for=condition=available --timeout=300s deployment/jupyter-sample-notebook
+	@echo "Deployment is ready!"
+	@echo ""
+	@echo "Checking service..."
+	$(KUBECLT) --kubeconfig=$(KUBECONFIG) get service jupyter-sample-notebook-service
+	@echo "Service found!"
+	@echo ""
+	@echo "Checking JupyterServer status..."
+	$(KUBECLT) --kubeconfig=$(KUBECONFIG) get jupyterserver sample-notebook -o jsonpath='{.status}' || echo "Status not yet available"
+	@echo ""
 	@echo "DELETE TEST"
 	$(KUBECLT) --kubeconfig=$(KUBECONFIG) delete JupyterServer sample-notebook
 	@echo "JupyterServer successfully deleted"
+	@echo ""
+	@echo "Verifying cleanup..."
+	@sleep 3
+	@echo "Checking if deployment was cleaned up..."
+	$(KUBECLT) --kubeconfig=$(KUBECONFIG) get deployment jupyter-sample-notebook 2>/dev/null && echo "WARNING: Deployment still exists" || echo "Deployment cleaned up successfully"
+	@echo "Checking if service was cleaned up..."
+	$(KUBECLT) --kubeconfig=$(KUBECONFIG) get service jupyter-sample-notebook-service 2>/dev/null && echo "WARNING: Service still exists" || echo "Service cleaned up successfully"
+
+# Port forward to a specific Jupyter server
+.PHONY: port-forward
+port-forward:
+	@echo "Available Jupyter servers:"
+	@$(KUBECLT) --kubeconfig=$(KUBECONFIG) get jupyterservers --no-headers | awk '{print "  " $$1}'
+	@echo ""
+	@read -p "Enter server name: " SERVER_NAME; \
+	if [ -z "$$SERVER_NAME" ]; then \
+		echo "Server name cannot be empty"; \
+		exit 1; \
+	fi; \
+	echo "Port forwarding to jupyter-$$SERVER_NAME-service..."; \
+	echo "Access at http://localhost:8888"; \
+	echo "Press Ctrl+C to stop port forwarding"; \
+	$(KUBECLT) --kubeconfig=$(KUBECONFIG) port-forward service/jupyter-$$SERVER_NAME-service 8888:8888
+
+# Get logs from a Jupyter server
+.PHONY: logs
+logs:
+	@read -p "Enter server name: " SERVER_NAME; \
+	if [ -z "$$SERVER_NAME" ]; then \
+		echo "Server name cannot be empty"; \
+		exit 1; \
+	fi; \
+	echo "Getting logs for jupyter-$$SERVER_NAME..."; \
+	$(KUBECLT) --kubeconfig=$(KUBECONFIG) logs -l app=jupyter-server,instance=$$SERVER_NAME -f
 
 # Tear down local development environment
 .PHONY: local-dev-teardown
@@ -114,16 +167,32 @@ clean:
 # Help message
 help:
 	@echo "Makefile targets:"
+	@echo ""
+	@echo "Development:"
 	@echo "  sync                - Sync the UV environment"
 	@echo "  fix-all             - Run formatter and linter fix"
 	@echo "  check-all           - Run linter without fix, type-checker and unit tests"
 	@echo "  run-all             - Run formatter and linter fix, type-check and unit tests"
-	@echo "  build               - Bundle dependencies, build Docker image and push to local registry"
+	@echo ""
+	@echo "Deployment:"
 	@echo "  local-dev-setup     - Set up local cluster and configure kubectl access"
 	@echo "  build               - Build the image and push to local finch cluster"
 	@echo "  apply-crd           - Manually apply CRD to the cluster"
 	@echo "  delete-crd          - Delete the old CRD from the cluster, no-op if does not exist"
 	@echo "  local-deploy        - Set up local cluster, configure kubectl access, build and install Helm chart locally"
-	@echo "  operator-tests      - Test basic operation on the custom operators"
 	@echo "  local-dev-teardown  - Tear down local development environment"
+	@echo ""
+	@echo "Testing:"
+	@echo "  operator-tests      - Test basic operation on the custom operators"
+	@echo ""
+	@echo "Jupyter Server Management:"
+	@echo "  list-servers        - List all Jupyter servers and their status"
+	@echo "  port-forward        - Interactive port forward to a Jupyter server"
+	@echo "  port-forward-custom - Port forward with custom local port"
+	@echo "  port-forward-sample - Quick port forward to sample-notebook server"
+	@echo "  show-access         - Show access instructions for a server"
+	@echo "  watch-servers       - Watch Jupyter server status in real-time"
+	@echo "  logs                - Get logs from a Jupyter server"
+	@echo ""
+	@echo "Cleanup:"
 	@echo "  clean               - Clean build artifacts"

--- a/helm/jupyter-k8s/templates/rbac.yaml
+++ b/helm/jupyter-k8s/templates/rbac.yaml
@@ -14,6 +14,14 @@ rules:
   - apiGroups: [""]
     resources: ["pods", "services", "persistentvolumeclaims", "secrets", "configmaps"]
     verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  # Permissions for deployments (needed to create Jupyter deployments)
+  - apiGroups: ["apps"]
+    resources: ["deployments", "replicasets"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  # Permissions for CRDs (needed by kopf to watch for CRD changes)
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list", "watch"]
   # Permissions for Jupyter notebook custom resources
   - apiGroups: ["servers.jupyter.org"]
     resources: ["jupyterservers", "jupyterservers/status"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ requires-python = ">=3.12"
 dependencies = [
     "kopf>=1.38.0",
     "kubernetes>=33.1.0",
+    "pydantic>=2.0.0",
     "pyyaml>=6.0.2",
 ]
 

--- a/src/jupyter_k8s/controllers/notebook.py
+++ b/src/jupyter_k8s/controllers/notebook.py
@@ -1,25 +1,279 @@
 """Notebook controller handlers for the Jupyter K8s operator."""
 
 import logging
+from typing import Any
 
 import kopf
+from kubernetes import client  # type: ignore
+from kubernetes.client.rest import ApiException  # type: ignore
+from pydantic import ValidationError
+
+from ..models import JupyterServerSpec
 
 # Set up logger
 logger = logging.getLogger("jupyter-k8s")
 
+# Create module-level client instances
+apps_v1 = client.AppsV1Api()
+core_v1 = client.CoreV1Api()
+
+
+def handle_create_notebook(spec: dict[str, Any], name: str, namespace: str, meta: dict[str, Any]) -> dict[str, Any]:
+    """Handle creation of a Jupyter notebook server."""
+
+    try:
+        # Validate and parse spec
+        jupyter_spec = JupyterServerSpec(**spec)
+    except ValidationError as e:
+        logger.error(f"Invalid spec for {name}: {e}")
+        return {
+            "status": {
+                "phase": "Failed",
+                "error": str(e),
+                "message": "Invalid spec",
+            }
+        }
+
+    try:
+        # Create Deployment
+        deployment = create_jupyter_deployment(name, namespace, jupyter_spec)
+        logger.info(f"Creating deployment: jupyter-{name}")
+
+        deployment_result = apps_v1.create_namespaced_deployment(namespace=namespace, body=deployment)
+        deployment_name = deployment_result.metadata.name if deployment_result.metadata else f"jupyter-{name}"
+        logger.info(f"Deployment created successfully: {deployment_name}")
+
+        # Create Service
+        service = create_jupyter_service(name, namespace)
+        logger.info(f"Creating service: jupyter-{name}-service")
+
+        service_result = core_v1.create_namespaced_service(namespace=namespace, body=service)
+        service_name = service_result.metadata.name if service_result.metadata else f"jupyter-{name}-service"
+        logger.info(f"Service created successfully: {service_name}")
+
+        # Return status update
+        return {
+            "status": {
+                "phase": "Running",
+                "deploymentName": deployment_name,
+                "serviceName": service_name,
+                "accessInstructions": {
+                    "portForward": f"kubectl port-forward service/{service_name} 8888:8888 -n {namespace}",
+                    "url": "http://localhost:8888",
+                },
+            }
+        }
+
+    except ApiException as e:
+        logger.error(f"Failed to create Jupyter server: {e}")
+        return {
+            "status": {
+                "phase": "Failed",
+                "error": str(e),
+                "message": "Failed to create resources",
+            }
+        }
+
+
+def handle_delete_notebook(name: str, namespace: str) -> None:
+    """Handle deletion of a Jupyter notebook server."""
+
+    try:
+        deployment_name = f"jupyter-{name}"
+        service_name = f"jupyter-{name}-service"
+
+        # Delete deployment
+        try:
+            apps_v1.delete_namespaced_deployment(name=deployment_name, namespace=namespace)
+            logger.info(f"Deployment {deployment_name} deleted successfully")
+        except ApiException as e:
+            if e.status != 404:  # Ignore not found errors
+                logger.warning(f"Failed to delete deployment {deployment_name}: {e}")
+
+        # Delete service
+        try:
+            core_v1.delete_namespaced_service(name=service_name, namespace=namespace)
+            logger.info(f"Service {service_name} deleted successfully")
+        except ApiException as e:
+            if e.status != 404:  # Ignore not found errors
+                logger.warning(f"Failed to delete service {service_name}: {e}")
+
+    except Exception as e:
+        logger.error(f"Failed to delete Jupyter server resources: {e}")
+
+
+def handle_update_notebook(
+    spec: dict[str, Any], name: str, namespace: str, old: dict[str, Any], new: dict[str, Any]
+) -> dict[str, Any] | None:
+    """Handle update of a Jupyter notebook server."""
+
+    # Check if spec has actually changed
+    old_spec = old.get("spec", {})
+    new_spec = new.get("spec", {})
+
+    if old_spec == new_spec:
+        logger.info(f"No spec changes detected for {name}, skipping update")
+        return None
+
+    try:
+        # Validate and parse spec
+        jupyter_spec = JupyterServerSpec(**spec)
+    except ValidationError as e:
+        logger.error(f"Invalid spec for {name}: {e}")
+        return {
+            "status": {
+                "phase": "Failed",
+                "error": str(e),
+                "message": "Invalid spec",
+            }
+        }
+
+    try:
+        deployment_name = f"jupyter-{name}"
+
+        # Update deployment
+        deployment = create_jupyter_deployment(name, namespace, jupyter_spec)
+        logger.info(f"Updating deployment: {deployment_name}")
+
+        deployment_result = apps_v1.patch_namespaced_deployment(
+            name=deployment_name, namespace=namespace, body=deployment
+        )
+        deployment_name_result = deployment_result.metadata.name if deployment_result.metadata else deployment_name
+        logger.info(f"Deployment updated successfully: {deployment_name_result}")
+
+        return {
+            "status": {
+                "phase": "Running",
+                "deploymentName": deployment_name,
+                "serviceName": f"jupyter-{name}-service",
+            }
+        }
+
+    except ApiException as e:
+        logger.error(f"Failed to update Jupyter server: {e}")
+        return {
+            "status": {
+                "phase": "Failed",
+                "error": str(e),
+            }
+        }
+
 
 @kopf.on.create("servers.jupyter.org", "v1alpha1", "jupyterservers")
-def create_notebook(*_, **kwargs) -> dict[str, str]:
-    """Handle creation of a Jupyter server resource."""
-    name = kwargs.get("name") or kwargs.get("meta", {}).get("name", "unknown")
-    logger.info(f"Received create event for JupyterServer: {name}")
-    logger.info("This is a minimal implementation that does not create any resources.")
-    return {"status": "Acknowledged", "message": "Create request logged (no action taken)"}
+def create_notebook(spec, name, namespace, meta, **kwargs):
+    """Kopf handler for creating Jupyter notebook servers."""
+    return handle_create_notebook(spec, name, namespace, meta)
 
 
 @kopf.on.delete("servers.jupyter.org", "v1alpha1", "jupyterservers")
-def delete_notebook(*_, **kwargs) -> None:
-    """Handle deletion of a Jupyter server resource."""
-    name = kwargs.get("name") or kwargs.get("meta", {}).get("name", "unknown")
-    logger.info(f"Received delete event for JupyterServer: {name}")
-    logger.info("This is a minimal implementation that does not delete any resources.")
+def delete_notebook(name, namespace, **kwargs):
+    """Kopf handler for deleting Jupyter notebook servers."""
+    handle_delete_notebook(name, namespace)
+
+
+@kopf.on.update("servers.jupyter.org", "v1alpha1", "jupyterservers")
+def update_notebook(spec, name, namespace, old, new, **kwargs):
+    """Kopf handler for updating Jupyter notebook servers."""
+    return handle_update_notebook(spec, name, namespace, old, new)
+
+
+def create_jupyter_deployment(name: str, namespace: str, jupyter_spec: JupyterServerSpec) -> client.V1Deployment:
+    """Create a Kubernetes deployment for Jupyter server."""
+
+    image = jupyter_spec.image
+    resources = jupyter_spec.resources.dict() if jupyter_spec.resources else {}
+
+    # Create container
+    container = client.V1Container(
+        name="jupyter",
+        image=image,
+        ports=[client.V1ContainerPort(container_port=8888, name="jupyter")],
+        env=[
+            client.V1EnvVar(name="JUPYTER_ENABLE_LAB", value="yes"),
+            client.V1EnvVar(name="JUPYTER_TOKEN", value=""),
+        ],
+        liveness_probe=client.V1Probe(
+            http_get=client.V1HTTPGetAction(path="/api", port=8888),
+            initial_delay_seconds=30,
+            period_seconds=10,
+        ),
+        readiness_probe=client.V1Probe(
+            http_get=client.V1HTTPGetAction(path="/api", port=8888),
+            initial_delay_seconds=5,
+            period_seconds=5,
+        ),
+    )
+
+    # Add resources if specified
+    if resources:
+        container.resources = client.V1ResourceRequirements(**resources)
+
+    # Create pod template
+    template = client.V1PodTemplateSpec(
+        metadata=client.V1ObjectMeta(
+            labels={
+                "app": "jupyter-server",
+                "instance": name,
+            }
+        ),
+        spec=client.V1PodSpec(containers=[container]),
+    )
+
+    # Create deployment spec
+    deployment_spec = client.V1DeploymentSpec(
+        replicas=1,
+        selector=client.V1LabelSelector(
+            match_labels={
+                "app": "jupyter-server",
+                "instance": name,
+            }
+        ),
+        template=template,
+    )
+
+    # Create deployment
+    deployment = client.V1Deployment(
+        api_version="apps/v1",
+        kind="Deployment",
+        metadata=client.V1ObjectMeta(
+            name=f"jupyter-{name}",
+            namespace=namespace,
+            labels={
+                "app": "jupyter-server",
+                "instance": name,
+            },
+        ),
+        spec=deployment_spec,
+    )
+
+    return deployment
+
+
+def create_jupyter_service(name: str, namespace: str) -> client.V1Service:
+    """Create a Kubernetes service for Jupyter server."""
+    return client.V1Service(
+        api_version="v1",
+        kind="Service",
+        metadata=client.V1ObjectMeta(
+            name=f"jupyter-{name}-service",
+            namespace=namespace,
+            labels={
+                "app": "jupyter-server",
+                "instance": name,
+            },
+        ),
+        spec=client.V1ServiceSpec(
+            selector={
+                "app": "jupyter-server",
+                "instance": name,
+            },
+            ports=[
+                client.V1ServicePort(
+                    port=8888,
+                    target_port=8888,
+                    name="jupyter",
+                )
+            ],
+            type="ClusterIP",
+        ),
+    )

--- a/src/jupyter_k8s/main.py
+++ b/src/jupyter_k8s/main.py
@@ -5,6 +5,9 @@ import logging
 
 import kopf
 
+# Import controllers to register handlers
+from jupyter_k8s.controllers import notebook  # noqa: F401
+
 # Set up logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("jupyter-k8s")

--- a/src/jupyter_k8s/models.py
+++ b/src/jupyter_k8s/models.py
@@ -1,0 +1,30 @@
+"""Data models for Jupyter K8s operator."""
+
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class ResourceRequirements(BaseModel):
+    """Kubernetes resource requirements."""
+
+    requests: dict[str, str] | None = None
+    limits: dict[str, str] | None = None
+
+
+class JupyterServerSpec(BaseModel):
+    """JupyterServer spec model."""
+
+    name: str
+    image: str
+    desiredStatus: Literal["Running", "Stopped"] | None = "Running"
+    serviceAccountName: str | None = None
+    resources: ResourceRequirements | None = None
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "JupyterServerSpec":
+        """Create instance from dictionary with nested resource conversion."""
+        if "resources" in data and data["resources"] is not None:
+            data = data.copy()
+            data["resources"] = ResourceRequirements(**data["resources"])
+        return cls(**data)

--- a/tests/controllers/test_notebooks.py
+++ b/tests/controllers/test_notebooks.py
@@ -1,90 +1,308 @@
 """Tests for the Jupyter K8s server controller."""
 
 import unittest
-from typing import Any
 from unittest.mock import Mock, patch
 
-from jupyter_k8s.controllers.notebook import create_notebook, delete_notebook
+from kubernetes.client.rest import ApiException  # type: ignore
+
+from jupyter_k8s.controllers.notebook import (
+    create_jupyter_deployment,
+    create_jupyter_service,
+    handle_create_notebook,
+    handle_delete_notebook,
+    handle_update_notebook,
+)
+from jupyter_k8s.models import JupyterServerSpec
 
 
 class TestCreateNotebook(unittest.TestCase):
+    """Test cases for notebook creation."""
+
+    def setUp(self) -> None:
+        """Set up test fixtures."""
+        self.mock_spec = {
+            "name": "comprehensive-notebook-server",
+            "desiredStatus": "Running",
+            "image": "jupyter/scipy-notebook:latest",
+            "serviceAccountName": "default",
+            "resources": {
+                "requests": {"memory": "512Mi", "cpu": "250m"},
+                "limits": {"memory": "1Gi", "cpu": "500m"},
+            },
+        }
+        self.mock_meta = {"name": "test-notebook", "namespace": "default"}
+
+    @patch("jupyter_k8s.controllers.notebook.apps_v1")
+    @patch("jupyter_k8s.controllers.notebook.core_v1")
     @patch("jupyter_k8s.controllers.notebook.logger")
-    def test_create_notebook_happy_case(self, mock_logger: Mock) -> None:
-        """Test that create_notebook logs messages and returns expected status."""
+    def test_create_notebook_success(self, mock_logger, mock_core_v1, mock_apps_v1):
+        """Test successful creation of a Jupyter server."""
         # Arrange
-        mock_kwargs = {"meta": {"name": "test-notebook"}}
+        mock_deployment_result = Mock()
+        mock_deployment_result.metadata.name = "jupyter-test-notebook"
+        mock_apps_v1.create_namespaced_deployment.return_value = mock_deployment_result
+
+        mock_service_result = Mock()
+        mock_service_result.metadata.name = "jupyter-test-notebook-service"
+        mock_core_v1.create_namespaced_service.return_value = mock_service_result
 
         # Act
-        result = create_notebook(**mock_kwargs)  # type: ignore
+        result = handle_create_notebook(
+            spec=self.mock_spec,
+            name="test-notebook",
+            namespace="default",
+            meta=self.mock_meta,
+        )
 
         # Assert
-        self.assertEqual({"status": "Acknowledged", "message": "Create request logged (no action taken)"}, result)
-        mock_logger.info.assert_called()
-        self.assertEqual(mock_logger.info.call_count, 2)
+        self.assertEqual(result["status"]["phase"], "Running")
+        self.assertEqual(result["status"]["deploymentName"], "jupyter-test-notebook")
+        self.assertEqual(result["status"]["serviceName"], "jupyter-test-notebook-service")
+        self.assertEqual(
+            result["status"]["accessInstructions"]["portForward"],
+            "kubectl port-forward service/jupyter-test-notebook-service 8888:8888 -n default",
+        )
+        self.assertEqual(result["status"]["accessInstructions"]["url"], "http://localhost:8888")
 
+        # Verify API calls
+        mock_apps_v1.create_namespaced_deployment.assert_called_once()
+        mock_core_v1.create_namespaced_service.assert_called_once()
+
+        # Verify logging
+        mock_logger.info.assert_any_call("Creating deployment: jupyter-test-notebook")
+        mock_logger.info.assert_any_call("Creating service: jupyter-test-notebook-service")
+
+    @patch("jupyter_k8s.controllers.notebook.apps_v1")
+    @patch("jupyter_k8s.controllers.notebook.core_v1")
     @patch("jupyter_k8s.controllers.notebook.logger")
-    def test_create_notebook_no_meta(self, mock_logger: Mock) -> None:
-        """Test that create_notebook handles missing metadata."""
+    def test_create_notebook_deployment_failure(self, mock_logger, mock_core_v1, mock_apps_v1):
+        """Test handling of deployment creation failure."""
         # Arrange
-        mock_kwargs = {"name": "test-notebook"}
+        mock_apps_v1.create_namespaced_deployment.side_effect = ApiException(status=400, reason="Bad Request")
 
         # Act
-        result = create_notebook(**mock_kwargs)  # type: ignore
+        result = handle_create_notebook(
+            spec=self.mock_spec,
+            name="test-notebook",
+            namespace="default",
+            meta=self.mock_meta,
+        )
 
         # Assert
-        self.assertEqual({"status": "Acknowledged", "message": "Create request logged (no action taken)"}, result)
-        mock_logger.info.assert_called()
-        self.assertEqual(mock_logger.info.call_count, 2)
+        self.assertEqual(result["status"]["phase"], "Failed")
+        self.assertIn("error", result["status"])
+        self.assertEqual(result["status"]["message"], "Failed to create resources")
 
+        # Verify service creation was not attempted
+        mock_core_v1.create_namespaced_service.assert_not_called()
+
+        # Verify error logging
+        mock_logger.error.assert_called_once()
+
+    @patch("jupyter_k8s.controllers.notebook.apps_v1")
+    @patch("jupyter_k8s.controllers.notebook.core_v1")
     @patch("jupyter_k8s.controllers.notebook.logger")
-    def test_create_notebook_no_name(self, mock_logger: Mock) -> None:
-        """Test that create_notebook handles missing name."""
+    def test_create_notebook_service_failure(self, mock_logger, mock_core_v1, mock_apps_v1):
+        """Test handling of service creation failure."""
         # Arrange
-        mock_kwargs: dict[str, Any] = {}
+        mock_deployment_result = Mock()
+        mock_deployment_result.metadata.name = "jupyter-test-notebook"
+        mock_apps_v1.create_namespaced_deployment.return_value = mock_deployment_result
+
+        mock_core_v1.create_namespaced_service.side_effect = ApiException(status=400, reason="Bad Request")
 
         # Act
-        result = create_notebook(**mock_kwargs)  # type: ignore
+        result = handle_create_notebook(
+            spec=self.mock_spec,
+            name="test-notebook",
+            namespace="default",
+            meta=self.mock_meta,
+        )
 
         # Assert
-        self.assertEqual({"status": "Acknowledged", "message": "Create request logged (no action taken)"}, result)
-        self.assertEqual(mock_logger.info.call_count, 2)
+        self.assertEqual(result["status"]["phase"], "Failed")
+        self.assertIn("error", result["status"])
+        self.assertEqual(result["status"]["message"], "Failed to create resources")
+
+        # Verify both API calls were attempted
+        mock_apps_v1.create_namespaced_deployment.assert_called_once()
+        mock_core_v1.create_namespaced_service.assert_called_once()
+
+    def test_create_jupyter_deployment(self):
+        """Test creation of Kubernetes deployment object."""
+        jupyter_spec = JupyterServerSpec.from_dict(self.mock_spec)
+        # Act
+        deployment = create_jupyter_deployment(
+            name="test-notebook",
+            namespace="default",
+            jupyter_spec=jupyter_spec,
+        )
+
+        # Assert
+        self.assertEqual(deployment.metadata.name, "jupyter-test-notebook")
+        self.assertEqual(deployment.metadata.namespace, "default")
+        self.assertEqual(
+            deployment.metadata.labels,
+            {"app": "jupyter-server", "instance": "test-notebook"},
+        )
+
+        # Check deployment spec
+        self.assertEqual(deployment.spec.replicas, 1)
+        self.assertEqual(
+            deployment.spec.selector.match_labels,
+            {"app": "jupyter-server", "instance": "test-notebook"},
+        )
+
+        # Check pod template
+        container = deployment.spec.template.spec.containers[0]
+        self.assertEqual(container.name, "jupyter")
+        self.assertEqual(container.image, self.mock_spec["image"])
+        self.assertEqual(container.ports[0].container_port, 8888)
+        self.assertEqual(container.env[0].name, "JUPYTER_ENABLE_LAB")
+        self.assertEqual(container.env[0].value, "yes")
+
+    def test_create_jupyter_service(self):
+        """Test creation of Kubernetes service object."""
+        # Act
+        service = create_jupyter_service(name="test-notebook", namespace="default")
+
+        # Assert
+        self.assertEqual(service.metadata.name, "jupyter-test-notebook-service")
+        self.assertEqual(service.metadata.namespace, "default")
+        self.assertEqual(
+            service.metadata.labels,
+            {"app": "jupyter-server", "instance": "test-notebook"},
+        )
+
+        # Check service spec
+        self.assertEqual(service.spec.type, "ClusterIP")
+        self.assertEqual(
+            service.spec.selector,
+            {"app": "jupyter-server", "instance": "test-notebook"},
+        )
+        self.assertEqual(service.spec.ports[0].port, 8888)
+        self.assertEqual(service.spec.ports[0].target_port, 8888)
+        self.assertEqual(service.spec.ports[0].name, "jupyter")
 
 
 class TestDeleteNotebook(unittest.TestCase):
-    @patch("jupyter_k8s.controllers.notebook.logger")
-    def test_delete_notebook_happy_case(self, mock_logger: Mock) -> None:
-        """Test that delete_notebook logs messages."""
-        # Arrange
-        mock_kwargs = {"meta": {"name": "test-notebook"}}
+    """Test cases for notebook deletion."""
 
+    @patch("jupyter_k8s.controllers.notebook.apps_v1")
+    @patch("jupyter_k8s.controllers.notebook.core_v1")
+    @patch("jupyter_k8s.controllers.notebook.logger")
+    def test_delete_notebook_success(self, mock_logger, mock_core_v1, mock_apps_v1):
+        """Test successful deletion of a Jupyter server."""
         # Act
-        delete_notebook(**mock_kwargs)  # type: ignore
+        handle_delete_notebook(name="test-notebook", namespace="default")
 
         # Assert
-        self.assertEqual(mock_logger.info.call_count, 2)
+        mock_apps_v1.delete_namespaced_deployment.assert_called_once_with(
+            name="jupyter-test-notebook", namespace="default"
+        )
+        mock_core_v1.delete_namespaced_service.assert_called_once_with(
+            name="jupyter-test-notebook-service", namespace="default"
+        )
 
+        # Verify logging
+        mock_logger.info.assert_any_call("Deployment jupyter-test-notebook deleted successfully")
+        mock_logger.info.assert_any_call("Service jupyter-test-notebook-service deleted successfully")
+
+    @patch("jupyter_k8s.controllers.notebook.apps_v1")
+    @patch("jupyter_k8s.controllers.notebook.core_v1")
     @patch("jupyter_k8s.controllers.notebook.logger")
-    def test_delete_notebook_no_meta(self, mock_logger: Mock) -> None:
-        """Test that delete_notebook handles missing metadata."""
+    def test_delete_notebook_not_found(self, mock_logger, mock_core_v1, mock_apps_v1):
+        """Test deletion when resources don't exist."""
         # Arrange
-        mock_kwargs = {"name": "test-notebook"}
+        mock_apps_v1.delete_namespaced_deployment.side_effect = ApiException(status=404)
+        mock_core_v1.delete_namespaced_service.side_effect = ApiException(status=404)
 
         # Act
-        delete_notebook(**mock_kwargs)  # type: ignore
+        handle_delete_notebook(name="test-notebook", namespace="default")
 
-        # Assert
-        mock_logger.info.assert_called()
-        self.assertEqual(mock_logger.info.call_count, 2)
+        # Assert - should not raise exception for 404s
+        mock_apps_v1.delete_namespaced_deployment.assert_called_once()
+        mock_core_v1.delete_namespaced_service.assert_called_once()
 
+    @patch("jupyter_k8s.controllers.notebook.apps_v1")
+    @patch("jupyter_k8s.controllers.notebook.core_v1")
     @patch("jupyter_k8s.controllers.notebook.logger")
-    def test_delete_notebook_no_name(self, mock_logger: Mock) -> None:
-        """Test that delete_notebook handles missing name."""
+    def test_delete_notebook_error(self, mock_logger, mock_core_v1, mock_apps_v1):
+        """Test deletion with API error."""
         # Arrange
-        mock_kwargs: dict[str, Any] = {}
+        mock_apps_v1.delete_namespaced_deployment.side_effect = ApiException(status=500, reason="Internal Server Error")
 
         # Act
-        delete_notebook(**mock_kwargs)  # type: ignore
+        handle_delete_notebook(name="test-notebook", namespace="default")
 
         # Assert
-        mock_logger.info.assert_called()
-        self.assertEqual(mock_logger.info.call_count, 2)
+        mock_logger.warning.assert_called_once()
+        self.assertIn(
+            "Failed to delete deployment",
+            mock_logger.warning.call_args[0][0],
+        )
+
+
+class TestUpdateNotebook(unittest.TestCase):
+    """Test cases for notebook updates."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.old = {
+            "spec": {
+                "image": "jupyter/scipy-notebook:old",
+                "resources": {"requests": {"memory": "256Mi"}},
+            }
+        }
+        self.new = {
+            "spec": {
+                "image": "jupyter/scipy-notebook:new",
+                "resources": {"requests": {"memory": "512Mi"}},
+            }
+        }
+
+    @patch("jupyter_k8s.controllers.notebook.apps_v1")
+    @patch("jupyter_k8s.controllers.notebook.logger")
+    def test_update_notebook_no_changes(self, mock_logger, mock_apps_v1):
+        """Test update when no spec changes detected."""
+        # Act
+        result = handle_update_notebook(
+            spec=self.old["spec"],
+            name="test-notebook",
+            namespace="default",
+            old=self.old,
+            new=self.old,  # Same spec
+        )
+
+        # Assert
+        self.assertIsNone(result)
+        mock_apps_v1.patch_namespaced_deployment.assert_not_called()
+        mock_logger.info.assert_called_with("No spec changes detected for test-notebook, skipping update")
+
+    @patch("jupyter_k8s.controllers.notebook.apps_v1")
+    @patch("jupyter_k8s.controllers.notebook.logger")
+    def test_update_notebook_failure(self, mock_logger, mock_apps_v1):
+        """Test update with API error."""
+        # Arrange
+        mock_apps_v1.patch_namespaced_deployment.side_effect = ApiException(status=400, reason="Bad Request")
+
+        # Act
+        result = handle_update_notebook(
+            spec=self.new["spec"],
+            name="test-notebook",
+            namespace="default",
+            old=self.old,
+            new=self.new,
+        )
+
+        # Assert
+        self.assertIsNotNone(result)
+        assert result is not None  # For type checking
+        self.assertEqual(result["status"]["phase"], "Failed")
+        self.assertIn("error", result["status"])
+
+        mock_logger.error.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION

Basic Operator logic with kopf
Tested by deploying to local kind cluster.
------

```
❯ kubectl --kubeconfig=.kubeconfig get deployment jupyter-test-custom-notebook -o jsonpath='{.spec.template.spec.containers[0].resources}'
{"limits":{"cpu":"500m","memory":"1Gi"},"requests":{"cpu":"250m","memory":"512Mi"}}
```
---
```
❯ make operator-tests
CREATE TEST
kubectl --kubeconfig=.kubeconfig apply -f examples/sample-notebook.yaml
jupyterserver.servers.jupyter.org/sample-notebook created
JupyterServer successfully created

GET TEST
kubectl --kubeconfig=.kubeconfig get JupyterServer
NAME              AGE
sample-notebook   0s
JupyterServer successfully retrieved

Waiting for operator to process the resource...
Checking if deployment was created...
kubectl --kubeconfig=.kubeconfig get deployment jupyter-sample-notebook
NAME                      READY   UP-TO-DATE   AVAILABLE   AGE
jupyter-sample-notebook   0/1     1            0           4s
Deployment found!

Waiting for deployment to be ready...
kubectl --kubeconfig=.kubeconfig wait --for=condition=available --timeout=300s deployment/jupyter-sample-notebook
deployment.apps/jupyter-sample-notebook condition met
Deployment is ready!

Checking service...
kubectl --kubeconfig=.kubeconfig get service jupyter-sample-notebook-service
NAME                              TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)    AGE
jupyter-sample-notebook-service   ClusterIP   10.96.199.205   <none>        8888/TCP   10s
Service found!

Checking JupyterServer status...
kubectl --kubeconfig=.kubeconfig get jupyterserver sample-notebook -o jsonpath='{.status}' || echo "Status not yet available"
{}
DELETE TEST
kubectl --kubeconfig=.kubeconfig delete JupyterServer sample-notebook
jupyterserver.servers.jupyter.org "sample-notebook" deleted
JupyterServer successfully deleted

Verifying cleanup...
Checking if deployment was cleaned up...
kubectl --kubeconfig=.kubeconfig get deployment jupyter-sample-notebook 2>/dev/null && echo "WARNING: Deployment still exists" || echo "Deployment cleaned up successfully"
Deployment cleaned up successfully
Checking if service was cleaned up...
kubectl --kubeconfig=.kubeconfig get service jupyter-sample-notebook-service 2>/dev/null && echo "WARNING: Service still exists" || echo "Service cleaned up successfully"
Service cleaned up successfully
```