### PR TITLE
fixed e2e owner webhook test

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -175,7 +175,11 @@ var _ = Describe("Manager", Ordered, func() {
 
 		It("should ensure the metrics endpoint is serving metrics", func() {
 			By("creating a ClusterRoleBinding for the service account to allow access to metrics")
-			cmd := exec.Command("kubectl", "create", "clusterrolebinding", metricsRoleBindingName,
+			// Delete existing ClusterRoleBinding if it exists
+			cmd := exec.Command("kubectl", "delete", "clusterrolebinding", metricsRoleBindingName, "--ignore-not-found")
+			_, _ = utils.Run(cmd) // Ignore errors if it doesn't exist
+
+			cmd = exec.Command("kubectl", "create", "clusterrolebinding", metricsRoleBindingName,
 				"--clusterrole=jupyter-k8s-metrics-reader",
 				fmt.Sprintf("--serviceaccount=%s:%s", namespace, serviceAccountName),
 			)

--- a/test/e2e/webhook_owner_test.go
+++ b/test/e2e/webhook_owner_test.go
@@ -84,7 +84,7 @@ var _ = Describe("Webhook Owner", Ordered, func() {
 
 			By("verifying created-by annotation exists")
 			cmd = exec.Command("kubectl", "get", "workspace", "workspace-sample",
-				"-o", "jsonpath={.metadata.annotations.created-by}")
+				"-o", "jsonpath={.metadata.annotations.workspaces\\.jupyter\\.org/created-by}")
 			output, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 			annotation := strings.TrimSpace(string(output))


### PR DESCRIPTION
Fixing failing e2e test due to creator username change, confirmed passing: 
```
Ran 19 of 19 Specs in 102.713 seconds
SUCCESS! -- 19 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestE2E (102.71s)
PASS
ok  	github.com/jupyter-ai-contrib/jupyter-k8s/test/e2e	103.138s
```