### PR TITLE
feat: private workspace support

### DIFF
--- a/api/v1alpha1/workspace_types.go
+++ b/api/v1alpha1/workspace_types.go
@@ -73,6 +73,15 @@ type WorkspaceSpec struct {
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="templateRef is immutable"
 	// +optional
 	TemplateRef *string `json:"templateRef,omitempty"`
+
+	// SharedStatus specifies the sharing status of the workspace
+	// +kubebuilder:validation:Enum=private;public
+	// +optional
+	SharedStatus string `json:"sharedStatus,omitempty"`
+
+	// ServiceAccountName specifies the ServiceAccount used by the pod
+	// +optional
+	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 }
 
 // WorkspaceStatus defines the observed state of Workspace.

--- a/config/crd/bases/workspaces.jupyter.org_workspaces.yaml
+++ b/config/crd/bases/workspaces.jupyter.org_workspaces.yaml
@@ -123,6 +123,16 @@ spec:
                       More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                     type: object
                 type: object
+              serviceAccountName:
+                description: ServiceAccountName specifies the ServiceAccount used
+                  by the pod
+                type: string
+              sharedStatus:
+                description: SharedStatus specifies the sharing status of the workspace
+                enum:
+                - private
+                - public
+                type: string
               storage:
                 description: Storage specifies the storage configuration
                 properties:

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -20,7 +20,7 @@ resources:
 - ../manager
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-- ../webhook
+#- ../webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 - ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
@@ -32,6 +32,8 @@ resources:
 # Only CR(s) which requires webhooks and are applied on namespaces labeled with 'webhooks: enabled' will
 # be able to communicate with the Webhook Server.
 #- ../network-policy
+# [VAP] ValidatingAdmissionPolicies for workspace access control
+#- ../vap
 
 
 # Uncomment the patches line if you enable Metrics

