### PR TITLE
ci: Run all workflows except e2e once, run e2e on approval

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,9 @@ name: Lint
 
 on:
   push:
+    branches: [main]
   pull_request:
+  workflow_dispatch:
 
 jobs:
   lint:

--- a/.github/workflows/test-chart.yml
+++ b/.github/workflows/test-chart.yml
@@ -2,7 +2,9 @@ name: Test Chart
 
 on:
   push:
+    branches: [main]
   pull_request:
+  workflow_dispatch:
 
 jobs:
   test-e2e:

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -2,12 +2,20 @@ name: E2E Tests
 
 on:
   push:
+    branches: [main]
   pull_request:
+  workflow_dispatch:
 
 jobs:
   test-e2e:
     name: Run on Ubuntu
     runs-on: ubuntu-latest
+    permissions:
+      contents: read       # To checkout code
+      pull-requests: write # To add ci:e2e-approved label
+    # Require approval UNLESS: on main, manual trigger, or PR has ci:e2e-approved label
+    environment: ${{ !(github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:e2e-approved'))) && 'e2e-tests' || '' }}
+
     steps:
       - name: Clone the code
         uses: actions/checkout@v4
@@ -31,3 +39,35 @@ jobs:
           go mod tidy
           # Use Docker instead of Finch in GitHub Actions
           make test-e2e CONTAINER_TOOL=docker
+
+      # After E2E passes, auto-add label for future runs
+      - name: Add E2E approved label
+        if: success() && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              if (!context.payload.pull_request) {
+                console.log('ℹ️ Not a pull request event, skipping label addition');
+                return;
+              }
+
+              const labels = context.payload.pull_request.labels.map(l => l.name);
+
+              if (!labels.includes('ci:e2e-approved')) {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.payload.pull_request.number,
+                  labels: ['ci:e2e-approved']
+                });
+                console.log('✅ Successfully added ci:e2e-approved label');
+                console.log('   Future pushes to this PR will run E2E automatically without approval');
+              } else {
+                console.log('ℹ️ ci:e2e-approved label already exists, skipping');
+              }
+            } catch (error) {
+              console.error('❌ Failed to add ci:e2e-approved label:', error.message);
+              console.error('   This is non-fatal - E2E tests passed but label was not added');
+              // Don't fail the workflow if label addition fails
+            }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,9 @@ name: Tests
 
 on:
   push:
+    branches: [main]
   pull_request:
+  workflow_dispatch:
 
 jobs:
   test:


### PR DESCRIPTION
### Problem

1. All 4 workflows in https://github.com/jupyter-infra/jupyter-k8s/tree/main/.github/workflows have the duplication issue due to:
```
on:
  push:
  pull_request:
```
This causes workflows to run TWICE on every PR push (once for push, once for pull_request; see # of CI workflows completed in https://github.com/jupyter-infra/jupyter-k8s/pull/31 for example).

2. Some workflows are pretty heavy (E2E), run ~10-15 minutes so it will be more optimal to run them after PR is more or less done / ready vs on every push like it is run now

### Suggested solution 

* Every PR push runs 4 light workflows once
* E2E needs approval once per PR, then runs automatically (requires approval via e2e-tests environment and rules in it; runs automatically by adding `e2e-approved` label to PR on approval). Members of `jupyter-infra/jupyter-deploy-writers` group now will need to approve E2E tests for them to run (see demo below)
* All workflows support manual triggering
* Main branch runs all workflows on every push / merge for post-merge validation. Pushed by design should only come from merged PRs

### E2E approval demo:

![e2e_approval_demo](https://github.com/user-attachments/assets/af27e0b6-109c-4779-b175-d287d7d1a25a)

