### PR TITLE
feat: owner webhook implementation

### DIFF
--- a/config/certmanager/certificate.yaml
+++ b/config/certmanager/certificate.yaml
@@ -1,0 +1,13 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: jupyter-k8s-serving-cert
+  namespace: system
+spec:
+  dnsNames:
+  - jupyter-k8s-controller-manager.jupyter-k8s-system.svc
+  - jupyter-k8s-controller-manager.jupyter-k8s-system.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: webhook-server-cert

--- a/config/certmanager/issuer.yaml
+++ b/config/certmanager/issuer.yaml
@@ -1,0 +1,7 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned-issuer
+  namespace: system
+spec:
+  selfSigned: {}

--- a/config/certmanager/kustomization.yaml
+++ b/config/certmanager/kustomization.yaml
@@ -1,0 +1,6 @@
+resources:
+- certificate.yaml
+- issuer.yaml
+
+configurations:
+- kustomizeconfig.yaml

--- a/config/certmanager/kustomizeconfig.yaml
+++ b/config/certmanager/kustomizeconfig.yaml
@@ -1,0 +1,13 @@
+nameReference:
+- kind: Issuer
+  group: cert-manager.io
+  fieldSpecs:
+  - kind: Certificate
+    group: cert-manager.io
+    path: spec/issuerRef/name
+
+varReference:
+- path: spec/dnsNames
+  kind: Certificate
+- path: spec/dnsNames
+  kind: Certificate

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -12,5 +12,5 @@ patches:
 
 # [WEBHOOK] To enable webhook, uncomment the following section
 # the following config is for teaching kustomize how to do kustomization for CRDs.
-#configurations:
-#- kustomizeconfig.yaml
+configurations:
+- kustomizeconfig.yaml

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -20,9 +20,9 @@ resources:
 - ../manager
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-#- ../webhook
+- ../webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
-#- ../certmanager
+- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 # [METRICS] Expose the controller manager metrics service.

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -63,11 +63,15 @@ spec:
         args:
           - --leader-elect
           - --health-probe-bind-address=:8081
+          - --webhook-port=9443
           - --application-images-pull-policy=IfNotPresent
           - --application-images-registry=docker.io/library
         image: controller:latest
         name: manager
-        ports: []
+        ports:
+        - containerPort: 9443
+          name: webhook
+          protocol: TCP
         securityContext:
           readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
@@ -95,7 +99,13 @@ spec:
           requests:
             cpu: 10m
             memory: 64Mi
-        volumeMounts: []
-      volumes: []
+        volumeMounts:
+        - name: webhook-certs
+          mountPath: /tmp/k8s-webhook-server/serving-certs
+          readOnly: true
+      volumes:
+      - name: webhook-certs
+        secret:
+          secretName: webhook-server-cert
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/config/webhook/certificate.yaml
+++ b/config/webhook/certificate.yaml
@@ -1,0 +1,20 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: jupyter-k8s-webhook-cert
+  namespace: jupyter-k8s-system
+spec:
+  secretName: jupyter-k8s-webhook-certs
+  duration: 2160h  # 90 days
+  renewBefore: 360h  # 15 days
+  privateKey:
+    rotationPolicy: Always
+  subject:
+    organizations:
+      - jupyter-k8s-operator
+  commonName: jupyter-k8s-webhook
+  dnsNames:
+    - jupyter-k8s-controller-manager.jupyter-k8s-system.svc
+  issuerRef:
+    name: jupyter-k8s-issuer
+    kind: Issuer

--- a/config/webhook/issuer.yaml
+++ b/config/webhook/issuer.yaml
@@ -1,0 +1,7 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: jupyter-k8s-issuer
+  namespace: jupyter-k8s-system
+spec:
+  selfSigned: {}

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -1,0 +1,6 @@
+resources:
+- webhook-config.yaml
+- service.yaml
+
+configurations:
+- kustomizeconfig.yaml