--- a/config/vap/immutable-creator-username-annotation.yaml
+++ b/config/vap/immutable-creator-username-annotation.yaml
@@ -1,0 +1,31 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: workspace-immutable-creator-username
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   ["workspaces.jupyter.org"]
+      apiVersions: ["v1alpha1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["workspaces"]
+  validations:
+  - expression: |
+      (request.operation == 'CREATE' && 
+       (!has(object.metadata.annotations) || 
+        !('creator-username' in object.metadata.annotations))) ||
+      (request.operation == 'UPDATE' && 
+       has(object.metadata.annotations) &&
+       'creator-username' in object.metadata.annotations &&
+       oldObject.metadata.annotations['creator-username'] == object.metadata.annotations['creator-username'])
+    message: "Operation failed: The 'creator-username' annotation cannot be set manually and is immutable."
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: workspace-immutable-creator-username-binding
+spec:
+  policyName: workspace-immutable-creator-username
+  validationActions:
+  - Deny

--- a/config/vap/kustomization.yaml
+++ b/config/vap/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+- immutable-creator-username-annotation.yaml
+- private-workspace-vap.yaml
+- private-workspace-vap-binding.yaml

--- a/config/vap/private-workspace-vap-binding.yaml
+++ b/config/vap/private-workspace-vap-binding.yaml
@@ -1,0 +1,23 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: workspace-creator-only-update-binding
+spec:
+  policyName: workspace-creator-only-update
+  validationActions:
+  - Deny
+  matchResources:
+    namespaceSelector:
+      matchExpressions: []
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: workspace-creator-only-delete-binding
+spec:
+  policyName: workspace-creator-only-delete
+  validationActions:
+  - Deny
+  matchResources:
+    namespaceSelector:
+      matchExpressions: []

--- a/config/vap/private-workspace-vap.yaml
+++ b/config/vap/private-workspace-vap.yaml
@@ -1,0 +1,47 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: workspace-creator-only-update
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   ["workspaces.jupyter.org"]
+      apiVersions: ["v1alpha1"]
+      operations:  ["UPDATE"]
+      resources:   ["workspaces"]
+  validations:
+  - expression: |
+      !has(object.spec.sharedStatus) ||
+      object.spec.sharedStatus == 'public' ||
+      'CLUSTER_ADMIN_GROUP' in request.userInfo.groups ||
+      request.userInfo.username == 'system:serviceaccount:NAMESPACE:NAMEPREFIXcontroller-manager' ||
+      (object.spec.sharedStatus == 'private' && 
+       (!has(object.metadata.annotations) ||
+        !('creator-username' in object.metadata.annotations) ||
+        object.metadata.annotations['creator-username'] == request.userInfo.username))
+    message: "Operation failed: Only the creator, operator service account, or CLUSTER_ADMIN_GROUP group can update a private space."
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: workspace-creator-only-delete
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   ["workspaces.jupyter.org"]
+      apiVersions: ["v1alpha1"]
+      operations:  ["DELETE"]
+      resources:   ["workspaces"]
+  validations:
+  - expression: |
+      !has(oldObject.spec.sharedStatus) ||
+      oldObject.spec.sharedStatus == 'public' ||
+      'CLUSTER_ADMIN_GROUP' in request.userInfo.groups ||
+      request.userInfo.username == 'system:serviceaccount:NAMESPACE:NAMEPREFIXcontroller-manager' ||
+      (oldObject.spec.sharedStatus == 'private' && 
+       (!has(oldObject.metadata.annotations) ||
+        !('creator-username' in oldObject.metadata.annotations) ||
+        oldObject.metadata.annotations['creator-username'] == request.userInfo.username))
+    message: "Operation failed: Only the creator, operator service account, or CLUSTER_ADMIN_GROUP group can delete a private space."

--- a/config/webhook/webhook-config.yaml
+++ b/config/webhook/webhook-config.yaml
@@ -1,14 +1,14 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: jupyter-k8s-webhook
+  name: mutating-webhook-configuration
   annotations:
     cert-manager.io/inject-ca-from: jupyter-k8s-system/jupyter-k8s-serving-cert
 webhooks:
 - name: workspaces.jupyter.org
   clientConfig:
     service:
-      name: jupyter-k8s-controller-manager
+      name: jupyter-k8s-webhook-service
       namespace: jupyter-k8s-system
       path: "/mutate-workspace"
       port: 9443

--- a/dist/chart/templates/crd/workspaces.jupyter.org_workspaces.yaml
+++ b/dist/chart/templates/crd/workspaces.jupyter.org_workspaces.yaml
@@ -133,6 +133,12 @@ spec:
                 description: ServiceAccountName specifies the ServiceAccount used
                   by the pod
                 type: string
+              sharedStatus:
+                description: SharedStatus specifies the sharing status of the workspace
+                enum:
+                - private
+                - public
+                type: string
               storage:
                 description: Storage specifies the storage configuration
                 properties:
@@ -161,6 +167,15 @@ spec:
                 x-kubernetes-validations:
                 - message: storage is immutable
                   rule: self == oldSelf
+              templateRef:
+                description: |-
+                  TemplateRef references a WorkspaceTemplate to use as base configuration
+                  When set, template provides defaults and spec fields (Image, Resources, Storage.Size) act as overrides
+                  IMMUTABLE: Cannot be changed after workspace creation
+                type: string
+                x-kubernetes-validations:
+                - message: templateRef is immutable
+                  rule: self == oldSelf
             required:
             - displayName
             type: object
@@ -176,6 +191,7 @@ spec:
                   - "Available": the resource is fully functional and ready to use
                   - "Progressing": the resource is being created or updated
                   - "Degraded": the resource failed to reach or maintain its desired state
+                  - "Valid": the workspace configuration passes all validation checks (template, quota, etc.)
 
                   The status of each condition is one of True, False, or Unknown.
                 items:

--- a/dist/chart/templates/crd/workspaces.jupyter.org_workspacetemplates.yaml
+++ b/dist/chart/templates/crd/workspaces.jupyter.org_workspacetemplates.yaml
@@ -1,0 +1,413 @@
+{{- if .Values.crd.enable }}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+  annotations:
+    {{- if .Values.crd.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: workspacetemplates.workspaces.jupyter.org
+spec:
+  group: workspaces.jupyter.org
+  names:
+    kind: WorkspaceTemplate
+    listKind: WorkspaceTemplateList
+    plural: workspacetemplates
+    singular: workspacetemplate
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.displayName
+      name: Display Name
+      type: string
+    - jsonPath: .spec.defaultImage
+      name: Default Image
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          WorkspaceTemplate is the Schema for the workspacetemplates API
+          Templates define reusable, secure-by-default configurations for workspaces.
+          The spec is immutable after creation - to update a template, create a new version.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: WorkspaceTemplateSpec defines the desired state of WorkspaceTemplate
+            properties:
+              allowSecondaryStorages:
+                default: true
+                description: |-
+                  AllowSecondaryStorages controls whether workspaces using this template
+                  can mount additional storage volumes beyond the primary storage
+                type: boolean
+              allowedImages:
+                description: |-
+                  AllowedImages is a list of container images that can be used with this template
+                  If empty, only DefaultImage is allowed (secure by default)
+                  If populated, workspace can override image with any from this list
+                items:
+                  type: string
+                maxItems: 50
+                type: array
+              defaultImage:
+                description: DefaultImage is the default container image for workspaces
+                  using this template
+                maxLength: 500
+                minLength: 1
+                type: string
+              defaultResources:
+                description: DefaultResources specifies the default resource requirements
+                properties:
+                  claims:
+                    description: |-
+                      Claims lists the names of resources, defined in spec.resourceClaims,
+                      that are used by this container.
+
+                      This field depends on the
+                      DynamicResourceAllocation feature gate.
+
+                      This field is immutable. It can only be set for containers.
+                    items:
+                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                      properties:
+                        name:
+                          description: |-
+                            Name must match the name of one entry in pod.spec.resourceClaims of
+                            the Pod where this field is used. It makes that resource available
+                            inside a container.
+                          type: string
+                        request:
+                          description: |-
+                            Request is the name chosen for a request in the referenced claim.
+                            If empty, everything from the claim is made available, otherwise
+                            only the result of this request.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: |-
+                      Limits describes the maximum amount of compute resources allowed.
+                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: |-
+                      Requests describes the minimum amount of compute resources required.
+                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                type: object
+              description:
+                description: Description provides additional information about this
+                  template
+                maxLength: 500
+                type: string
+              displayName:
+                description: DisplayName is the human-readable name of this template
+                maxLength: 100
+                minLength: 1
+                type: string
+              environmentVariables:
+                description: EnvironmentVariables defines default environment variables
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: |-
+                        Name of the environment variable.
+                        May consist of any printable ASCII characters except '='.
+                      type: string
+                    value:
+                      description: |-
+                        Variable references $(VAR_NAME) are expanded
+                        using the previously defined environment variables in the container and
+                        any service environment variables. If a variable cannot be resolved,
+                        the reference in the input string will be unchanged. Double $$ are reduced
+                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                        Escaped references will never be expanded, regardless of whether the variable
+                        exists or not.
+                        Defaults to "".
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fieldRef:
+                          description: |-
+                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fileKeyRef:
+                          description: |-
+                            FileKeyRef selects a key of the env file.
+                            Requires the EnvFiles feature gate to be enabled.
+                          properties:
+                            key:
+                              description: |-
+                                The key within the env file. An invalid key will prevent the pod from starting.
+                                The keys defined within a source may consist of any printable ASCII characters except '='.
+                                During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                              type: string
+                            optional:
+                              default: false
+                              description: |-
+                                Specify whether the file or its key must be defined. If the file or key
+                                does not exist, then the env var is not published.
+                                If optional is set to true and the specified key does not exist,
+                                the environment variable will not be set in the Pod's containers.
+
+                                If optional is set to false and the specified key does not exist,
+                                an error will be returned during Pod creation.
+                              type: boolean
+                            path:
+                              description: |-
+                                The path within the volume from which to select the file.
+                                Must be relative and may not contain the '..' path or start with '..'.
+                              type: string
+                            volumeName:
+                              description: The name of the volume mount containing
+                                the env file.
+                              type: string
+                          required:
+                          - key
+                          - path
+                          - volumeName
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        resourceFieldRef:
+                          description: |-
+                            Selects a resource of the container: only resources limits and requests
+                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              primaryStorage:
+                description: PrimaryStorage defines storage configuration
+                properties:
+                  defaultSize:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    default: 10Gi
+                    description: DefaultSize is the default storage size
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  maxSize:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: MaxSize is the maximum allowed storage size
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  minSize:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: MinSize is the minimum allowed storage size
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                type: object
+              resourceBounds:
+                description: ResourceBounds defines the min/max boundaries for resource
+                  overrides
+                properties:
+                  cpu:
+                    description: CPU bounds
+                    properties:
+                      max:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Max is the maximum allowed value
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      min:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Min is the minimum allowed value
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                    required:
+                    - max
+                    - min
+                    type: object
+                  gpu:
+                    description: GPU bounds
+                    properties:
+                      max:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Max is the maximum allowed value
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      min:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Min is the minimum allowed value
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                    required:
+                    - max
+                    - min
+                    type: object
+                  memory:
+                    description: Memory bounds
+                    properties:
+                      max:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Max is the maximum allowed value
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      min:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Min is the minimum allowed value
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                    required:
+                    - max
+                    - min
+                    type: object
+                type: object
+            required:
+            - defaultImage
+            - displayName
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: template spec is immutable after creation
+          rule: self.spec == oldSelf.spec
+    served: true
+    storage: true
+    subresources: {}
+{{- end -}}

--- a/dist/chart/templates/manager/manager.yaml
+++ b/dist/chart/templates/manager/manager.yaml
@@ -31,8 +31,8 @@ spec:
             {{- range .Values.controllerManager.container.args }}
             - {{ . }}
             {{- end }}
-            - "--application-images-pull-policy={{ .Values.application.imagesPullPolicy }}"
-            - "--application-images-registry={{ .Values.application.imagesRegistry }}"
+            - --application-images-pull-policy={{ .Values.application.imagesPullPolicy }}
+            - --application-images-registry={{ .Values.application.imagesRegistry }}
           command:
             - /manager
           image: {{ .Values.controllerManager.container.image.repository }}:{{ .Values.controllerManager.container.image.tag }}

--- a/dist/chart/templates/rbac/role.yaml
+++ b/dist/chart/templates/rbac/role.yaml
@@ -10,6 +10,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - persistentvolumeclaims
   - services
   verbs:
@@ -47,15 +54,25 @@ rules:
 - apiGroups:
   - workspaces.jupyter.org
   resources:
-  - workspaces/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - workspaces.jupyter.org
-  resources:
   - workspaces/status
   verbs:
   - get
   - patch
+  - update
+- apiGroups:
+  - workspaces.jupyter.org
+  resources:
+  - workspacetemplates
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - workspaces.jupyter.org
+  resources:
+  - workspacetemplates/finalizers
+  verbs:
   - update
 {{- end -}}

--- a/dist/chart/templates/vap/immutable-creator-username-annotation.yaml
+++ b/dist/chart/templates/vap/immutable-creator-username-annotation.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.vap.enable }}
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: workspace-immutable-creator-username
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   ["workspaces.jupyter.org"]
+      apiVersions: ["v1alpha1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["workspaces"]
+  validations:
+  - expression: |
+      (request.operation == 'CREATE' && 
+       (!has(object.metadata.annotations) || 
+        !('creator-username' in object.metadata.annotations))) ||
+      (request.operation == 'UPDATE' && 
+       has(object.metadata.annotations) &&
+       'creator-username' in object.metadata.annotations &&
+       oldObject.metadata.annotations['creator-username'] == object.metadata.annotations['creator-username'])
+    message: "Operation failed: The 'creator-username' annotation cannot be set manually and is immutable."
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: workspace-immutable-creator-username-binding
+spec:
+  policyName: workspace-immutable-creator-username
+  validationActions:
+  - Deny
+{{- end }}

--- a/dist/chart/templates/vap/private-workspace-vap-binding.yaml
+++ b/dist/chart/templates/vap/private-workspace-vap-binding.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.vap.enable }}
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: workspace-creator-only-update-binding
+spec:
+  policyName: workspace-creator-only-update
+  validationActions:
+  - Deny
+  matchResources:
+    namespaceSelector:
+      matchExpressions: []
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: workspace-creator-only-delete-binding
+spec:
+  policyName: workspace-creator-only-delete
+  validationActions:
+  - Deny
+  matchResources:
+    namespaceSelector:
+      matchExpressions: []
+{{- end }}

