### PR TITLE
feat: admission webhook for workspace access control

### DIFF
--- a/api/v1alpha1/workspace_types.go
+++ b/api/v1alpha1/workspace_types.go
@@ -91,6 +91,12 @@ type WorkspaceSpec struct {
 	// +kubebuilder:validation:Enum=Running;Stopped
 	DesiredStatus string `json:"desiredStatus,omitempty"`
 
+	// AccessType specifies who can modify the space.
+	// Public means anyone with RBAC permissions can update/delete the space.
+	// OwnerOnly means only the creator can update/delete the space.
+	// +kubebuilder:validation:Enum=Public;OwnerOnly
+	AccessType string `json:"accessType,omitempty"`
+
 	// Resources specifies the resource requirements
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
 

--- a/config/crd/bases/workspaces.jupyter.org_workspaces.yaml
+++ b/config/crd/bases/workspaces.jupyter.org_workspaces.yaml
@@ -65,6 +65,15 @@ spec:
                 required:
                 - name
                 type: object
+              accessType:
+                description: |-
+                  AccessType specifies who can modify the space.
+                  Public means anyone with RBAC permissions can update/delete the space.
+                  OwnerOnly means only the creator can update/delete the space.
+                enum:
+                - Public
+                - OwnerOnly
+                type: string
               affinity:
                 description: Affinity specifies node affinity and anti-affinity rules
                   for the workspace pod

--- a/dist/chart/templates/crd/workspaces.jupyter.org_workspaces.yaml
+++ b/dist/chart/templates/crd/workspaces.jupyter.org_workspaces.yaml
@@ -71,6 +71,15 @@ spec:
                 required:
                 - name
                 type: object
+              accessType:
+                description: |-
+                  AccessType specifies who can modify the space.
+                  Public means anyone with RBAC permissions can update/delete the space.
+                  OwnerOnly means only the creator can update/delete the space.
+                enum:
+                - Public
+                - OwnerOnly
+                type: string
               affinity:
                 description: Affinity specifies node affinity and anti-affinity rules
                   for the workspace pod

--- a/dist/chart/values.yaml
+++ b/dist/chart/values.yaml
@@ -2,6 +2,8 @@
 controllerManager:
   replicas: 1
   container:
+    env:
+      CLUSTER_ADMIN_GROUP: "cluster-workspace-admin"
     image:
       repository: controller
       tag: latest

--- a/hack/apply-helm-patches.sh
+++ b/hack/apply-helm-patches.sh
@@ -70,6 +70,15 @@ if [ -f "${PATCHES_DIR}/values.yaml.patch" ]; then
     echo "Applying patches to values.yaml..."
     echo "Found patch file: ${PATCHES_DIR}/values.yaml.patch"
 
+    # Add env section to controllerManager.container if it doesn't exist
+    if ! grep -q "env:" "${CHART_DIR}/values.yaml"; then
+        # Add env section right after container: (macOS compatible)
+        sed -i.bak '/container:/a\
+    env:\
+      CLUSTER_ADMIN_GROUP: "cluster-workspace-admin"\
+' "${CHART_DIR}/values.yaml" && rm "${CHART_DIR}/values.yaml.bak"
+    fi
+
     # Check if the application section already exists
     if grep -q "^# \[APPLICATION\]" "${CHART_DIR}/values.yaml"; then
         echo "Removing existing APPLICATION section from values.yaml"

--- a/internal/webhook/v1alpha1/workspace_webhook_test.go
+++ b/internal/webhook/v1alpha1/workspace_webhook_test.go
@@ -49,6 +49,7 @@ var _ = Describe("Workspace Webhook", func() {
 				DisplayName:   "Test Workspace",
 				Image:         "jupyter/base-notebook:latest",
 				DesiredStatus: "Running",
+				AccessType:    "Public",
 			},
 		}
 		defaulter = WorkspaceCustomDefaulter{}
@@ -127,6 +128,152 @@ var _ = Describe("Workspace Webhook", func() {
 			warnings, err := validator.ValidateUpdate(ctx, oldWorkspace, workspace)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(warnings).To(BeEmpty())
+		})
+
+		It("should reject OwnerOnly workspace update by non-owner", func() {
+			userInfo := &authenticationv1.UserInfo{Username: "different-user"}
+			req := admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{UserInfo: *userInfo}}
+			userCtx := admission.NewContextWithRequest(ctx, req)
+
+			oldWorkspace := workspace.DeepCopy()
+			oldWorkspace.Spec.AccessType = accessTypeOwnerOnly
+			oldWorkspace.Annotations = map[string]string{
+				controller.AnnotationCreatedBy: "original-user",
+			}
+			newWorkspace := workspace.DeepCopy()
+			newWorkspace.Spec.AccessType = accessTypeOwnerOnly
+			newWorkspace.Annotations = map[string]string{
+				controller.AnnotationCreatedBy: "original-user",
+			}
+
+			warnings, err := validator.ValidateUpdate(userCtx, oldWorkspace, newWorkspace)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("access denied"))
+			Expect(warnings).To(BeEmpty())
+		})
+
+		It("should allow Public workspace update", func() {
+			oldWorkspace := workspace.DeepCopy()
+			oldWorkspace.Spec.AccessType = accessTypePublic
+			newWorkspace := workspace.DeepCopy()
+			newWorkspace.Spec.AccessType = accessTypePublic
+			newWorkspace.Spec.Image = "jupyter/scipy-notebook:latest"
+
+			warnings, err := validator.ValidateUpdate(ctx, oldWorkspace, newWorkspace)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(warnings).To(BeEmpty())
+		})
+
+		It("should allow OwnerOnly workspace update by owner", func() {
+			userInfo := &authenticationv1.UserInfo{Username: "owner-user"}
+			req := admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{UserInfo: *userInfo}}
+			userCtx := admission.NewContextWithRequest(ctx, req)
+
+			oldWorkspace := workspace.DeepCopy()
+			oldWorkspace.Spec.AccessType = accessTypeOwnerOnly
+			oldWorkspace.Annotations = map[string]string{
+				controller.AnnotationCreatedBy: "owner-user",
+			}
+			newWorkspace := workspace.DeepCopy()
+			newWorkspace.Spec.AccessType = accessTypeOwnerOnly
+			newWorkspace.Annotations = map[string]string{
+				controller.AnnotationCreatedBy: "owner-user",
+			}
+
+			warnings, err := validator.ValidateUpdate(userCtx, oldWorkspace, newWorkspace)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(warnings).To(BeEmpty())
+		})
+
+		It("should allow OwnerOnly workspace deletion by owner", func() {
+			userInfo := &authenticationv1.UserInfo{Username: "owner-user"}
+			req := admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{UserInfo: *userInfo}}
+			userCtx := admission.NewContextWithRequest(ctx, req)
+
+			ownerOnlyWorkspace := workspace.DeepCopy()
+			ownerOnlyWorkspace.Spec.AccessType = accessTypeOwnerOnly
+			ownerOnlyWorkspace.Annotations = map[string]string{
+				controller.AnnotationCreatedBy: "owner-user",
+			}
+
+			warnings, err := validator.ValidateDelete(userCtx, ownerOnlyWorkspace)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(warnings).To(BeEmpty())
+		})
+
+		It("should reject update that changes created-by annotation", func() {
+			oldWorkspace := workspace.DeepCopy()
+			oldWorkspace.Annotations = map[string]string{
+				controller.AnnotationCreatedBy: "original-user",
+			}
+			newWorkspace := workspace.DeepCopy()
+			newWorkspace.Annotations = map[string]string{
+				controller.AnnotationCreatedBy: "malicious-user",
+			}
+
+			warnings, err := validator.ValidateUpdate(ctx, oldWorkspace, newWorkspace)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("created-by annotation is immutable"))
+			Expect(warnings).To(BeEmpty())
+		})
+
+		It("should reject update that changes last-updated-by annotation", func() {
+			oldWorkspace := workspace.DeepCopy()
+			oldWorkspace.Annotations = map[string]string{
+				controller.AnnotationLastUpdatedBy: "original-user",
+			}
+			newWorkspace := workspace.DeepCopy()
+			newWorkspace.Annotations = map[string]string{
+				controller.AnnotationLastUpdatedBy: "malicious-user",
+			}
+
+			warnings, err := validator.ValidateUpdate(ctx, oldWorkspace, newWorkspace)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("last-updated-by annotation is immutable"))
+			Expect(warnings).To(BeEmpty())
+		})
+
+		It("should reject changing accessType from Public to OwnerOnly", func() {
+			oldWorkspace := workspace.DeepCopy()
+			oldWorkspace.Spec.AccessType = accessTypePublic
+			newWorkspace := workspace.DeepCopy()
+			newWorkspace.Spec.AccessType = accessTypeOwnerOnly
+
+			warnings, err := validator.ValidateUpdate(ctx, oldWorkspace, newWorkspace)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("cannot change accessType from Public to OwnerOnly"))
+			Expect(warnings).To(BeEmpty())
+		})
+
+		It("should allow changing accessType from OwnerOnly to Public", func() {
+			oldWorkspace := workspace.DeepCopy()
+			oldWorkspace.Spec.AccessType = accessTypeOwnerOnly
+			newWorkspace := workspace.DeepCopy()
+			newWorkspace.Spec.AccessType = accessTypePublic
+
+			warnings, err := validator.ValidateUpdate(ctx, oldWorkspace, newWorkspace)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(warnings).To(BeEmpty())
+		})
+	})
+
+	Context("sanitizeUsername", func() {
+		It("should handle normal usernames", func() {
+			Expect(sanitizeUsername("user123")).To(Equal("user123"))
+			Expect(sanitizeUsername("test@example.com")).To(Equal("test@example.com"))
+			Expect(sanitizeUsername("arn:aws:iam::123456789012:role/EKSRole")).To(Equal("arn:aws:iam::123456789012:role/EKSRole"))
+		})
+
+		It("should escape special characters", func() {
+			Expect(sanitizeUsername("user\nname")).To(Equal("user\\nname"))
+			Expect(sanitizeUsername("user\tname")).To(Equal("user\\tname"))
+			Expect(sanitizeUsername("user\"name")).To(Equal("user\\\"name"))
+			Expect(sanitizeUsername("user\\name")).To(Equal("user\\\\name"))
+		})
+
+		It("should handle unicode characters", func() {
+			Expect(sanitizeUsername("用户")).To(Equal("用户"))
+			Expect(sanitizeUsername("user🚀")).To(Equal("user🚀"))
 		})
 
 		It("should validate workspace deletion successfully", func() {


### PR DESCRIPTION
This PR implements a validating webhook that enforces access control for workspaces based on their accessType field and ensures annotation immutability.

## Changes
- Added WorkspaceCustomValidator with access control logic
- Configured CLUSTER_ADMIN_GROUP environment variable via Helm
- Implemented username sanitization for special characters
- Refactored validation to avoid early returns for future extensibility

## Testing
- Webhook validates Public workspaces can be modified by anyone
- OwnerOnly workspaces restricted to owner or cluster admins
- Annotations created-by and last-updated-by are immutable after creation