--- a/config/webhook/kustomizeconfig.yaml
+++ b/config/webhook/kustomizeconfig.yaml
@@ -1,0 +1,17 @@
+nameReference:
+- kind: Service
+  version: v1
+  fieldSpecs:
+  - kind: MutatingWebhookConfiguration
+    group: admissionregistration.k8s.io
+    path: webhooks/clientConfig/service/name
+
+namespace:
+- kind: MutatingWebhookConfiguration
+  group: admissionregistration.k8s.io
+  path: webhooks/clientConfig/service/namespace
+  create: false
+
+varReference:
+- path: metadata/annotations/cert-manager.io\/inject-ca-from
+  kind: MutatingWebhookConfiguration

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  ports:
+  - port: 9443
+    targetPort: 9443
+    name: webhook
+  selector:
+    control-plane: controller-manager
+    app.kubernetes.io/name: jupyter-k8s

--- a/config/webhook/webhook-config.yaml
+++ b/config/webhook/webhook-config.yaml
@@ -1,0 +1,23 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: jupyter-k8s-webhook
+  annotations:
+    cert-manager.io/inject-ca-from: jupyter-k8s-system/jupyter-k8s-serving-cert
+webhooks:
+- name: workspaces.jupyter.org
+  clientConfig:
+    service:
+      name: jupyter-k8s-controller-manager
+      namespace: jupyter-k8s-system
+      path: "/mutate-workspace"
+      port: 9443
+  rules:
+  - operations: ["CREATE"]
+    apiGroups: ["workspaces.jupyter.org"]
+    apiVersions: ["v1alpha1"]
+    resources: ["workspaces"]
+  admissionReviewVersions: ["v1"]
+  sideEffects: None
+  failurePolicy: Fail
+  timeoutSeconds: 10

--- a/internal/webhook/workspace_webhook.go
+++ b/internal/webhook/workspace_webhook.go
@@ -1,0 +1,101 @@
+// Package webhook provides mutating admission webhooks for Workspace resources.
+// The WorkspaceMutator automatically adds ownership annotations to track resource creators.
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// WorkspaceMutator is a mutating admission webhook that automatically adds a "created-by" annotation
+// to Workspace resources when they are created. This annotation tracks which user created the Workspace
+// and can be used for ownership-based access control and auditing.
+type WorkspaceMutator struct{}
+
+// Handle processes admission requests for Workspace resources and adds a "created-by" annotation
+// containing the sanitized username of the requesting user. This enables ownership tracking
+// and audit trails for workspace creation.
+func (m *WorkspaceMutator) Handle(ctx context.Context, req admission.Request) admission.Response {
+	logger := log.FromContext(ctx).WithName("workspace-webhook")
+
+	logger.V(1).Info("Processing admission request",
+		"kind", req.Kind.Kind,
+		"group", req.Kind.Group,
+		"namespace", req.Namespace,
+		"name", req.Name,
+		"user", req.UserInfo.Username)
+
+	if req.Kind.Kind != "Workspace" || req.Kind.Group != "workspaces.jupyter.org" {
+		logger.Info("Skipping non-Workspace resource", "kind", req.Kind.Kind, "group", req.Kind.Group)
+		return admission.Allowed("Not a workspaces.jupyter.org/Workspace resource")
+	}
+
+	if req.Object.Raw == nil {
+		logger.Error(nil, "Request object is nil")
+		return admission.Errored(http.StatusBadRequest, fmt.Errorf("request object is nil"))
+	}
+
+	var obj map[string]interface{}
+	if err := json.Unmarshal(req.Object.Raw, &obj); err != nil {
+		logger.Error(err, "Failed to unmarshal object")
+		return admission.Errored(http.StatusBadRequest, fmt.Errorf("error unmarshaling object: %v", err))
+	}
+
+	metadata, ok := obj["metadata"].(map[string]interface{})
+	if !ok {
+		logger.Error(nil, "Metadata field not found or invalid")
+		return admission.Errored(http.StatusBadRequest, fmt.Errorf("metadata field not found or invalid"))
+	}
+
+	sanitizedUsername := sanitizeUsername(req.UserInfo.Username)
+	logger.Info("Adding created-by annotation",
+		"workspace", req.Name,
+		"namespace", req.Namespace,
+		"user", sanitizedUsername)
+
+	var patch string
+	if annotations, ok := metadata["annotations"].(map[string]interface{}); ok && annotations != nil {
+		patch = `[{"op":"add","path":"/metadata/annotations/created-by","value":"` + sanitizedUsername + `"}]`
+		logger.V(1).Info("Adding annotation to existing annotations", "patch", patch)
+	} else {
+		patch = `[{"op":"add","path":"/metadata/annotations","value":{"created-by":"` + sanitizedUsername + `"}}]`
+		logger.V(1).Info("Creating new annotations object", "patch", patch)
+	}
+	patchType := admissionv1.PatchTypeJSONPatch
+
+	logger.Info("Successfully processed workspace admission request",
+		"workspace", req.Name,
+		"namespace", req.Namespace,
+		"user", sanitizedUsername)
+
+	return admission.Response{
+		AdmissionResponse: admissionv1.AdmissionResponse{
+			UID:       req.UID,
+			Allowed:   true,
+			Result:    &metav1.Status{Code: http.StatusOK},
+			Patch:     []byte(patch),
+			PatchType: &patchType,
+		},
+	}
+}
+
+// InjectDecoder injects the admission decoder. This method is required by the
+// admission.DecoderInjector interface but is not used by this webhook implementation.
+func (m *WorkspaceMutator) InjectDecoder(d *admission.Decoder) error {
+	return nil
+}
+
+// sanitizeUsername properly escapes characters for JSON without changing the username
+func sanitizeUsername(username string) string {
+	// Use Go's JSON marshaling to properly escape the string
+	escaped, _ := json.Marshal(username)
+	// Remove the surrounding quotes that json.Marshal adds
+	return string(escaped[1 : len(escaped)-1])
+}