--- a/dist/chart/templates/vap/private-workspace-vap.yaml
+++ b/dist/chart/templates/vap/private-workspace-vap.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.vap.enable }}
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: workspace-creator-only-update
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   ["workspaces.jupyter.org"]
+      apiVersions: ["v1alpha1"]
+      operations:  ["UPDATE"]
+      resources:   ["workspaces"]
+  validations:
+  - expression: |
+      !has(object.spec.sharedStatus) ||
+      object.spec.sharedStatus == 'public' ||
+      '{{ .Values.vap.clusterAdminGroup }}' in request.userInfo.groups ||
+      request.userInfo.username == 'system:serviceaccount:{{ .Values.namespace }}:{{ .Values.vap.namePrefix }}controller-manager' ||
+      (object.spec.sharedStatus == 'private' && 
+       (!has(object.metadata.annotations) ||
+        !('creator-username' in object.metadata.annotations) ||
+        object.metadata.annotations['creator-username'] == request.userInfo.username))
+    message: "Operation failed: Only the creator, operator service account, or {{ .Values.vap.clusterAdminGroup }} group can update a private space."
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: workspace-creator-only-delete
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   ["workspaces.jupyter.org"]
+      apiVersions: ["v1alpha1"]
+      operations:  ["DELETE"]
+      resources:   ["workspaces"]
+  validations:
+  - expression: |
+      !has(oldObject.spec.sharedStatus) ||
+      oldObject.spec.sharedStatus == 'public' ||
+      '{{ .Values.vap.clusterAdminGroup }}' in request.userInfo.groups ||
+      request.userInfo.username == 'system:serviceaccount:{{ .Values.namespace }}:{{ .Values.vap.namePrefix }}controller-manager' ||
+      (oldObject.spec.sharedStatus == 'private' && 
+       (!has(oldObject.metadata.annotations) ||
+        !('creator-username' in oldObject.metadata.annotations) ||
+        oldObject.metadata.annotations['creator-username'] == request.userInfo.username))
+    message: "Operation failed: Only the creator, operator service account, or {{ .Values.vap.clusterAdminGroup }} group can delete a private space."
+{{- end }}

