### PR TITLE
feat: stub AWS HyperPod guided helm chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -560,6 +560,30 @@ deploy-aws-traefik-dex-internal:
 deploy-aws-traefik-dex:
 	$(MAKE) deploy-aws-traefik-dex-internal CLOUD_PROVIDER=aws
 
+deploy-aws-hyperpod-internal:
+	@if [ ! -f .env ]; then \
+		echo "❌ .env file not found. Copy the `.env.example` file to `.env` and edit the values."; \
+		echo "Required variables: DOMAIN"; \
+		exit 1; \
+	fi
+	@echo "Loading configuration from .env file and deploying aws-hyperpod..."
+	@( \
+		set -e; \
+		. ./.env; \
+		echo 'Deploying AWS HyperPod helm chart'; \
+		helm upgrade --install aws-hyperpod ./guided-charts/aws-hyperpod \
+			--create-namespace --namespace jupyter-k8s-system \
+			--set domain=$$DOMAIN; \
+	)
+
+.PHONY: deploy-aws-hyperpod
+deploy-aws-hyperpod: ## Deploy aws-hyperpod guided chart
+	$(MAKE) deploy-aws-hyperpod-internal CLOUD_PROVIDER=aws
+
+.PHONY: undeploy-aws-hyperpod  
+undeploy-aws-hyperpod: ## Remove aws-hyperpod guided chart
+	helm uninstall aws-hyperpod --namespace jupyter-k8s-system
+
 .PHONY: apply-sample-routing
 apply-sample-routing:
 	@echo "Loading configuration from .env file and deploying..."

--- a/guided-charts/aws-hyperpod/Chart.yaml
+++ b/guided-charts/aws-hyperpod/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: jupyter-k8s-aws-hyperpod
+description: A template for deploying jupyter-k8s on HyperPod with SSM remote access and presigned URL support
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+icon: "https://example.com/icon.png"
+
+# Dependencies
+# Require traefik CRDs to be installed (https://traefik.github.io/charts)
+# Not adding as a dependency because of `helm` install issues
+# Run `helm upgrade --install traefik-crd traefik/traefik-crds` first

--- a/guided-charts/aws-hyperpod/templates/ebs-storageclass.yaml
+++ b/guided-charts/aws-hyperpod/templates/ebs-storageclass.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.storageClass.ebs.create }}
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: {{ .Values.storageClass.ebs.name }}
+  labels:
+    app.kubernetes.io/name: jupyter-k8s-aws-traefik-dex
+  {{- if .Values.storageClass.ebs.isDefault }}
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+  {{- end }}
+provisioner: {{ .Values.storageClass.ebs.provisioner }}
+parameters:
+  {{- toYaml .Values.storageClass.ebs.parameters | nindent 2 }}
+reclaimPolicy: {{ .Values.storageClass.ebs.reclaimPolicy }}
+volumeBindingMode: {{ .Values.storageClass.ebs.volumeBindingMode }}
+---
+{{- end }}

--- a/guided-charts/aws-hyperpod/templates/validations.tpl
+++ b/guided-charts/aws-hyperpod/templates/validations.tpl
@@ -1,0 +1,11 @@
+# [AWS TRAEFIK DEX]: Configuration for aws-traefik-dex deployment mode
+{{- if (.Capabilities.APIVersions.Has "helm.toolkit.fluxcd.io/v2beta1") }}
+{{- fail "This chart is not compatible with Flux CD. Please use a different deployment method." }}
+{{- end }}
+
+{{- if not .Values.domain }}
+{{- fail "domain is required" }}
+{{- end }}
+
+# This file intentionally does not produce any Kubernetes resources
+# It only validates and sets default values

--- a/guided-charts/aws-hyperpod/values.yaml
+++ b/guided-charts/aws-hyperpod/values.yaml
@@ -1,0 +1,20 @@
+# [AWS HYPERPOD]: Configuration for aws-hyperpod deployment mode
+# This includes presigned URL and remote access setup
+
+namespace: jupyter-k8s-system # TODO consider if we need seperate namespace
+
+# Full domain for the application (required)
+domain: ""
+
+# [STORAGE] StorageClasses for Workspaces
+storageClass:
+  ebs:
+    create: true
+    name: ebs-sc
+    isDefault: false
+    provisioner: ebs.csi.aws.com
+    reclaimPolicy: Delete
+    volumeBindingMode: WaitForFirstConsumer
+    parameters:
+      type: gp3
+      fsType: ext4


### PR DESCRIPTION
## Add AWS HyperPod guided Helm chart

This PR introduces a new guided Helm chart specifically designed for AWS HyperPod environments, providing a streamlined deployment experience for Jupyter workspaces on HyperPod clusters. This is currently just a stub, but will be extended to include remote access and presigned URL support. 

### Changes
• **New Helm chart**: guided-charts/aws-hyperpod/
• **Makefile targets**: Added build and deployment commands for the AWS HyperPod chart

This chart complements the existing customizable deployment options by offering a batteries-included experience for AWS HyperPod users.