--- a/internal/webhook/workspace_webhook_test.go
+++ b/internal/webhook/workspace_webhook_test.go
@@ -1,0 +1,239 @@
+package webhook
+
+import (
+	"context"
+	"testing"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+func TestWorkspaceMutator_Handle(t *testing.T) {
+	tests := []struct {
+		name            string
+		req             admission.Request
+		expectedAllowed bool
+		expectedPatch   string
+		expectError     bool
+	}{
+		{
+			name: "successful mutation with no existing annotations",
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Kind: metav1.GroupVersionKind{
+						Group:   "workspaces.jupyter.org",
+						Version: "v1alpha1",
+						Kind:    "Workspace",
+					},
+					Object: runtime.RawExtension{
+						Raw: []byte(`{"metadata":{"name":"test-workspace"}}`),
+					},
+					UserInfo: authenticationv1.UserInfo{
+						Username: "test-user",
+					},
+				},
+			},
+			expectedAllowed: true,
+			expectedPatch:   `[{"op":"add","path":"/metadata/annotations","value":{"created-by":"test-user"}}]`,
+		},
+		{
+			name: "successful mutation with existing annotations",
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Kind: metav1.GroupVersionKind{
+						Group:   "workspaces.jupyter.org",
+						Version: "v1alpha1",
+						Kind:    "Workspace",
+					},
+					Object: runtime.RawExtension{
+						Raw: []byte(`{"metadata":{"name":"test-workspace","annotations":{"existing":"value"}}}`),
+					},
+					UserInfo: authenticationv1.UserInfo{
+						Username: "test-user",
+					},
+				},
+			},
+			expectedAllowed: true,
+			expectedPatch:   `[{"op":"add","path":"/metadata/annotations/created-by","value":"test-user"}]`,
+		},
+		{
+			name: "username with special characters",
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Kind: metav1.GroupVersionKind{
+						Group:   "workspaces.jupyter.org",
+						Version: "v1alpha1",
+						Kind:    "Workspace",
+					},
+					Object: runtime.RawExtension{
+						Raw: []byte(`{"metadata":{"name":"test-workspace"}}`),
+					},
+					UserInfo: authenticationv1.UserInfo{
+						Username: `user@domain.com`,
+					},
+				},
+			},
+			expectedAllowed: true,
+			expectedPatch:   `[{"op":"add","path":"/metadata/annotations","value":{"created-by":"user@domain.com"}}]`,
+		},
+		{
+			name: "non-workspace resource should be allowed without mutation",
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Kind: metav1.GroupVersionKind{
+						Group:   "apps",
+						Version: "v1",
+						Kind:    "Deployment",
+					},
+					Object: runtime.RawExtension{
+						Raw: []byte(`{"metadata":{"name":"test-deployment"}}`),
+					},
+					UserInfo: authenticationv1.UserInfo{
+						Username: "test-user",
+					},
+				},
+			},
+			expectedAllowed: true,
+			expectedPatch:   "",
+		},
+		{
+			name: "nil object should return error",
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Kind: metav1.GroupVersionKind{
+						Group:   "workspaces.jupyter.org",
+						Version: "v1alpha1",
+						Kind:    "Workspace",
+					},
+					Object: runtime.RawExtension{
+						Raw: nil,
+					},
+					UserInfo: authenticationv1.UserInfo{
+						Username: "test-user",
+					},
+				},
+			},
+			expectedAllowed: false,
+			expectError:     true,
+		},
+		{
+			name: "invalid JSON should return error",
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Kind: metav1.GroupVersionKind{
+						Group:   "workspaces.jupyter.org",
+						Version: "v1alpha1",
+						Kind:    "Workspace",
+					},
+					Object: runtime.RawExtension{
+						Raw: []byte(`invalid json`),
+					},
+					UserInfo: authenticationv1.UserInfo{
+						Username: "test-user",
+					},
+				},
+			},
+			expectedAllowed: false,
+			expectError:     true,
+		},
+		{
+			name: "missing metadata should return error",
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Kind: metav1.GroupVersionKind{
+						Group:   "workspaces.jupyter.org",
+						Version: "v1alpha1",
+						Kind:    "Workspace",
+					},
+					Object: runtime.RawExtension{
+						Raw: []byte(`{"spec":{}}`),
+					},
+					UserInfo: authenticationv1.UserInfo{
+						Username: "test-user",
+					},
+				},
+			},
+			expectedAllowed: false,
+			expectError:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &WorkspaceMutator{}
+			resp := m.Handle(context.Background(), tt.req)
+
+			if resp.Allowed != tt.expectedAllowed {
+				t.Errorf("expected allowed=%v, got=%v", tt.expectedAllowed, resp.Allowed)
+			}
+
+			if tt.expectError && resp.Result.Code == 200 {
+				t.Error("expected error but got success")
+			}
+
+			if !tt.expectError && resp.Result.Code != 200 {
+				t.Errorf("expected success but got error: %v", resp.Result.Message)
+			}
+
+			if tt.expectedPatch != "" {
+				if string(resp.Patch) != tt.expectedPatch {
+					t.Errorf("expected patch=%s, got=%s", tt.expectedPatch, string(resp.Patch))
+				}
+			}
+		})
+	}
+}
+
+func TestSanitizeUsername(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "simple username",
+			input:    "testuser",
+			expected: "testuser",
+		},
+		{
+			name:     "username with email",
+			input:    "user@domain.com",
+			expected: "user@domain.com",
+		},
+		{
+			name:     "username with quotes",
+			input:    `user"with"quotes`,
+			expected: `user\"with\"quotes`,
+		},
+		{
+			name:     "username with backslashes",
+			input:    `user\with\backslashes`,
+			expected: `user\\with\\backslashes`,
+		},
+		{
+			name:     "empty username",
+			input:    "",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := sanitizeUsername(tt.input)
+			if result != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestWorkspaceMutator_InjectDecoder(t *testing.T) {
+	m := &WorkspaceMutator{}
+	err := m.InjectDecoder(nil)
+	if err != nil {
+		t.Errorf("InjectDecoder should not return error, got: %v", err)
+	}
+}


### PR DESCRIPTION
### Core Implementation
• **New webhook**: WorkspaceMutator in internal/webhook/workspace_webhook.go
• **Automatic annotation**: Adds created-by: <username> to all new Workspace resources

### Manager Updates
• **Webhook registration**: Integrated webhook server in cmd/main.go
• **Port configuration**: Added --webhook-port flag (default 9443)

## Testing
•   End-to-end tested: Deployed to live EKS cluster with cert-manager

## Security
• Uses cert-manager for automatic TLS certificate management
• Proper username sanitization prevents injection attacks
• Read-only certificate volume mounts
• Follows Kubernetes webhook security best practices

## Deployment
Webhook is automatically enabled when deploying with make deploy. Requires cert-manager to be installed in the cluster.