--- a/dist/chart/values.yaml
+++ b/dist/chart/values.yaml
@@ -81,3 +81,15 @@ application:
   # This controls how the JupyterServer containers pull their images
   imagesPullPolicy: IfNotPresent
   imagesRegistry: "docker.io/library"
+
+# [NAMESPACE]: Namespace configuration
+namespace: jupyter-k8s-system
+
+# [VAP]: ValidatingAdmissionPolicy configuration
+vap:
+  # Enable ValidatingAdmissionPolicies for workspace access control
+  enable: true
+  # Name prefix applied to all resources
+  namePrefix: jupyter-k8s-
+  # Cluster admin group name (used as-is, not prefixed)
+  clusterAdminGroup: cluster-workspace-admin

--- a/hack/helm-patches/immutable-creator-username-annotation.yaml.patch
+++ b/hack/helm-patches/immutable-creator-username-annotation.yaml.patch
@@ -1,0 +1,33 @@
+{{- if .Values.vap.enable }}
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: workspace-immutable-creator-username
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   ["workspaces.jupyter.org"]
+      apiVersions: ["v1alpha1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["workspaces"]
+  validations:
+  - expression: |
+      (request.operation == 'CREATE' && 
+       (!has(object.metadata.annotations) || 
+        !('creator-username' in object.metadata.annotations))) ||
+      (request.operation == 'UPDATE' && 
+       has(object.metadata.annotations) &&
+       'creator-username' in object.metadata.annotations &&
+       oldObject.metadata.annotations['creator-username'] == object.metadata.annotations['creator-username'])
+    message: "Operation failed: The 'creator-username' annotation cannot be set manually and is immutable."
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: workspace-immutable-creator-username-binding
+spec:
+  policyName: workspace-immutable-creator-username
+  validationActions:
+  - Deny
+{{- end }}

--- a/hack/helm-patches/private-workspace-vap-binding.yaml.patch
+++ b/hack/helm-patches/private-workspace-vap-binding.yaml.patch
@@ -1,0 +1,25 @@
+{{- if .Values.vap.enable }}
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: workspace-creator-only-update-binding
+spec:
+  policyName: workspace-creator-only-update
+  validationActions:
+  - Deny
+  matchResources:
+    namespaceSelector:
+      matchExpressions: []
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: workspace-creator-only-delete-binding
+spec:
+  policyName: workspace-creator-only-delete
+  validationActions:
+  - Deny
+  matchResources:
+    namespaceSelector:
+      matchExpressions: []
+{{- end }}

--- a/hack/helm-patches/private-workspace-vap.yaml.patch
+++ b/hack/helm-patches/private-workspace-vap.yaml.patch
@@ -1,0 +1,49 @@
+{{- if .Values.vap.enable }}
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: workspace-creator-only-update
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   ["workspaces.jupyter.org"]
+      apiVersions: ["v1alpha1"]
+      operations:  ["UPDATE"]
+      resources:   ["workspaces"]
+  validations:
+  - expression: |
+      !has(object.spec.sharedStatus) ||
+      object.spec.sharedStatus == 'public' ||
+      '{{ .Values.vap.clusterAdminGroup }}' in request.userInfo.groups ||
+      request.userInfo.username == 'system:serviceaccount:{{ .Values.namespace }}:{{ .Values.vap.namePrefix }}controller-manager' ||
+      (object.spec.sharedStatus == 'private' && 
+       (!has(object.metadata.annotations) ||
+        !('creator-username' in object.metadata.annotations) ||
+        object.metadata.annotations['creator-username'] == request.userInfo.username))
+    message: "Operation failed: Only the creator, operator service account, or {{ .Values.vap.clusterAdminGroup }} group can update a private space."
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: workspace-creator-only-delete
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   ["workspaces.jupyter.org"]
+      apiVersions: ["v1alpha1"]
+      operations:  ["DELETE"]
+      resources:   ["workspaces"]
+  validations:
+  - expression: |
+      !has(oldObject.spec.sharedStatus) ||
+      oldObject.spec.sharedStatus == 'public' ||
+      '{{ .Values.vap.clusterAdminGroup }}' in request.userInfo.groups ||
+      request.userInfo.username == 'system:serviceaccount:{{ .Values.namespace }}:{{ .Values.vap.namePrefix }}controller-manager' ||
+      (oldObject.spec.sharedStatus == 'private' && 
+       (!has(oldObject.metadata.annotations) ||
+        !('creator-username' in oldObject.metadata.annotations) ||
+        oldObject.metadata.annotations['creator-username'] == request.userInfo.username))
+    message: "Operation failed: Only the creator, operator service account, or {{ .Values.vap.clusterAdminGroup }} group can delete a private space."
+{{- end }}

--- a/hack/helm-patches/values.yaml.patch
+++ b/hack/helm-patches/values.yaml.patch
@@ -4,3 +4,15 @@ application:
   # This controls how the JupyterServer containers pull their images
   imagesPullPolicy: IfNotPresent
   imagesRegistry: "docker.io/library"
+
+# [NAMESPACE]: Namespace configuration
+namespace: jupyter-k8s-system
+
+# [VAP]: ValidatingAdmissionPolicy configuration
+vap:
+  # Enable ValidatingAdmissionPolicies for workspace access control
+  enable: true
+  # Name prefix applied to all resources
+  namePrefix: jupyter-k8s-
+  # Cluster admin group name (used as-is, not prefixed)
+  clusterAdminGroup: cluster-workspace-admin

--- a/internal/webhook/workspace_webhook.go
+++ b/internal/webhook/workspace_webhook.go
@@ -14,12 +14,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
-// WorkspaceMutator is a mutating admission webhook that automatically adds a "created-by" annotation
+// WorkspaceMutator is a mutating admission webhook that automatically adds a "creator-username" annotation
 // to Workspace resources when they are created. This annotation tracks which user created the Workspace
 // and can be used for ownership-based access control and auditing.
 type WorkspaceMutator struct{}
 
-// Handle processes admission requests for Workspace resources and adds a "created-by" annotation
+// Handle processes admission requests for Workspace resources and adds a "creator-username" annotation
 // containing the sanitized username of the requesting user. This enables ownership tracking
 // and audit trails for workspace creation.
 func (m *WorkspaceMutator) Handle(ctx context.Context, req admission.Request) admission.Response {
@@ -55,17 +55,17 @@ func (m *WorkspaceMutator) Handle(ctx context.Context, req admission.Request) ad
 	}
 
 	sanitizedUsername := sanitizeUsername(req.UserInfo.Username)
-	logger.Info("Adding created-by annotation",
+	logger.Info("Adding creator-username annotation",
 		"workspace", req.Name,
 		"namespace", req.Namespace,
 		"user", sanitizedUsername)
 
 	var patch string
 	if annotations, ok := metadata["annotations"].(map[string]interface{}); ok && annotations != nil {
-		patch = `[{"op":"add","path":"/metadata/annotations/created-by","value":"` + sanitizedUsername + `"}]`
+		patch = `[{"op":"add","path":"/metadata/annotations/creator-username","value":"` + sanitizedUsername + `"}]`
 		logger.V(1).Info("Adding annotation to existing annotations", "patch", patch)
 	} else {
-		patch = `[{"op":"add","path":"/metadata/annotations","value":{"created-by":"` + sanitizedUsername + `"}}]`
+		patch = `[{"op":"add","path":"/metadata/annotations","value":{"creator-username":"` + sanitizedUsername + `"}}]`
 		logger.V(1).Info("Creating new annotations object", "patch", patch)
 	}
 	patchType := admissionv1.PatchTypeJSONPatch

--- a/internal/webhook/workspace_webhook_test.go
+++ b/internal/webhook/workspace_webhook_test.go
@@ -37,7 +37,7 @@ func TestWorkspaceMutator_Handle(t *testing.T) {
 				},
 			},
 			expectedAllowed: true,
-			expectedPatch:   `[{"op":"add","path":"/metadata/annotations","value":{"created-by":"test-user"}}]`,
+			expectedPatch:   `[{"op":"add","path":"/metadata/annotations","value":{"creator-username":"test-user"}}]`,
 		},
 		{
 			name: "successful mutation with existing annotations",
@@ -57,7 +57,7 @@ func TestWorkspaceMutator_Handle(t *testing.T) {
 				},
 			},
 			expectedAllowed: true,
-			expectedPatch:   `[{"op":"add","path":"/metadata/annotations/created-by","value":"test-user"}]`,
+			expectedPatch:   `[{"op":"add","path":"/metadata/annotations/creator-username","value":"test-user"}]`,
 		},
 		{
 			name: "username with special characters",
@@ -77,7 +77,7 @@ func TestWorkspaceMutator_Handle(t *testing.T) {
 				},
 			},
 			expectedAllowed: true,
-			expectedPatch:   `[{"op":"add","path":"/metadata/annotations","value":{"created-by":"user@domain.com"}}]`,
+			expectedPatch:   `[{"op":"add","path":"/metadata/annotations","value":{"creator-username":"user@domain.com"}}]`,
 		},
 		{
 			name: "non-workspace resource should be allowed without mutation",

--- a/test/helm/crd-only/resources_test.go
+++ b/test/helm/crd-only/resources_test.go
@@ -18,6 +18,7 @@ var _ = Describe("CRD-Only Helm Resources", func() {
 	var excludeDirs = map[string]bool{
 		"samples": true,
 		"default": true,
+		"vap":     true, // VAP resources are managed by Helm patches
 	}
 
 	It("should include all CRD-only resources in the Helm chart", func() {
@@ -157,6 +158,16 @@ func shouldSkipResourceCheck(res helm.ResourceIdentifier) bool {
 
 	// Skip ServiceMonitor resources
 	if res.Kind == "ServiceMonitor" {
+		return true
+	}
+
+	// Skip cert-manager resources (conditionally included)
+	if res.Kind == "Certificate" || res.Kind == "Issuer" {
+		return true
+	}
+
+	// Skip webhook resources (conditionally included)
+	if res.Kind == "MutatingWebhookConfiguration" || res.Kind == "ValidatingWebhookConfiguration" {
 		return true
 	}
 


### PR DESCRIPTION
Adding private workspace support. `kubebuilder edit --plugins=helm/v1-alpha --force` does not generate VAPs so I added some manual patching logic to the apply-helm-patches script. There are a couple other changes, including:

1. Adding more comprehensive logic in the undeploy-aws script
2. Adding serviceAccountName to the kubebuilder, previously it was only in the generated file
3. Fixing unit tests, previously they were failing due to including cert-manager resources
4. Fixing manager.yaml patch script, this was previously failing when running make helm-generate