### PR TITLE
refactor: Changing API group to singular

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,13 +127,13 @@ spec:
 
 **Create a template with resource limits and security policies:**
 ```sh
-kubectl apply -f config/samples/workspaces_v1alpha1_workspacetemplate_production.yaml
+kubectl apply -f config/samples/workspace_v1alpha1_workspacetemplate_production.yaml
 kubectl get workspacetemplates
 ```
 
 **Create a workspace using the template:**
 ```sh
-kubectl apply -f config/samples/workspaces_v1alpha1_workspace_with_template.yaml
+kubectl apply -f config/samples/workspace_v1alpha1_workspace_with_template.yaml
 ```
 
 **Check validation status:**

--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the workspaces v1alpha1 API group.
 // +kubebuilder:object:generate=true
-// +groupName=workspaces.jupyter.org
+// +groupName=workspace.jupyter.org
 package v1alpha1
 
 import (
@@ -26,7 +26,7 @@ import (
 
 var (
 	// GroupVersion is group version used to register these objects.
-	GroupVersion = schema.GroupVersion{Group: "workspaces.jupyter.org", Version: "v1alpha1"}
+	GroupVersion = schema.GroupVersion{Group: "workspace.jupyter.org", Version: "v1alpha1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -40,7 +40,7 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
-	workspacesv1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
+	workspacev1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
 	"github.com/jupyter-ai-contrib/jupyter-k8s/internal/controller"
 	"github.com/jupyter-ai-contrib/jupyter-k8s/internal/extensionapi"
 	webhookv1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/internal/webhook/v1alpha1"
@@ -62,7 +62,7 @@ var (
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
-	utilruntime.Must(workspacesv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(workspacev1alpha1.AddToScheme(scheme))
 	// +kubebuilder:scaffold:scheme
 }
 

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"strings"
 
-	workspacesv1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
+	workspacev1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
 	"github.com/jupyter-ai-contrib/jupyter-k8s/internal/controller"
 
 	corev1 "k8s.io/api/core/v1"
@@ -38,7 +38,7 @@ func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
 	// Add custom resource schemes
-	utilruntime.Must(workspacesv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(workspacev1alpha1.AddToScheme(scheme))
 }
 
 // parseGVKWatches parses a comma-separated list of GVK strings into GVKWatch objects

--- a/config/crd/bases/workspace.jupyter.org_workspaceaccessstrategies.yaml
+++ b/config/crd/bases/workspace.jupyter.org_workspaceaccessstrategies.yaml
@@ -4,9 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-  name: workspaceaccessstrategies.workspaces.jupyter.org
+  name: workspaceaccessstrategies.workspace.jupyter.org
 spec:
-  group: workspaces.jupyter.org
+  group: workspace.jupyter.org
   names:
     kind: WorkspaceAccessStrategy
     listKind: WorkspaceAccessStrategyList

--- a/config/crd/bases/workspace.jupyter.org_workspaces.yaml
+++ b/config/crd/bases/workspace.jupyter.org_workspaces.yaml
@@ -4,9 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-  name: workspaces.workspaces.jupyter.org
+  name: workspaces.workspace.jupyter.org
 spec:
-  group: workspaces.jupyter.org
+  group: workspace.jupyter.org
   names:
     kind: Workspace
     listKind: WorkspaceList

--- a/config/crd/bases/workspace.jupyter.org_workspacetemplates.yaml
+++ b/config/crd/bases/workspace.jupyter.org_workspacetemplates.yaml
@@ -1,34 +1,25 @@
-{{- if .Values.crd.enable }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  labels:
-    {{- include "chart.labels" . | nindent 4 }}
   annotations:
-    {{- if .Values.crd.keep }}
-    "helm.sh/resource-policy": keep
-    {{- end }}
     controller-gen.kubebuilder.io/version: v0.18.0
-  name: workspaces.workspaces.jupyter.org
+  name: workspacetemplates.workspace.jupyter.org
 spec:
-  group: workspaces.jupyter.org
+  group: workspace.jupyter.org
   names:
-    kind: Workspace
-    listKind: WorkspaceList
-    plural: workspaces
-    singular: workspace
-  scope: Namespaced
+    kind: WorkspaceTemplate
+    listKind: WorkspaceTemplateList
+    plural: workspacetemplates
+    singular: workspacetemplate
+  scope: Cluster
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .status.conditions[?(@.type=="Available")].status
-      name: Available
+    - jsonPath: .spec.displayName
+      name: Display Name
       type: string
-    - jsonPath: .status.conditions[?(@.type=="Progressing")].status
-      name: Progressing
-      type: string
-    - jsonPath: .status.conditions[?(@.type=="Degraded")].status
-      name: Degraded
+    - jsonPath: .spec.defaultImage
+      name: Default Image
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
@@ -36,7 +27,10 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: Workspace is the Schema for the workspaces API
+        description: |-
+          WorkspaceTemplate is the Schema for the workspacetemplates API
+          Templates define reusable, secure-by-default configurations for workspaces.
+          The spec is immutable after creation - to update a template, create a new version.
         properties:
           apiVersion:
             description: |-
@@ -56,24 +50,26 @@ spec:
           metadata:
             type: object
           spec:
-            description: spec defines the desired state of Workspace
+            description: WorkspaceTemplateSpec defines the desired state of WorkspaceTemplate
             properties:
-              accessStrategy:
-                description: AccessStrategy specifies the WorkspaceAccessStrategy
-                  to use
-                properties:
-                  name:
-                    description: Name of the WorkspaceAccessStrategy
-                    type: string
-                  namespace:
-                    description: Namespace where the WorkspaceAccessStrategy is located
-                    type: string
-                required:
-                - name
-                type: object
-              affinity:
-                description: Affinity specifies node affinity and anti-affinity rules
-                  for the workspace pod
+              allowSecondaryStorages:
+                default: true
+                description: |-
+                  AllowSecondaryStorages controls whether workspaces using this template
+                  can mount additional storage volumes beyond the primary storage
+                type: boolean
+              allowedImages:
+                description: |-
+                  AllowedImages is a list of container images that can be used with this template
+                  If empty, only DefaultImage is allowed (secure by default)
+                  If populated, workspace can override image with any from this list
+                items:
+                  type: string
+                maxItems: 50
+                type: array
+              defaultAffinity:
+                description: DefaultAffinity specifies default node affinity and anti-affinity
+                  rules
                 properties:
                   nodeAffinity:
                     description: Describes node affinity scheduling rules for the
@@ -984,9 +980,9 @@ spec:
                         x-kubernetes-list-type: atomic
                     type: object
                 type: object
-              containerConfig:
-                description: ContainerConfig specifies container command and args
-                  configuration
+              defaultContainerConfig:
+                description: DefaultContainerConfig specifies default container command
+                  and args configuration
                 properties:
                   args:
                     description: Args specifies the container arguments
@@ -999,262 +995,28 @@ spec:
                       type: string
                     type: array
                 type: object
-              desiredStatus:
-                description: DesiredStatus specifies the desired operational status
-                enum:
-                - Running
-                - Stopped
+              defaultImage:
+                description: DefaultImage is the default container image for workspaces
+                  using this template
+                maxLength: 500
+                minLength: 1
                 type: string
-              displayName:
-                description: Display Name of the server
-                type: string
-              image:
-                description: Image specifies the container image to use
-                type: string
-              lifecycle:
-                description: |-
-                  Lifecycle specifies actions that the management system should take
-                  in response to container lifecycle events (for instance, lifecycle hooks)
-                properties:
-                  postStart:
-                    description: |-
-                      PostStart is called immediately after a container is created. If the handler fails,
-                      the container is terminated and restarted according to its restart policy.
-                      Other management of the container blocks until the hook completes.
-                      More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
-                    properties:
-                      exec:
-                        description: Exec specifies a command to execute in the container.
-                        properties:
-                          command:
-                            description: |-
-                              Command is the command line to execute inside the container, the working directory for the
-                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                              a shell, you need to explicitly call out to that shell.
-                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
-                            items:
-                              type: string
-                            type: array
-                            x-kubernetes-list-type: atomic
-                        type: object
-                      httpGet:
-                        description: HTTPGet specifies an HTTP GET request to perform.
-                        properties:
-                          host:
-                            description: |-
-                              Host name to connect to, defaults to the pod IP. You probably want to set
-                              "Host" in httpHeaders instead.
-                            type: string
-                          httpHeaders:
-                            description: Custom headers to set in the request. HTTP
-                              allows repeated headers.
-                            items:
-                              description: HTTPHeader describes a custom header to
-                                be used in HTTP probes
-                              properties:
-                                name:
-                                  description: |-
-                                    The header field name.
-                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
-                                  type: string
-                                value:
-                                  description: The header field value
-                                  type: string
-                              required:
-                              - name
-                              - value
-                              type: object
-                            type: array
-                            x-kubernetes-list-type: atomic
-                          path:
-                            description: Path to access on the HTTP server.
-                            type: string
-                          port:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            description: |-
-                              Name or number of the port to access on the container.
-                              Number must be in the range 1 to 65535.
-                              Name must be an IANA_SVC_NAME.
-                            x-kubernetes-int-or-string: true
-                          scheme:
-                            description: |-
-                              Scheme to use for connecting to the host.
-                              Defaults to HTTP.
-                            type: string
-                        required:
-                        - port
-                        type: object
-                      sleep:
-                        description: Sleep represents a duration that the container
-                          should sleep.
-                        properties:
-                          seconds:
-                            description: Seconds is the number of seconds to sleep.
-                            format: int64
-                            type: integer
-                        required:
-                        - seconds
-                        type: object
-                      tcpSocket:
-                        description: |-
-                          Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                          for backward compatibility. There is no validation of this field and
-                          lifecycle hooks will fail at runtime when it is specified.
-                        properties:
-                          host:
-                            description: 'Optional: Host name to connect to, defaults
-                              to the pod IP.'
-                            type: string
-                          port:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            description: |-
-                              Number or name of the port to access on the container.
-                              Number must be in the range 1 to 65535.
-                              Name must be an IANA_SVC_NAME.
-                            x-kubernetes-int-or-string: true
-                        required:
-                        - port
-                        type: object
-                    type: object
-                  preStop:
-                    description: |-
-                      PreStop is called immediately before a container is terminated due to an
-                      API request or management event such as liveness/startup probe failure,
-                      preemption, resource contention, etc. The handler is not called if the
-                      container crashes or exits. The Pod's termination grace period countdown begins before the
-                      PreStop hook is executed. Regardless of the outcome of the handler, the
-                      container will eventually terminate within the Pod's termination grace
-                      period (unless delayed by finalizers). Other management of the container blocks until the hook completes
-                      or until the termination grace period is reached.
-                      More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
-                    properties:
-                      exec:
-                        description: Exec specifies a command to execute in the container.
-                        properties:
-                          command:
-                            description: |-
-                              Command is the command line to execute inside the container, the working directory for the
-                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                              a shell, you need to explicitly call out to that shell.
-                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
-                            items:
-                              type: string
-                            type: array
-                            x-kubernetes-list-type: atomic
-                        type: object
-                      httpGet:
-                        description: HTTPGet specifies an HTTP GET request to perform.
-                        properties:
-                          host:
-                            description: |-
-                              Host name to connect to, defaults to the pod IP. You probably want to set
-                              "Host" in httpHeaders instead.
-                            type: string
-                          httpHeaders:
-                            description: Custom headers to set in the request. HTTP
-                              allows repeated headers.
-                            items:
-                              description: HTTPHeader describes a custom header to
-                                be used in HTTP probes
-                              properties:
-                                name:
-                                  description: |-
-                                    The header field name.
-                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
-                                  type: string
-                                value:
-                                  description: The header field value
-                                  type: string
-                              required:
-                              - name
-                              - value
-                              type: object
-                            type: array
-                            x-kubernetes-list-type: atomic
-                          path:
-                            description: Path to access on the HTTP server.
-                            type: string
-                          port:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            description: |-
-                              Name or number of the port to access on the container.
-                              Number must be in the range 1 to 65535.
-                              Name must be an IANA_SVC_NAME.
-                            x-kubernetes-int-or-string: true
-                          scheme:
-                            description: |-
-                              Scheme to use for connecting to the host.
-                              Defaults to HTTP.
-                            type: string
-                        required:
-                        - port
-                        type: object
-                      sleep:
-                        description: Sleep represents a duration that the container
-                          should sleep.
-                        properties:
-                          seconds:
-                            description: Seconds is the number of seconds to sleep.
-                            format: int64
-                            type: integer
-                        required:
-                        - seconds
-                        type: object
-                      tcpSocket:
-                        description: |-
-                          Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                          for backward compatibility. There is no validation of this field and
-                          lifecycle hooks will fail at runtime when it is specified.
-                        properties:
-                          host:
-                            description: 'Optional: Host name to connect to, defaults
-                              to the pod IP.'
-                            type: string
-                          port:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            description: |-
-                              Number or name of the port to access on the container.
-                              Number must be in the range 1 to 65535.
-                              Name must be an IANA_SVC_NAME.
-                            x-kubernetes-int-or-string: true
-                        required:
-                        - port
-                        type: object
-                    type: object
-                  stopSignal:
-                    description: |-
-                      StopSignal defines which signal will be sent to a container when it is being stopped.
-                      If not specified, the default is defined by the container runtime in use.
-                      StopSignal can only be set for Pods with a non-empty .spec.os.name
-                    type: string
-                type: object
-              nodeSelector:
+              defaultNodeSelector:
                 additionalProperties:
                   type: string
-                description: NodeSelector specifies node selection constraints for
-                  the workspace pod
+                description: DefaultNodeSelector specifies default node selection
+                  constraints
                 type: object
-              ownershipType:
-                description: |-
-                  OwnershipType specifies who can modify the space.
-                  Public means anyone with RBAC permissions can update/delete the space.
-                  OwnerOnly means only the creator can update/delete the space.
+              defaultOwnershipType:
+                default: Public
+                description: DefaultOwnershipType specifies the default access type
+                  for workspaces using this template
                 enum:
                 - Public
                 - OwnerOnly
                 type: string
-              resources:
-                description: Resources specifies the resource requirements
+              defaultResources:
+                description: DefaultResources specifies the default resource requirements
                 properties:
                   claims:
                     description: |-
@@ -1312,46 +1074,9 @@ spec:
                       More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                     type: object
                 type: object
-              storage:
-                description: Storage specifies the storage configuration
-                properties:
-                  mountPath:
-                    default: /home/jovyan
-                    description: |-
-                      MountPath specifies where to mount the persistent volume in the container
-                      Default is /home/jovyan (jovyan is the standard user in Jupyter images)
-                    type: string
-                  size:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    default: 10Gi
-                    description: |-
-                      Size specifies the size of the persistent volume
-                      Supports standard Kubernetes resource quantities (e.g., "10Gi", "500Mi", "1Ti")
-                      Integer values without units are interpreted as bytes
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  storageClassName:
-                    description: StorageClassName specifies the storage class to use
-                      for persistent storage
-                    type: string
-                type: object
-                x-kubernetes-validations:
-                - message: storage is immutable
-                  rule: self == oldSelf
-              templateRef:
-                description: |-
-                  TemplateRef references a WorkspaceTemplate to use as base configuration
-                  When set, template provides defaults and spec fields (Image, Resources, Storage.Size) act as overrides
-                  IMMUTABLE: Cannot be changed after workspace creation
-                type: string
-                x-kubernetes-validations:
-                - message: templateRef is immutable
-                  rule: self == oldSelf
-              tolerations:
-                description: Tolerations specifies tolerations for the workspace pod
-                  to schedule on nodes with matching taints
+              defaultTolerations:
+                description: DefaultTolerations specifies default tolerations for
+                  scheduling on nodes with taints
                 items:
                   description: |-
                     The pod this Toleration is attached to tolerates any taint that matches
@@ -1389,155 +1114,284 @@ spec:
                       type: string
                   type: object
                 type: array
-              volumes:
-                description: Volumes specifies additional volumes to mount from existing
-                  PersistantVolumeClaims
+              description:
+                description: Description provides additional information about this
+                  template
+                maxLength: 500
+                type: string
+              displayName:
+                description: DisplayName is the human-readable name of this template
+                maxLength: 100
+                minLength: 1
+                type: string
+              environmentVariables:
+                description: EnvironmentVariables defines default environment variables
                 items:
-                  description: VolumeSpec defines a volume to mount from an existing
-                    PVC
+                  description: EnvVar represents an environment variable present in
+                    a Container.
                   properties:
-                    mountPath:
-                      description: MountPath is the path where the volume should be
-                        mounted (Unix-style path, e.g. /data)
-                      type: string
                     name:
-                      description: Name is a unique identifier for this volume within
-                        the pod (maps to pod.spec.volumes[].name)
+                      description: |-
+                        Name of the environment variable.
+                        May consist of any printable ASCII characters except '='.
                       type: string
-                    persistentVolumeClaimName:
-                      description: PersistentVolumeClaimName is the name of the existing
-                        PVC to mount
+                    value:
+                      description: |-
+                        Variable references $(VAR_NAME) are expanded
+                        using the previously defined environment variables in the container and
+                        any service environment variables. If a variable cannot be resolved,
+                        the reference in the input string will be unchanged. Double $$ are reduced
+                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                        Escaped references will never be expanded, regardless of whether the variable
+                        exists or not.
+                        Defaults to "".
                       type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fieldRef:
+                          description: |-
+                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fileKeyRef:
+                          description: |-
+                            FileKeyRef selects a key of the env file.
+                            Requires the EnvFiles feature gate to be enabled.
+                          properties:
+                            key:
+                              description: |-
+                                The key within the env file. An invalid key will prevent the pod from starting.
+                                The keys defined within a source may consist of any printable ASCII characters except '='.
+                                During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                              type: string
+                            optional:
+                              default: false
+                              description: |-
+                                Specify whether the file or its key must be defined. If the file or key
+                                does not exist, then the env var is not published.
+                                If optional is set to true and the specified key does not exist,
+                                the environment variable will not be set in the Pod's containers.
+
+                                If optional is set to false and the specified key does not exist,
+                                an error will be returned during Pod creation.
+                              type: boolean
+                            path:
+                              description: |-
+                                The path within the volume from which to select the file.
+                                Must be relative and may not contain the '..' path or start with '..'.
+                              type: string
+                            volumeName:
+                              description: The name of the volume mount containing
+                                the env file.
+                              type: string
+                          required:
+                          - key
+                          - path
+                          - volumeName
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        resourceFieldRef:
+                          description: |-
+                            Selects a resource of the container: only resources limits and requests
+                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
                   required:
-                  - mountPath
                   - name
-                  - persistentVolumeClaimName
                   type: object
                 type: array
+              primaryStorage:
+                description: PrimaryStorage defines storage configuration
+                properties:
+                  defaultMountPath:
+                    default: /home/jovyan
+                    description: DefaultMountPath is the default mount path for the
+                      storage
+                    type: string
+                  defaultSize:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    default: 10Gi
+                    description: DefaultSize is the default storage size
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  defaultStorageClassName:
+                    description: DefaultStorageClassName is the default storage class
+                      name
+                    type: string
+                  maxSize:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: MaxSize is the maximum allowed storage size
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  minSize:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: MinSize is the minimum allowed storage size
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                type: object
+              resourceBounds:
+                description: ResourceBounds defines the min/max boundaries for resource
+                  overrides
+                properties:
+                  cpu:
+                    description: CPU bounds
+                    properties:
+                      max:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Max is the maximum allowed value
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      min:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Min is the minimum allowed value
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                    required:
+                    - max
+                    - min
+                    type: object
+                  gpu:
+                    description: GPU bounds
+                    properties:
+                      max:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Max is the maximum allowed value
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      min:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Min is the minimum allowed value
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                    required:
+                    - max
+                    - min
+                    type: object
+                  memory:
+                    description: Memory bounds
+                    properties:
+                      max:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Max is the maximum allowed value
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      min:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Min is the minimum allowed value
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                    required:
+                    - max
+                    - min
+                    type: object
+                type: object
             required:
+            - defaultImage
             - displayName
             type: object
-          status:
-            description: status defines the observed state of Workspace
-            properties:
-              accessResourceSelector:
-                description: |-
-                  AccessResourceSelector is a label selector that can be used to find all resources
-                  created from the workspace's AccessStrategy templates
-                type: string
-              accessResources:
-                description: |-
-                  AccessResources provides status details of individual resources created from
-                  the workspace's AccessStrategy templates
-                items:
-                  description: AccessResourceStatus defines the status of a resource
-                    created from a template
-                  properties:
-                    apiVersion:
-                      description: APIVersion of the Kubernetes resource
-                      type: string
-                    kind:
-                      description: Kind of the Kubernetes resource
-                      type: string
-                    name:
-                      description: Name of the resource
-                      type: string
-                    namespace:
-                      description: Namespace of the resource
-                      type: string
-                  required:
-                  - apiVersion
-                  - kind
-                  - name
-                  - namespace
-                  type: object
-                type: array
-              accessURL:
-                description: AccessURL is the URL at which the workspace can be accessed
-                type: string
-              conditions:
-                description: |-
-                  Conditions represent the current state of the Workspace resource.
-                  Each condition has a unique type and reflects the status of a specific aspect of the resource.
-
-                  Standard condition types include:
-                  - "Available": the resource is fully functional and ready to use
-                  - "Progressing": the resource is being created or updated
-                  - "Degraded": the resource failed to reach or maintain its desired state
-                  - "Valid": the workspace configuration passes all validation checks (template, quota, etc.)
-
-                  The status of each condition is one of True, False, or Unknown.
-                items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
-                  properties:
-                    lastTransitionTime:
-                      description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
-                  type: object
-                type: array
-                x-kubernetes-list-map-keys:
-                - type
-                x-kubernetes-list-type: map
-              deploymentName:
-                description: DeploymentName is the name of the deployment managing
-                  the Workspace pods
-                type: string
-              serviceName:
-                description: ServiceName is the name of the service exposing the Workspace
-                type: string
-            type: object
-        required:
-        - spec
         type: object
+        x-kubernetes-validations:
+        - message: template spec is immutable after creation
+          rule: self.spec == oldSelf.spec
     served: true
     storage: true
-    subresources:
-      status: {}
-{{- end -}}
+    subresources: {}

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -2,9 +2,9 @@
 # since it depends on service name and namespace that are out of this kustomize package.
 # It should be run by config/default
 resources:
-- bases/workspaces.jupyter.org_workspaces.yaml
-- bases/workspaces.jupyter.org_workspacetemplates.yaml
-- bases/workspaces.jupyter.org_workspaceaccessstrategies.yaml
+- bases/workspace.jupyter.org_workspaces.yaml
+- bases/workspace.jupyter.org_workspacetemplates.yaml
+- bases/workspace.jupyter.org_workspaceaccessstrategies.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
 patches:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -64,7 +64,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - workspaces.jupyter.org
+  - workspace.jupyter.org
   resources:
   - '*'
   verbs:
@@ -76,7 +76,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - workspaces.jupyter.org
+  - workspace.jupyter.org
   resources:
   - workspacetemplates
   verbs:
@@ -86,7 +86,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - workspaces.jupyter.org
+  - workspace.jupyter.org
   resources:
   - workspacetemplates/finalizers
   verbs:

--- a/config/rbac/workspace_admin_role.yaml
+++ b/config/rbac/workspace_admin_role.yaml
@@ -1,7 +1,7 @@
 # This rule is not used by the project jupyter-k8s itself.
 # It is provided to allow the cluster admin to help manage permissions for users.
 #
-# Grants full permissions ('*') over workspaces.jupyter.org.
+# Grants full permissions ('*') over workspace.jupyter.org.
 # This role is intended for users authorized to modify roles and bindings within the cluster,
 # enabling them to delegate specific permissions to other users or groups as needed.
 
@@ -14,13 +14,13 @@ metadata:
   name: workspace-admin-role
 rules:
 - apiGroups:
-  - workspaces.jupyter.org
+  - workspace.jupyter.org
   resources:
   - workspaces
   verbs:
   - '*'
 - apiGroups:
-  - workspaces.jupyter.org
+  - workspace.jupyter.org
   resources:
   - workspaces/status
   verbs:

--- a/config/rbac/workspace_editor_role.yaml
+++ b/config/rbac/workspace_editor_role.yaml
@@ -1,7 +1,7 @@
 # This rule is not used by the project jupyter-k8s itself.
 # It is provided to allow the cluster admin to help manage permissions for users.
 #
-# Grants permissions to create, update, and delete resources within the workspaces.jupyter.org.
+# Grants permissions to create, update, and delete resources within the workspace.jupyter.org.
 # This role is intended for users who need to manage these resources
 # but should not control RBAC or manage permissions for others.
 
@@ -14,7 +14,7 @@ metadata:
   name: workspace-editor-role
 rules:
 - apiGroups:
-  - workspaces.jupyter.org
+  - workspace.jupyter.org
   resources:
   - workspaces
   verbs:
@@ -26,7 +26,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - workspaces.jupyter.org
+  - workspace.jupyter.org
   resources:
   - workspaces/status
   verbs:

--- a/config/rbac/workspace_viewer_role.yaml
+++ b/config/rbac/workspace_viewer_role.yaml
@@ -1,7 +1,7 @@
 # This rule is not used by the project jupyter-k8s itself.
 # It is provided to allow the cluster admin to help manage permissions for users.
 #
-# Grants read-only access to workspaces.jupyter.org resources.
+# Grants read-only access to workspace.jupyter.org resources.
 # This role is intended for users who need visibility into these resources
 # without permissions to modify them. It is ideal for monitoring purposes and limited-access viewing.
 
@@ -14,7 +14,7 @@ metadata:
   name: workspace-viewer-role
 rules:
 - apiGroups:
-  - workspaces.jupyter.org
+  - workspace.jupyter.org
   resources:
   - workspaces
   verbs:
@@ -22,7 +22,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - workspaces.jupyter.org
+  - workspace.jupyter.org
   resources:
   - workspaces/status
   verbs:

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -1,10 +1,10 @@
 ## Append samples of your project ##
 resources:
-- workspaces_v1alpha1_workspace.yaml
-- workspaces_v1alpha1_workspace_stopped.yaml
-- workspaces_v1alpha1_workspace_with_storage.yaml
-- workspaces_v1alpha1_workspace_with_template.yaml
-- workspaces_v1alpha1_workspacetemplate_production.yaml
+- workspace_v1alpha1_workspace.yaml
+- workspace_v1alpha1_workspace_stopped.yaml
+- workspace_v1alpha1_workspace_with_storage.yaml
+- workspace_v1alpha1_workspace_with_template.yaml
+- workspace_v1alpha1_workspacetemplate_production.yaml
 - workspace_with_additional_volumes.yaml
 - workspace_with_container_config.yaml
 - workspace_with_lifecycle.yaml

--- a/config/samples/test_template_rejection.yaml
+++ b/config/samples/test_template_rejection.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: workspaces.jupyter.org/v1alpha1
+apiVersion: workspace.jupyter.org/v1alpha1
 kind: WorkspaceTemplate
 metadata:
   name: restricted-template
@@ -31,7 +31,7 @@ spec:
     maxSize: 20Gi
 
 ---
-apiVersion: workspaces.jupyter.org/v1alpha1
+apiVersion: workspace.jupyter.org/v1alpha1
 kind: Workspace
 metadata:
   name: test-rejected-workspace
@@ -53,7 +53,7 @@ spec:
     size: "50Gi"
 
 ---
-apiVersion: workspaces.jupyter.org/v1alpha1
+apiVersion: workspace.jupyter.org/v1alpha1
 kind: Workspace
 metadata:
   name: test-valid-workspace

--- a/config/samples/workspace_v1alpha1_workspace.yaml
+++ b/config/samples/workspace_v1alpha1_workspace.yaml
@@ -1,12 +1,13 @@
-apiVersion: workspaces.jupyter.org/v1alpha1
+apiVersion: workspace.jupyter.org/v1alpha1
 kind: Workspace
 metadata:
   labels:
     app.kubernetes.io/name: jupyter-k8s
     app.kubernetes.io/managed-by: kustomize
-  name: workspace-with-storage
+  name: workspace-sample
 spec:
-  displayName: "Jupyter Server with Storage"
+  displayName: sample-running
+  image: uv
   desiredStatus: Running
   resources:
     requests:
@@ -15,7 +16,3 @@ spec:
     limits:
       memory: "256Mi"
       cpu: "200m"
-  storage:
-    storageClassName: "standard"
-    size: "1Gi"
-    mountPath: "/home/jovyan/work"

--- a/config/samples/workspace_v1alpha1_workspace_stopped.yaml
+++ b/config/samples/workspace_v1alpha1_workspace_stopped.yaml
@@ -1,4 +1,4 @@
-apiVersion: workspaces.jupyter.org/v1alpha1
+apiVersion: workspace.jupyter.org/v1alpha1
 kind: Workspace
 metadata:
   labels:

--- a/config/samples/workspace_v1alpha1_workspace_with_storage.yaml
+++ b/config/samples/workspace_v1alpha1_workspace_with_storage.yaml
@@ -1,13 +1,12 @@
-apiVersion: workspaces.jupyter.org/v1alpha1
+apiVersion: workspace.jupyter.org/v1alpha1
 kind: Workspace
 metadata:
   labels:
     app.kubernetes.io/name: jupyter-k8s
     app.kubernetes.io/managed-by: kustomize
-  name: workspace-sample
+  name: workspace-with-storage
 spec:
-  displayName: sample-running
-  image: uv
+  displayName: "Jupyter Server with Storage"
   desiredStatus: Running
   resources:
     requests:
@@ -16,3 +15,7 @@ spec:
     limits:
       memory: "256Mi"
       cpu: "200m"
+  storage:
+    storageClassName: "standard"
+    size: "1Gi"
+    mountPath: "/home/jovyan/work"

--- a/config/samples/workspace_v1alpha1_workspace_with_template.yaml
+++ b/config/samples/workspace_v1alpha1_workspace_with_template.yaml
@@ -1,4 +1,4 @@
-apiVersion: workspaces.jupyter.org/v1alpha1
+apiVersion: workspace.jupyter.org/v1alpha1
 kind: Workspace
 metadata:
   labels:

--- a/config/samples/workspace_v1alpha1_workspacetemplate_production.yaml
+++ b/config/samples/workspace_v1alpha1_workspacetemplate_production.yaml
@@ -1,5 +1,5 @@
 # Example WorkspaceTemplate for production use
-apiVersion: workspaces.jupyter.org/v1alpha1
+apiVersion: workspace.jupyter.org/v1alpha1
 kind: WorkspaceTemplate
 metadata:
   name: production-notebook-template

--- a/config/samples/workspace_with_additional_volumes.yaml
+++ b/config/samples/workspace_with_additional_volumes.yaml
@@ -1,4 +1,4 @@
-apiVersion: workspaces.jupyter.org/v1alpha1
+apiVersion: workspace.jupyter.org/v1alpha1
 kind: Workspace
 metadata:
   labels:

--- a/config/samples/workspace_with_container_config.yaml
+++ b/config/samples/workspace_with_container_config.yaml
@@ -1,4 +1,4 @@
-apiVersion: workspaces.jupyter.org/v1alpha1
+apiVersion: workspace.jupyter.org/v1alpha1
 kind: Workspace
 metadata:
   labels:

--- a/config/samples/workspace_with_lifecycle.yaml
+++ b/config/samples/workspace_with_lifecycle.yaml
@@ -1,4 +1,4 @@
-apiVersion: workspaces.jupyter.org/v1alpha1
+apiVersion: workspace.jupyter.org/v1alpha1
 kind: Workspace
 metadata:
   labels:

--- a/config/samples/workspace_with_node_selector.yaml
+++ b/config/samples/workspace_with_node_selector.yaml
@@ -1,4 +1,4 @@
-apiVersion: workspaces.jupyter.org/v1alpha1
+apiVersion: workspace.jupyter.org/v1alpha1
 kind: Workspace
 metadata:
   labels:

--- a/config/samples_routing/workspace_access_strategy.yaml
+++ b/config/samples_routing/workspace_access_strategy.yaml
@@ -1,4 +1,4 @@
-apiVersion: workspaces.jupyter.org/v1alpha1
+apiVersion: workspace.jupyter.org/v1alpha1
 kind: WorkspaceAccessStrategy
 metadata:
   name: sample-access-strategy

--- a/config/samples_routing/workspace_with_access_strategy.yaml
+++ b/config/samples_routing/workspace_with_access_strategy.yaml
@@ -1,4 +1,4 @@
-apiVersion: workspaces.jupyter.org/v1alpha1
+apiVersion: workspace.jupyter.org/v1alpha1
 kind: Workspace
 metadata:
   name: ws-with-access

--- a/config/samples_routing/workspace_with_access_strategy_private.yaml
+++ b/config/samples_routing/workspace_with_access_strategy_private.yaml
@@ -1,4 +1,4 @@
-apiVersion: workspaces.jupyter.org/v1alpha1
+apiVersion: workspace.jupyter.org/v1alpha1
 kind: Workspace
 metadata:
   name: private-ws-with-access

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -10,13 +10,13 @@ webhooks:
     service:
       name: jupyter-k8s-controller-manager
       namespace: system
-      path: /mutate-workspaces-jupyter-org-v1alpha1-workspace
+      path: /mutate-workspace-jupyter-org-v1alpha1-workspace
       port: 9443
   failurePolicy: Fail
   name: mworkspace-v1alpha1.kb.io
   rules:
   - apiGroups:
-    - workspaces.jupyter.org
+    - workspace.jupyter.org
     apiVersions:
     - v1alpha1
     operations:
@@ -37,13 +37,13 @@ webhooks:
     service:
       name: jupyter-k8s-controller-manager
       namespace: system
-      path: /validate-workspaces-jupyter-org-v1alpha1-workspace
+      path: /validate-workspace-jupyter-org-v1alpha1-workspace
       port: 9443
   failurePolicy: Fail
   name: vworkspace-v1alpha1.kb.io
   rules:
   - apiGroups:
-    - workspaces.jupyter.org
+    - workspace.jupyter.org
     apiVersions:
     - v1alpha1
     operations:

--- a/dist/chart/templates/crd/workspace.jupyter.org_workspaceaccessstrategies.yaml
+++ b/dist/chart/templates/crd/workspace.jupyter.org_workspaceaccessstrategies.yaml
@@ -10,9 +10,9 @@ metadata:
     "helm.sh/resource-policy": keep
     {{- end }}
     controller-gen.kubebuilder.io/version: v0.18.0
-  name: workspaceaccessstrategies.workspaces.jupyter.org
+  name: workspaceaccessstrategies.workspace.jupyter.org
 spec:
-  group: workspaces.jupyter.org
+  group: workspace.jupyter.org
   names:
     kind: WorkspaceAccessStrategy
     listKind: WorkspaceAccessStrategyList

--- a/dist/chart/templates/crd/workspace.jupyter.org_workspaces.yaml
+++ b/dist/chart/templates/crd/workspace.jupyter.org_workspaces.yaml
@@ -10,22 +10,25 @@ metadata:
     "helm.sh/resource-policy": keep
     {{- end }}
     controller-gen.kubebuilder.io/version: v0.18.0
-  name: workspacetemplates.workspaces.jupyter.org
+  name: workspaces.workspace.jupyter.org
 spec:
-  group: workspaces.jupyter.org
+  group: workspace.jupyter.org
   names:
-    kind: WorkspaceTemplate
-    listKind: WorkspaceTemplateList
-    plural: workspacetemplates
-    singular: workspacetemplate
-  scope: Cluster
+    kind: Workspace
+    listKind: WorkspaceList
+    plural: workspaces
+    singular: workspace
+  scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .spec.displayName
-      name: Display Name
+    - jsonPath: .status.conditions[?(@.type=="Available")].status
+      name: Available
       type: string
-    - jsonPath: .spec.defaultImage
-      name: Default Image
+    - jsonPath: .status.conditions[?(@.type=="Progressing")].status
+      name: Progressing
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Degraded")].status
+      name: Degraded
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
@@ -33,10 +36,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: |-
-          WorkspaceTemplate is the Schema for the workspacetemplates API
-          Templates define reusable, secure-by-default configurations for workspaces.
-          The spec is immutable after creation - to update a template, create a new version.
+        description: Workspace is the Schema for the workspaces API
         properties:
           apiVersion:
             description: |-
@@ -56,26 +56,24 @@ spec:
           metadata:
             type: object
           spec:
-            description: WorkspaceTemplateSpec defines the desired state of WorkspaceTemplate
+            description: spec defines the desired state of Workspace
             properties:
-              allowSecondaryStorages:
-                default: true
-                description: |-
-                  AllowSecondaryStorages controls whether workspaces using this template
-                  can mount additional storage volumes beyond the primary storage
-                type: boolean
-              allowedImages:
-                description: |-
-                  AllowedImages is a list of container images that can be used with this template
-                  If empty, only DefaultImage is allowed (secure by default)
-                  If populated, workspace can override image with any from this list
-                items:
-                  type: string
-                maxItems: 50
-                type: array
-              defaultAffinity:
-                description: DefaultAffinity specifies default node affinity and anti-affinity
-                  rules
+              accessStrategy:
+                description: AccessStrategy specifies the WorkspaceAccessStrategy
+                  to use
+                properties:
+                  name:
+                    description: Name of the WorkspaceAccessStrategy
+                    type: string
+                  namespace:
+                    description: Namespace where the WorkspaceAccessStrategy is located
+                    type: string
+                required:
+                - name
+                type: object
+              affinity:
+                description: Affinity specifies node affinity and anti-affinity rules
+                  for the workspace pod
                 properties:
                   nodeAffinity:
                     description: Describes node affinity scheduling rules for the
@@ -986,9 +984,9 @@ spec:
                         x-kubernetes-list-type: atomic
                     type: object
                 type: object
-              defaultContainerConfig:
-                description: DefaultContainerConfig specifies default container command
-                  and args configuration
+              containerConfig:
+                description: ContainerConfig specifies container command and args
+                  configuration
                 properties:
                   args:
                     description: Args specifies the container arguments
@@ -1001,28 +999,262 @@ spec:
                       type: string
                     type: array
                 type: object
-              defaultImage:
-                description: DefaultImage is the default container image for workspaces
-                  using this template
-                maxLength: 500
-                minLength: 1
+              desiredStatus:
+                description: DesiredStatus specifies the desired operational status
+                enum:
+                - Running
+                - Stopped
                 type: string
-              defaultNodeSelector:
+              displayName:
+                description: Display Name of the server
+                type: string
+              image:
+                description: Image specifies the container image to use
+                type: string
+              lifecycle:
+                description: |-
+                  Lifecycle specifies actions that the management system should take
+                  in response to container lifecycle events (for instance, lifecycle hooks)
+                properties:
+                  postStart:
+                    description: |-
+                      PostStart is called immediately after a container is created. If the handler fails,
+                      the container is terminated and restarted according to its restart policy.
+                      Other management of the container blocks until the hook completes.
+                      More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                    properties:
+                      exec:
+                        description: Exec specifies a command to execute in the container.
+                        properties:
+                          command:
+                            description: |-
+                              Command is the command line to execute inside the container, the working directory for the
+                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                              a shell, you need to explicitly call out to that shell.
+                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      httpGet:
+                        description: HTTPGet specifies an HTTP GET request to perform.
+                        properties:
+                          host:
+                            description: |-
+                              Host name to connect to, defaults to the pod IP. You probably want to set
+                              "Host" in httpHeaders instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              properties:
+                                name:
+                                  description: |-
+                                    The header field name.
+                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              Name or number of the port to access on the container.
+                              Number must be in the range 1 to 65535.
+                              Name must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                          scheme:
+                            description: |-
+                              Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      sleep:
+                        description: Sleep represents a duration that the container
+                          should sleep.
+                        properties:
+                          seconds:
+                            description: Seconds is the number of seconds to sleep.
+                            format: int64
+                            type: integer
+                        required:
+                        - seconds
+                        type: object
+                      tcpSocket:
+                        description: |-
+                          Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                          for backward compatibility. There is no validation of this field and
+                          lifecycle hooks will fail at runtime when it is specified.
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              Number or name of the port to access on the container.
+                              Number must be in the range 1 to 65535.
+                              Name must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                        required:
+                        - port
+                        type: object
+                    type: object
+                  preStop:
+                    description: |-
+                      PreStop is called immediately before a container is terminated due to an
+                      API request or management event such as liveness/startup probe failure,
+                      preemption, resource contention, etc. The handler is not called if the
+                      container crashes or exits. The Pod's termination grace period countdown begins before the
+                      PreStop hook is executed. Regardless of the outcome of the handler, the
+                      container will eventually terminate within the Pod's termination grace
+                      period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                      or until the termination grace period is reached.
+                      More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                    properties:
+                      exec:
+                        description: Exec specifies a command to execute in the container.
+                        properties:
+                          command:
+                            description: |-
+                              Command is the command line to execute inside the container, the working directory for the
+                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                              a shell, you need to explicitly call out to that shell.
+                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      httpGet:
+                        description: HTTPGet specifies an HTTP GET request to perform.
+                        properties:
+                          host:
+                            description: |-
+                              Host name to connect to, defaults to the pod IP. You probably want to set
+                              "Host" in httpHeaders instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              properties:
+                                name:
+                                  description: |-
+                                    The header field name.
+                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              Name or number of the port to access on the container.
+                              Number must be in the range 1 to 65535.
+                              Name must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                          scheme:
+                            description: |-
+                              Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      sleep:
+                        description: Sleep represents a duration that the container
+                          should sleep.
+                        properties:
+                          seconds:
+                            description: Seconds is the number of seconds to sleep.
+                            format: int64
+                            type: integer
+                        required:
+                        - seconds
+                        type: object
+                      tcpSocket:
+                        description: |-
+                          Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                          for backward compatibility. There is no validation of this field and
+                          lifecycle hooks will fail at runtime when it is specified.
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              Number or name of the port to access on the container.
+                              Number must be in the range 1 to 65535.
+                              Name must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                        required:
+                        - port
+                        type: object
+                    type: object
+                  stopSignal:
+                    description: |-
+                      StopSignal defines which signal will be sent to a container when it is being stopped.
+                      If not specified, the default is defined by the container runtime in use.
+                      StopSignal can only be set for Pods with a non-empty .spec.os.name
+                    type: string
+                type: object
+              nodeSelector:
                 additionalProperties:
                   type: string
-                description: DefaultNodeSelector specifies default node selection
-                  constraints
+                description: NodeSelector specifies node selection constraints for
+                  the workspace pod
                 type: object
-              defaultOwnershipType:
-                default: Public
-                description: DefaultOwnershipType specifies the default access type
-                  for workspaces using this template
+              ownershipType:
+                description: |-
+                  OwnershipType specifies who can modify the space.
+                  Public means anyone with RBAC permissions can update/delete the space.
+                  OwnerOnly means only the creator can update/delete the space.
                 enum:
                 - Public
                 - OwnerOnly
                 type: string
-              defaultResources:
-                description: DefaultResources specifies the default resource requirements
+              resources:
+                description: Resources specifies the resource requirements
                 properties:
                   claims:
                     description: |-
@@ -1080,9 +1312,46 @@ spec:
                       More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                     type: object
                 type: object
-              defaultTolerations:
-                description: DefaultTolerations specifies default tolerations for
-                  scheduling on nodes with taints
+              storage:
+                description: Storage specifies the storage configuration
+                properties:
+                  mountPath:
+                    default: /home/jovyan
+                    description: |-
+                      MountPath specifies where to mount the persistent volume in the container
+                      Default is /home/jovyan (jovyan is the standard user in Jupyter images)
+                    type: string
+                  size:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    default: 10Gi
+                    description: |-
+                      Size specifies the size of the persistent volume
+                      Supports standard Kubernetes resource quantities (e.g., "10Gi", "500Mi", "1Ti")
+                      Integer values without units are interpreted as bytes
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  storageClassName:
+                    description: StorageClassName specifies the storage class to use
+                      for persistent storage
+                    type: string
+                type: object
+                x-kubernetes-validations:
+                - message: storage is immutable
+                  rule: self == oldSelf
+              templateRef:
+                description: |-
+                  TemplateRef references a WorkspaceTemplate to use as base configuration
+                  When set, template provides defaults and spec fields (Image, Resources, Storage.Size) act as overrides
+                  IMMUTABLE: Cannot be changed after workspace creation
+                type: string
+                x-kubernetes-validations:
+                - message: templateRef is immutable
+                  rule: self == oldSelf
+              tolerations:
+                description: Tolerations specifies tolerations for the workspace pod
+                  to schedule on nodes with matching taints
                 items:
                   description: |-
                     The pod this Toleration is attached to tolerates any taint that matches
@@ -1120,285 +1389,155 @@ spec:
                       type: string
                   type: object
                 type: array
-              description:
-                description: Description provides additional information about this
-                  template
-                maxLength: 500
-                type: string
-              displayName:
-                description: DisplayName is the human-readable name of this template
-                maxLength: 100
-                minLength: 1
-                type: string
-              environmentVariables:
-                description: EnvironmentVariables defines default environment variables
+              volumes:
+                description: Volumes specifies additional volumes to mount from existing
+                  PersistantVolumeClaims
                 items:
-                  description: EnvVar represents an environment variable present in
-                    a Container.
+                  description: VolumeSpec defines a volume to mount from an existing
+                    PVC
                   properties:
+                    mountPath:
+                      description: MountPath is the path where the volume should be
+                        mounted (Unix-style path, e.g. /data)
+                      type: string
                     name:
-                      description: |-
-                        Name of the environment variable.
-                        May consist of any printable ASCII characters except '='.
+                      description: Name is a unique identifier for this volume within
+                        the pod (maps to pod.spec.volumes[].name)
                       type: string
-                    value:
-                      description: |-
-                        Variable references $(VAR_NAME) are expanded
-                        using the previously defined environment variables in the container and
-                        any service environment variables. If a variable cannot be resolved,
-                        the reference in the input string will be unchanged. Double $$ are reduced
-                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                        Escaped references will never be expanded, regardless of whether the variable
-                        exists or not.
-                        Defaults to "".
+                    persistentVolumeClaimName:
+                      description: PersistentVolumeClaimName is the name of the existing
+                        PVC to mount
                       type: string
-                    valueFrom:
-                      description: Source for the environment variable's value. Cannot
-                        be used if value is not empty.
-                      properties:
-                        configMapKeyRef:
-                          description: Selects a key of a ConfigMap.
-                          properties:
-                            key:
-                              description: The key to select.
-                              type: string
-                            name:
-                              default: ""
-                              description: |-
-                                Name of the referent.
-                                This field is effectively required, but due to backwards compatibility is
-                                allowed to be empty. Instances of this type with an empty value here are
-                                almost certainly wrong.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              type: string
-                            optional:
-                              description: Specify whether the ConfigMap or its key
-                                must be defined
-                              type: boolean
-                          required:
-                          - key
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        fieldRef:
-                          description: |-
-                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
-                          properties:
-                            apiVersion:
-                              description: Version of the schema the FieldPath is
-                                written in terms of, defaults to "v1".
-                              type: string
-                            fieldPath:
-                              description: Path of the field to select in the specified
-                                API version.
-                              type: string
-                          required:
-                          - fieldPath
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        fileKeyRef:
-                          description: |-
-                            FileKeyRef selects a key of the env file.
-                            Requires the EnvFiles feature gate to be enabled.
-                          properties:
-                            key:
-                              description: |-
-                                The key within the env file. An invalid key will prevent the pod from starting.
-                                The keys defined within a source may consist of any printable ASCII characters except '='.
-                                During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
-                              type: string
-                            optional:
-                              default: false
-                              description: |-
-                                Specify whether the file or its key must be defined. If the file or key
-                                does not exist, then the env var is not published.
-                                If optional is set to true and the specified key does not exist,
-                                the environment variable will not be set in the Pod's containers.
-
-                                If optional is set to false and the specified key does not exist,
-                                an error will be returned during Pod creation.
-                              type: boolean
-                            path:
-                              description: |-
-                                The path within the volume from which to select the file.
-                                Must be relative and may not contain the '..' path or start with '..'.
-                              type: string
-                            volumeName:
-                              description: The name of the volume mount containing
-                                the env file.
-                              type: string
-                          required:
-                          - key
-                          - path
-                          - volumeName
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        resourceFieldRef:
-                          description: |-
-                            Selects a resource of the container: only resources limits and requests
-                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
-                          properties:
-                            containerName:
-                              description: 'Container name: required for volumes,
-                                optional for env vars'
-                              type: string
-                            divisor:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              description: Specifies the output format of the exposed
-                                resources, defaults to "1"
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            resource:
-                              description: 'Required: resource to select'
-                              type: string
-                          required:
-                          - resource
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        secretKeyRef:
-                          description: Selects a key of a secret in the pod's namespace
-                          properties:
-                            key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              default: ""
-                              description: |-
-                                Name of the referent.
-                                This field is effectively required, but due to backwards compatibility is
-                                allowed to be empty. Instances of this type with an empty value here are
-                                almost certainly wrong.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              type: string
-                            optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
-                              type: boolean
-                          required:
-                          - key
-                          type: object
-                          x-kubernetes-map-type: atomic
-                      type: object
                   required:
+                  - mountPath
                   - name
+                  - persistentVolumeClaimName
                   type: object
                 type: array
-              primaryStorage:
-                description: PrimaryStorage defines storage configuration
-                properties:
-                  defaultMountPath:
-                    default: /home/jovyan
-                    description: DefaultMountPath is the default mount path for the
-                      storage
-                    type: string
-                  defaultSize:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    default: 10Gi
-                    description: DefaultSize is the default storage size
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  defaultStorageClassName:
-                    description: DefaultStorageClassName is the default storage class
-                      name
-                    type: string
-                  maxSize:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    description: MaxSize is the maximum allowed storage size
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  minSize:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    description: MinSize is the minimum allowed storage size
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                type: object
-              resourceBounds:
-                description: ResourceBounds defines the min/max boundaries for resource
-                  overrides
-                properties:
-                  cpu:
-                    description: CPU bounds
-                    properties:
-                      max:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        description: Max is the maximum allowed value
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      min:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        description: Min is the minimum allowed value
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                    required:
-                    - max
-                    - min
-                    type: object
-                  gpu:
-                    description: GPU bounds
-                    properties:
-                      max:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        description: Max is the maximum allowed value
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      min:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        description: Min is the minimum allowed value
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                    required:
-                    - max
-                    - min
-                    type: object
-                  memory:
-                    description: Memory bounds
-                    properties:
-                      max:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        description: Max is the maximum allowed value
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      min:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        description: Min is the minimum allowed value
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                    required:
-                    - max
-                    - min
-                    type: object
-                type: object
             required:
-            - defaultImage
             - displayName
             type: object
+          status:
+            description: status defines the observed state of Workspace
+            properties:
+              accessResourceSelector:
+                description: |-
+                  AccessResourceSelector is a label selector that can be used to find all resources
+                  created from the workspace's AccessStrategy templates
+                type: string
+              accessResources:
+                description: |-
+                  AccessResources provides status details of individual resources created from
+                  the workspace's AccessStrategy templates
+                items:
+                  description: AccessResourceStatus defines the status of a resource
+                    created from a template
+                  properties:
+                    apiVersion:
+                      description: APIVersion of the Kubernetes resource
+                      type: string
+                    kind:
+                      description: Kind of the Kubernetes resource
+                      type: string
+                    name:
+                      description: Name of the resource
+                      type: string
+                    namespace:
+                      description: Namespace of the resource
+                      type: string
+                  required:
+                  - apiVersion
+                  - kind
+                  - name
+                  - namespace
+                  type: object
+                type: array
+              accessURL:
+                description: AccessURL is the URL at which the workspace can be accessed
+                type: string
+              conditions:
+                description: |-
+                  Conditions represent the current state of the Workspace resource.
+                  Each condition has a unique type and reflects the status of a specific aspect of the resource.
+
+                  Standard condition types include:
+                  - "Available": the resource is fully functional and ready to use
+                  - "Progressing": the resource is being created or updated
+                  - "Degraded": the resource failed to reach or maintain its desired state
+                  - "Valid": the workspace configuration passes all validation checks (template, quota, etc.)
+
+                  The status of each condition is one of True, False, or Unknown.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              deploymentName:
+                description: DeploymentName is the name of the deployment managing
+                  the Workspace pods
+                type: string
+              serviceName:
+                description: ServiceName is the name of the service exposing the Workspace
+                type: string
+            type: object
+        required:
+        - spec
         type: object
-        x-kubernetes-validations:
-        - message: template spec is immutable after creation
-          rule: self.spec == oldSelf.spec
     served: true
     storage: true
-    subresources: {}
+    subresources:
+      status: {}
 {{- end -}}

--- a/dist/chart/templates/crd/workspace.jupyter.org_workspacetemplates.yaml
+++ b/dist/chart/templates/crd/workspace.jupyter.org_workspacetemplates.yaml
@@ -1,12 +1,18 @@
+{{- if .Values.crd.enable }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
   annotations:
+    {{- if .Values.crd.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
     controller-gen.kubebuilder.io/version: v0.18.0
-  name: workspacetemplates.workspaces.jupyter.org
+  name: workspacetemplates.workspace.jupyter.org
 spec:
-  group: workspaces.jupyter.org
+  group: workspace.jupyter.org
   names:
     kind: WorkspaceTemplate
     listKind: WorkspaceTemplateList
@@ -1395,3 +1401,4 @@ spec:
     served: true
     storage: true
     subresources: {}
+{{- end -}}

--- a/dist/chart/templates/rbac/role.yaml
+++ b/dist/chart/templates/rbac/role.yaml
@@ -67,7 +67,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - workspaces.jupyter.org
+  - workspace.jupyter.org
   resources:
   - '*'
   verbs:
@@ -79,7 +79,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - workspaces.jupyter.org
+  - workspace.jupyter.org
   resources:
   - workspacetemplates
   verbs:
@@ -89,7 +89,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - workspaces.jupyter.org
+  - workspace.jupyter.org
   resources:
   - workspacetemplates/finalizers
   verbs:

--- a/dist/chart/templates/rbac/workspace_admin_role.yaml
+++ b/dist/chart/templates/rbac/workspace_admin_role.yaml
@@ -2,7 +2,7 @@
 # This rule is not used by the project jupyter-k8s itself.
 # It is provided to allow the cluster admin to help manage permissions for users.
 #
-# Grants full permissions ('*') over workspaces.jupyter.org.
+# Grants full permissions ('*') over workspace.jupyter.org.
 # This role is intended for users authorized to modify roles and bindings within the cluster,
 # enabling them to delegate specific permissions to other users or groups as needed.
 
@@ -14,13 +14,13 @@ metadata:
   name: workspace-admin-role
 rules:
 - apiGroups:
-  - workspaces.jupyter.org
+  - workspace.jupyter.org
   resources:
   - workspaces
   verbs:
   - '*'
 - apiGroups:
-  - workspaces.jupyter.org
+  - workspace.jupyter.org
   resources:
   - workspaces/status
   verbs:

--- a/dist/chart/templates/rbac/workspace_editor_role.yaml
+++ b/dist/chart/templates/rbac/workspace_editor_role.yaml
@@ -2,7 +2,7 @@
 # This rule is not used by the project jupyter-k8s itself.
 # It is provided to allow the cluster admin to help manage permissions for users.
 #
-# Grants permissions to create, update, and delete resources within the workspaces.jupyter.org.
+# Grants permissions to create, update, and delete resources within the workspace.jupyter.org.
 # This role is intended for users who need to manage these resources
 # but should not control RBAC or manage permissions for others.
 
@@ -14,7 +14,7 @@ metadata:
   name: workspace-editor-role
 rules:
 - apiGroups:
-  - workspaces.jupyter.org
+  - workspace.jupyter.org
   resources:
   - workspaces
   verbs:
@@ -26,7 +26,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - workspaces.jupyter.org
+  - workspace.jupyter.org
   resources:
   - workspaces/status
   verbs:

--- a/dist/chart/templates/rbac/workspace_viewer_role.yaml
+++ b/dist/chart/templates/rbac/workspace_viewer_role.yaml
@@ -2,7 +2,7 @@
 # This rule is not used by the project jupyter-k8s itself.
 # It is provided to allow the cluster admin to help manage permissions for users.
 #
-# Grants read-only access to workspaces.jupyter.org resources.
+# Grants read-only access to workspace.jupyter.org resources.
 # This role is intended for users who need visibility into these resources
 # without permissions to modify them. It is ideal for monitoring purposes and limited-access viewing.
 
@@ -14,7 +14,7 @@ metadata:
   name: workspace-viewer-role
 rules:
 - apiGroups:
-  - workspaces.jupyter.org
+  - workspace.jupyter.org
   resources:
   - workspaces
   verbs:
@@ -22,7 +22,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - workspaces.jupyter.org
+  - workspace.jupyter.org
   resources:
   - workspaces/status
   verbs:

--- a/dist/chart/templates/webhook/webhooks.yaml
+++ b/dist/chart/templates/webhook/webhooks.yaml
@@ -16,7 +16,7 @@ webhooks:
       service:
         name: jupyter-k8s-webhook-service
         namespace: {{ .Release.Namespace }}
-        path: /mutate-workspaces-jupyter-org-v1alpha1-workspace
+        path: /mutate-workspace-jupyter-org-v1alpha1-workspace
     failurePolicy: Fail
     sideEffects: None
     admissionReviewVersions:
@@ -26,7 +26,7 @@ webhooks:
           - CREATE
           - UPDATE
         apiGroups:
-          - workspaces.jupyter.org
+          - workspace.jupyter.org
         apiVersions:
           - v1alpha1
         resources:
@@ -49,7 +49,7 @@ webhooks:
       service:
         name: jupyter-k8s-webhook-service
         namespace: {{ .Release.Namespace }}
-        path: /validate-workspaces-jupyter-org-v1alpha1-workspace
+        path: /validate-workspace-jupyter-org-v1alpha1-workspace
     failurePolicy: Fail
     sideEffects: None
     admissionReviewVersions:
@@ -60,7 +60,7 @@ webhooks:
           - UPDATE
           - DELETE
         apiGroups:
-          - workspaces.jupyter.org
+          - workspace.jupyter.org
         apiVersions:
           - v1alpha1
         resources:

--- a/guided-charts/aws-hyperpod/README-SSM-Setup.md
+++ b/guided-charts/aws-hyperpod/README-SSM-Setup.md
@@ -252,7 +252,7 @@ kubectl logs -f deployment/jupyter-k8s-controller-manager -n jupyter-k8s-system
 
 ```bash
 cat > test-workspace.yaml << EOF
-apiVersion: workspaces.jupyter.org/v1alpha1
+apiVersion: workspace.jupyter.org/v1alpha1
 kind: Workspace
 metadata:
   name: test-ssm-workspace
@@ -281,7 +281,7 @@ kubectl apply -f test-workspace.yaml
 
 ```bash
 # Watch pod creation
-kubectl get pods -l workspaces.jupyter.org/workspaceName=test-ssm-workspace -w
+kubectl get pods -l workspace.jupyter.org/workspaceName=test-ssm-workspace -w
 
 # Monitor operator logs for SSM workflow
 kubectl logs -f deployment/jupyter-k8s-controller-manager -n jupyter-k8s-system | grep -i ssm

--- a/guided-charts/aws-hyperpod/templates/aws-ssm-remote-access-strategy.yaml
+++ b/guided-charts/aws-hyperpod/templates/aws-ssm-remote-access-strategy.yaml
@@ -1,4 +1,4 @@
-apiVersion: workspaces.jupyter.org/v1alpha1
+apiVersion: workspace.jupyter.org/v1alpha1
 kind: WorkspaceAccessStrategy
 metadata:
   name: aws-ssm-remote-access

--- a/guided-charts/aws-traefik-dex/templates/github-rbac/group-role.yaml
+++ b/guided-charts/aws-traefik-dex/templates/github-rbac/group-role.yaml
@@ -9,13 +9,13 @@ metadata:
   annotations:
     description: "Grants namespace-specific permissions for workspaces to GitHub teams"
 rules:
-  - apiGroups: ["workspaces.jupyter.org"]
+  - apiGroups: ["workspace.jupyter.org"]
     resources: ["workspaces"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  - apiGroups: ["workspaces.jupyter.org"]
+  - apiGroups: ["workspace.jupyter.org"]
     resources: ["workspaces/connection"]
     verbs: ["create"]
-  - apiGroups: ["workspaces.jupyter.org"]
+  - apiGroups: ["workspace.jupyter.org"]
     resources: ["*"]
     verbs: ["get", "list", "watch"]
 {{- end }}

--- a/guided-charts/aws-traefik-dex/templates/github-rbac/group-rolebinding.yaml
+++ b/guided-charts/aws-traefik-dex/templates/github-rbac/group-rolebinding.yaml
@@ -5,7 +5,7 @@ metadata:
   name: github-workspace-orgs-binding
   namespace: default
   annotations:
-    description: "Grants access to workspaces.jupyter.org resources for specified GitHub teams"
+    description: "Grants access to workspace.jupyter.org resources for specified GitHub teams"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/guided-charts/aws-traefik-dex/templates/github-rbac/user-role.yaml
+++ b/guided-charts/aws-traefik-dex/templates/github-rbac/user-role.yaml
@@ -11,13 +11,13 @@ metadata:
   annotations:
     description: "Grants namespace-specific permissions for workspaces to GitHub user {{ $user }}"
 rules:
-  - apiGroups: ["workspaces.jupyter.org"]
+  - apiGroups: ["workspace.jupyter.org"]
     resources: ["workspaces"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  - apiGroups: ["workspaces.jupyter.org"]
+  - apiGroups: ["workspace.jupyter.org"]
     resources: ["workspaces/connection"]
     verbs: ["create"]
-  - apiGroups: ["workspaces.jupyter.org"]
+  - apiGroups: ["workspace.jupyter.org"]
     resources: ["*"]
     verbs: ["get", "list", "watch"]
 {{- end }}

--- a/guided-charts/aws-traefik-dex/templates/github-rbac/user-rolebinding.yaml
+++ b/guided-charts/aws-traefik-dex/templates/github-rbac/user-rolebinding.yaml
@@ -7,7 +7,7 @@ metadata:
   name: github-workspace-binding-{{ $user }}
   namespace: default
   annotations:
-    description: "Grants access to workspaces.jupyter.org resources for user {{ $user }}"
+    description: "Grants access to workspace.jupyter.org resources for user {{ $user }}"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/internal/aws/ssm_remote_access_strategy.go
+++ b/internal/aws/ssm_remote_access_strategy.go
@@ -7,7 +7,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	workspacesv1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
+	workspacev1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
 )
 
 // Variables for dependency injection in tests
@@ -76,7 +76,7 @@ func NewSSMRemoteAccessStrategy(ssmClient SSMRemoteAccessClientInterface, podExe
 }
 
 // InitSSMAgent initializes SSM agent for aws-ssm-remote-access strategy
-func (s *SSMRemoteAccessStrategy) InitSSMAgent(ctx context.Context, pod *corev1.Pod, workspace *workspacesv1alpha1.Workspace, accessStrategy *workspacesv1alpha1.WorkspaceAccessStrategy) error {
+func (s *SSMRemoteAccessStrategy) InitSSMAgent(ctx context.Context, pod *corev1.Pod, workspace *workspacev1alpha1.Workspace, accessStrategy *workspacev1alpha1.WorkspaceAccessStrategy) error {
 	if s.ssmClient == nil {
 		return fmt.Errorf("SSM client not available")
 	}
@@ -146,7 +146,7 @@ func (s *SSMRemoteAccessStrategy) isSSMRegistrationCompleted(ctx context.Context
 }
 
 // performSSMRegistration handles the SSM activation and registration process
-func (s *SSMRemoteAccessStrategy) performSSMRegistration(ctx context.Context, pod *corev1.Pod, workspace *workspacesv1alpha1.Workspace, accessStrategy *workspacesv1alpha1.WorkspaceAccessStrategy) error {
+func (s *SSMRemoteAccessStrategy) performSSMRegistration(ctx context.Context, pod *corev1.Pod, workspace *workspacev1alpha1.Workspace, accessStrategy *workspacev1alpha1.WorkspaceAccessStrategy) error {
 	logger := logf.FromContext(ctx).WithValues("pod", pod.Name, "workspace", workspace.Name)
 
 	if s.ssmClient == nil {
@@ -186,7 +186,7 @@ func (s *SSMRemoteAccessStrategy) performSSMRegistration(ctx context.Context, po
 }
 
 // createSSMActivation creates an SSM activation and returns activation code and ID
-func (s *SSMRemoteAccessStrategy) createSSMActivation(ctx context.Context, pod *corev1.Pod, workspace *workspacesv1alpha1.Workspace, accessStrategy *workspacesv1alpha1.WorkspaceAccessStrategy) (string, string, error) {
+func (s *SSMRemoteAccessStrategy) createSSMActivation(ctx context.Context, pod *corev1.Pod, workspace *workspacev1alpha1.Workspace, accessStrategy *workspacev1alpha1.WorkspaceAccessStrategy) (string, string, error) {
 	logger := logf.FromContext(ctx).WithValues("workspace", workspace.Name)
 
 	if s.ssmClient == nil {

--- a/internal/aws/ssm_remote_access_strategy_test.go
+++ b/internal/aws/ssm_remote_access_strategy_test.go
@@ -11,7 +11,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	workspacesv1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
+	workspacev1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
 )
 
 const (
@@ -120,8 +120,8 @@ func createTestPod(containerStatuses []corev1.ContainerStatus) *corev1.Pod {
 	}
 }
 
-func createTestWorkspace() *workspacesv1alpha1.Workspace {
-	return &workspacesv1alpha1.Workspace{
+func createTestWorkspace() *workspacev1alpha1.Workspace {
+	return &workspacev1alpha1.Workspace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-workspace",
 			Namespace: "test-namespace",
@@ -129,12 +129,12 @@ func createTestWorkspace() *workspacesv1alpha1.Workspace {
 	}
 }
 
-func createTestAccessStrategy(controllerConfig map[string]string) *workspacesv1alpha1.WorkspaceAccessStrategy {
-	return &workspacesv1alpha1.WorkspaceAccessStrategy{
+func createTestAccessStrategy(controllerConfig map[string]string) *workspacev1alpha1.WorkspaceAccessStrategy {
+	return &workspacev1alpha1.WorkspaceAccessStrategy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "aws-ssm-remote-access",
 		},
-		Spec: workspacesv1alpha1.WorkspaceAccessStrategySpec{
+		Spec: workspacev1alpha1.WorkspaceAccessStrategySpec{
 			ControllerConfig: controllerConfig,
 		},
 	}

--- a/internal/controller/access_resources_builder.go
+++ b/internal/controller/access_resources_builder.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"text/template"
 
-	workspacesv1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
+	workspacev1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -25,16 +25,16 @@ func NewAccessResourcesBuilder() *AccessResourcesBuilder {
 
 // fullAccessResourceData provides values for template substitutions
 type fullAccessResourceData struct {
-	Workspace      *workspacesv1alpha1.Workspace
-	AccessStrategy *workspacesv1alpha1.WorkspaceAccessStrategy
+	Workspace      *workspacev1alpha1.Workspace
+	AccessStrategy *workspacev1alpha1.WorkspaceAccessStrategy
 	Service        *corev1.Service
 }
 
 // BuildUnstructuredResource builds an unstructured resource from a template
 func (b *AccessResourcesBuilder) BuildUnstructuredResource(
-	accessResourceTemplate workspacesv1alpha1.AccessResourceTemplate,
-	workspace *workspacesv1alpha1.Workspace,
-	accessStrategy *workspacesv1alpha1.WorkspaceAccessStrategy,
+	accessResourceTemplate workspacev1alpha1.AccessResourceTemplate,
+	workspace *workspacev1alpha1.Workspace,
+	accessStrategy *workspacev1alpha1.WorkspaceAccessStrategy,
 	service *corev1.Service,
 ) (*unstructured.Unstructured, error) {
 	// Generate resource name using NamePrefix and workspace name
@@ -117,8 +117,8 @@ func (b *AccessResourcesBuilder) BuildUnstructuredResource(
 
 // ResolveAccessURL processes the AccessURLTemplate
 func (b *AccessResourcesBuilder) ResolveAccessURL(
-	workspace *workspacesv1alpha1.Workspace,
-	accessStrategy *workspacesv1alpha1.WorkspaceAccessStrategy,
+	workspace *workspacev1alpha1.Workspace,
+	accessStrategy *workspacev1alpha1.WorkspaceAccessStrategy,
 	service *corev1.Service,
 ) (string, error) {
 	accessUrlTemplate := accessStrategy.Spec.AccessURLTemplate
@@ -153,8 +153,8 @@ func (b *AccessResourcesBuilder) ResolveAccessURL(
 // ResolveAccessResourceSelector creates a label selector string for finding access resources
 // associated with a specific workspace and access strategy
 func (b *AccessResourcesBuilder) ResolveAccessResourceSelector(
-	workspace *workspacesv1alpha1.Workspace,
-	accessStrategy *workspacesv1alpha1.WorkspaceAccessStrategy,
+	workspace *workspacev1alpha1.Workspace,
+	accessStrategy *workspacev1alpha1.WorkspaceAccessStrategy,
 ) string {
 	hasAccessResources := len(accessStrategy.Spec.AccessResourceTemplates) > 0
 

--- a/internal/controller/access_resources_builder_test.go
+++ b/internal/controller/access_resources_builder_test.go
@@ -9,14 +9,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	workspacesv1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
+	workspacev1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
 )
 
 var _ = Describe("AccessResourcesBuilder", func() {
 	var (
 		accessBuilder      *AccessResourcesBuilder
-		testAccessStrategy *workspacesv1alpha1.WorkspaceAccessStrategy
-		testWorkspace      *workspacesv1alpha1.Workspace
+		testAccessStrategy *workspacev1alpha1.WorkspaceAccessStrategy
+		testWorkspace      *workspacev1alpha1.Workspace
 		testService        *corev1.Service
 	)
 
@@ -25,14 +25,14 @@ var _ = Describe("AccessResourcesBuilder", func() {
 		accessBuilder = NewAccessResourcesBuilder()
 
 		// Define test objects based on config/samples_routing
-		testAccessStrategy = &workspacesv1alpha1.WorkspaceAccessStrategy{
+		testAccessStrategy = &workspacev1alpha1.WorkspaceAccessStrategy{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "sample-access-strategy",
 				Namespace: "default",
 			},
-			Spec: workspacesv1alpha1.WorkspaceAccessStrategySpec{
+			Spec: workspacev1alpha1.WorkspaceAccessStrategySpec{
 				DisplayName: "JupyterLab Routing Strategy",
-				AccessResourceTemplates: []workspacesv1alpha1.AccessResourceTemplate{
+				AccessResourceTemplates: []workspacev1alpha1.AccessResourceTemplate{
 					{
 						Kind:       "IngressRoute",
 						ApiVersion: "traefik.io/v1alpha1",
@@ -44,16 +44,16 @@ var _ = Describe("AccessResourcesBuilder", func() {
 			},
 		}
 
-		testWorkspace = &workspacesv1alpha1.Workspace{
+		testWorkspace = &workspacev1alpha1.Workspace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-workspace",
 				Namespace: "test-namespace",
 			},
-			Spec: workspacesv1alpha1.WorkspaceSpec{
+			Spec: workspacev1alpha1.WorkspaceSpec{
 				DisplayName:    "Test Workspace",
 				Image:          "jupyter/minimal-notebook:latest",
 				DesiredStatus:  "Running",
-				AccessStrategy: &workspacesv1alpha1.AccessStrategyRef{Name: "sample-access-strategy"},
+				AccessStrategy: &workspacev1alpha1.AccessStrategyRef{Name: "sample-access-strategy"},
 			},
 		}
 
@@ -130,7 +130,7 @@ var _ = Describe("AccessResourcesBuilder", func() {
 			Expect(gvk.Kind).To(Equal("IngressRoute"))
 
 			// Test with a core API version (no group)
-			coreApiTemplate := workspacesv1alpha1.AccessResourceTemplate{
+			coreApiTemplate := workspacev1alpha1.AccessResourceTemplate{
 				Kind:       "ConfigMap",
 				ApiVersion: "v1", // Core API version without group
 				NamePrefix: "test-config",
@@ -303,7 +303,7 @@ var _ = Describe("AccessResourcesBuilder", func() {
 		It("Should return the empty string if the strategy does not define accessResources", func() {
 			// Create a copy of the access strategy without access resources
 			strategyWithoutResources := testAccessStrategy.DeepCopy()
-			strategyWithoutResources.Spec.AccessResourceTemplates = []workspacesv1alpha1.AccessResourceTemplate{}
+			strategyWithoutResources.Spec.AccessResourceTemplates = []workspacev1alpha1.AccessResourceTemplate{}
 
 			selector := accessBuilder.ResolveAccessResourceSelector(
 				testWorkspace,

--- a/internal/controller/conditions_utils.go
+++ b/internal/controller/conditions_utils.go
@@ -3,7 +3,7 @@ package controller
 import (
 	"context"
 
-	workspacesv1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
+	workspacev1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -24,7 +24,7 @@ func FindCondition(conditions *[]metav1.Condition, conditionType string) *metav1
 // or an empty list if there are no update needed.
 func GetNewConditionsOrEmptyIfUnchanged(
 	ctx context.Context,
-	workspace *workspacesv1alpha1.Workspace,
+	workspace *workspacev1alpha1.Workspace,
 	conditions *[]metav1.Condition) []metav1.Condition {
 
 	// abort early if nothing is requested

--- a/internal/controller/conditions_utils_test.go
+++ b/internal/controller/conditions_utils_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	workspacesv1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
+	workspacev1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -34,7 +34,7 @@ func TestFindCondition(t *testing.T) {
 
 func TestGetNewConditionsOrEmptyIfUnchanged(t *testing.T) {
 	ctx := context.Background()
-	workspace := &workspacesv1alpha1.Workspace{}
+	workspace := &workspacev1alpha1.Workspace{}
 	workspace.Status.Conditions = []metav1.Condition{
 		{Type: "Existing", Status: metav1.ConditionTrue, Reason: "InitialReason", Message: "Initial message"},
 		{Type: "ToUpdate", Status: metav1.ConditionFalse, Reason: "OldReason", Message: "Old message"},

--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -21,17 +21,17 @@ const (
 	AppLabel = "app"
 
 	// Access strategy label keys
-	LabelWorkspaceName           = "workspaces.jupyter.org/workspaceName"
-	LabelWorkspaceNamespace      = "workspaces.jupyter.org/workspaceNamespace"
-	LabelAccessStrategyName      = "workspaces.jupyter.org/accessStrategyName"
-	LabelAccessStrategyNamespace = "workspaces.jupyter.org/accessStrategyNamespace"
+	LabelWorkspaceName           = "workspace.jupyter.org/workspaceName"
+	LabelWorkspaceNamespace      = "workspace.jupyter.org/workspaceNamespace"
+	LabelAccessStrategyName      = "workspace.jupyter.org/accessStrategyName"
+	LabelAccessStrategyNamespace = "workspace.jupyter.org/accessStrategyNamespace"
 
 	// Label values
 	AppLabelValue = "jupyter"
 
 	// Annotation keys
-	AnnotationCreatedBy     = "workspaces.jupyter.org/created-by"
-	AnnotationLastUpdatedBy = "workspaces.jupyter.org/last-updated-by"
+	AnnotationCreatedBy     = "workspace.jupyter.org/created-by"
+	AnnotationLastUpdatedBy = "workspace.jupyter.org/last-updated-by"
 
 	// Status phases
 	PhaseCreating = "Creating"

--- a/internal/controller/deployment_builder.go
+++ b/internal/controller/deployment_builder.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	workspacesv1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
+	workspacev1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -35,7 +35,7 @@ func NewDeploymentBuilder(scheme *runtime.Scheme, options WorkspaceControllerOpt
 
 // BuildDeployment creates a Deployment resource for the given Workspace
 // Note: Template validation should happen in StateMachine before calling this
-func (db *DeploymentBuilder) BuildDeployment(ctx context.Context, workspace *workspacesv1alpha1.Workspace, resolvedTemplate *ResolvedTemplate) (*appsv1.Deployment, error) {
+func (db *DeploymentBuilder) BuildDeployment(ctx context.Context, workspace *workspacev1alpha1.Workspace, resolvedTemplate *ResolvedTemplate) (*appsv1.Deployment, error) {
 	resources := db.parseResourceRequirements(workspace, resolvedTemplate)
 
 	deployment := &appsv1.Deployment{
@@ -51,7 +51,7 @@ func (db *DeploymentBuilder) BuildDeployment(ctx context.Context, workspace *wor
 }
 
 // buildObjectMeta creates the metadata for the Deployment
-func (db *DeploymentBuilder) buildObjectMeta(workspace *workspacesv1alpha1.Workspace) metav1.ObjectMeta {
+func (db *DeploymentBuilder) buildObjectMeta(workspace *workspacev1alpha1.Workspace) metav1.ObjectMeta {
 	return metav1.ObjectMeta{
 		Name:      GenerateDeploymentName(workspace.Name),
 		Namespace: workspace.Namespace,
@@ -60,7 +60,7 @@ func (db *DeploymentBuilder) buildObjectMeta(workspace *workspacesv1alpha1.Works
 }
 
 // buildDeploymentSpec creates the deployment specification
-func (db *DeploymentBuilder) buildDeploymentSpec(workspace *workspacesv1alpha1.Workspace, resolvedTemplate *ResolvedTemplate, resources corev1.ResourceRequirements) appsv1.DeploymentSpec {
+func (db *DeploymentBuilder) buildDeploymentSpec(workspace *workspacev1alpha1.Workspace, resolvedTemplate *ResolvedTemplate, resources corev1.ResourceRequirements) appsv1.DeploymentSpec {
 	// Single replica for Jupyter workspaces (stateful, user-specific workloads)
 	replicas := int32(1)
 
@@ -79,7 +79,7 @@ func (db *DeploymentBuilder) buildDeploymentSpec(workspace *workspacesv1alpha1.W
 }
 
 // buildPodSpec creates the pod specification
-func (db *DeploymentBuilder) buildPodSpec(workspace *workspacesv1alpha1.Workspace, resolvedTemplate *ResolvedTemplate, resources corev1.ResourceRequirements) corev1.PodSpec {
+func (db *DeploymentBuilder) buildPodSpec(workspace *workspacev1alpha1.Workspace, resolvedTemplate *ResolvedTemplate, resources corev1.ResourceRequirements) corev1.PodSpec {
 	podSpec := corev1.PodSpec{
 		Containers: []corev1.Container{
 			db.buildPrimaryContainer(workspace, resolvedTemplate, resources),
@@ -141,7 +141,7 @@ func (db *DeploymentBuilder) buildPodSpec(workspace *workspacesv1alpha1.Workspac
 }
 
 // buildPrimaryContainer creates the container specification
-func (db *DeploymentBuilder) buildPrimaryContainer(workspace *workspacesv1alpha1.Workspace, resolvedTemplate *ResolvedTemplate, resources corev1.ResourceRequirements) corev1.Container {
+func (db *DeploymentBuilder) buildPrimaryContainer(workspace *workspacev1alpha1.Workspace, resolvedTemplate *ResolvedTemplate, resources corev1.ResourceRequirements) corev1.Container {
 	var image string
 	if resolvedTemplate != nil && resolvedTemplate.Image != "" {
 		image = resolvedTemplate.Image
@@ -199,7 +199,7 @@ func (db *DeploymentBuilder) buildPrimaryContainer(workspace *workspacesv1alpha1
 }
 
 // parseResourceRequirements extracts and validates resource requirements
-func (db *DeploymentBuilder) parseResourceRequirements(workspace *workspacesv1alpha1.Workspace, resolvedTemplate *ResolvedTemplate) corev1.ResourceRequirements {
+func (db *DeploymentBuilder) parseResourceRequirements(workspace *workspacev1alpha1.Workspace, resolvedTemplate *ResolvedTemplate) corev1.ResourceRequirements {
 	if resolvedTemplate != nil {
 		return resolvedTemplate.Resources
 	}

--- a/internal/controller/deployment_builder_access.go
+++ b/internal/controller/deployment_builder_access.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"text/template"
 
-	workspacesv1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
+	workspacev1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -13,15 +13,15 @@ import (
 
 // partialAccessResourceData provides values for template substitutions
 type partialAccessResourceData struct {
-	Workspace      *workspacesv1alpha1.Workspace
-	AccessStrategy *workspacesv1alpha1.WorkspaceAccessStrategy
+	Workspace      *workspacev1alpha1.Workspace
+	AccessStrategy *workspacev1alpha1.WorkspaceAccessStrategy
 }
 
 // resolveAccessStrategyEnv interpolates the env defined in the AccessStrategy
 // for a particular Workspace.
 func (b *DeploymentBuilder) resolveAccessStrategyEnv(
-	accessStrategy *workspacesv1alpha1.WorkspaceAccessStrategy,
-	workspace *workspacesv1alpha1.Workspace,
+	accessStrategy *workspacev1alpha1.WorkspaceAccessStrategy,
+	workspace *workspacev1alpha1.Workspace,
 ) ([]map[string]string, error) {
 	data := &partialAccessResourceData{
 		Workspace:      workspace,
@@ -55,8 +55,8 @@ func (b *DeploymentBuilder) resolveAccessStrategyEnv(
 // by the Workspace create / update API.
 func (db *DeploymentBuilder) addAccessStrategyEnvToContainer(
 	container *corev1.Container,
-	workspace *workspacesv1alpha1.Workspace,
-	accessStrategy *workspacesv1alpha1.WorkspaceAccessStrategy,
+	workspace *workspacev1alpha1.Workspace,
+	accessStrategy *workspacev1alpha1.WorkspaceAccessStrategy,
 ) error {
 	if container == nil {
 		return fmt.Errorf("container is nil, cannot apply env vars of AccessStrategy: %s", accessStrategy.Name)
@@ -106,8 +106,8 @@ func (db *DeploymentBuilder) addAccessStrategyEnvToContainer(
 // Currently only adds environment variables, but could be extended in the future
 func (db *DeploymentBuilder) ApplyAccessStrategyToDeployment(
 	deployment *appsv1.Deployment,
-	workspace *workspacesv1alpha1.Workspace,
-	accessStrategy *workspacesv1alpha1.WorkspaceAccessStrategy,
+	workspace *workspacev1alpha1.Workspace,
+	accessStrategy *workspacev1alpha1.WorkspaceAccessStrategy,
 ) error {
 	if deployment == nil {
 		return fmt.Errorf("cannot apply AccessStrategy '%s' to nil deployment", accessStrategy.Name)
@@ -135,7 +135,7 @@ func (db *DeploymentBuilder) ApplyAccessStrategyToDeployment(
 // addSSMSidecarContainer adds an SSM sidecar container to the deployment with shared volume
 func (db *DeploymentBuilder) addSSMSidecarContainer(
 	deployment *appsv1.Deployment,
-	accessStrategy *workspacesv1alpha1.WorkspaceAccessStrategy,
+	accessStrategy *workspacev1alpha1.WorkspaceAccessStrategy,
 ) error {
 	// Create shared volume for communication between main container and sidecar
 	sharedVolume := corev1.Volume{

--- a/internal/controller/deployment_builder_access_test.go
+++ b/internal/controller/deployment_builder_access_test.go
@@ -9,7 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	workspacesv1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
+	workspacev1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
 )
 
 const (
@@ -22,15 +22,15 @@ var _ = Describe("DeploymentBuilderForAccess", func() {
 		deploymentBuilder  *DeploymentBuilder
 		scheme             *runtime.Scheme
 		options            WorkspaceControllerOptions
-		testWorkspace      *workspacesv1alpha1.Workspace
-		testAccessStrategy *workspacesv1alpha1.WorkspaceAccessStrategy
+		testWorkspace      *workspacev1alpha1.Workspace
+		testAccessStrategy *workspacev1alpha1.WorkspaceAccessStrategy
 		testDeployment     *appsv1.Deployment
 	)
 
 	BeforeEach(func() {
 		// Initialize test objects based on config/samples_routing
 		scheme = runtime.NewScheme()
-		Expect(workspacesv1alpha1.AddToScheme(scheme)).To(Succeed())
+		Expect(workspacev1alpha1.AddToScheme(scheme)).To(Succeed())
 
 		options = WorkspaceControllerOptions{
 			ApplicationImagesPullPolicy: corev1.PullIfNotPresent,
@@ -40,16 +40,16 @@ var _ = Describe("DeploymentBuilderForAccess", func() {
 		deploymentBuilder = NewDeploymentBuilder(scheme, options, nil)
 
 		// Create test workspace
-		testWorkspace = &workspacesv1alpha1.Workspace{
+		testWorkspace = &workspacev1alpha1.Workspace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-workspace",
 				Namespace: "test-namespace",
 			},
-			Spec: workspacesv1alpha1.WorkspaceSpec{
+			Spec: workspacev1alpha1.WorkspaceSpec{
 				DisplayName:   "Test Workspace",
 				Image:         "jupyter/minimal-notebook:latest",
 				DesiredStatus: "Running",
-				AccessStrategy: &workspacesv1alpha1.AccessStrategyRef{
+				AccessStrategy: &workspacev1alpha1.AccessStrategyRef{
 					Name:      "test-access-strategy",
 					Namespace: "default",
 				},
@@ -67,14 +67,14 @@ var _ = Describe("DeploymentBuilderForAccess", func() {
 		}
 
 		// Create test access strategy with env vars
-		testAccessStrategy = &workspacesv1alpha1.WorkspaceAccessStrategy{
+		testAccessStrategy = &workspacev1alpha1.WorkspaceAccessStrategy{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-access-strategy",
 				Namespace: "default",
 			},
-			Spec: workspacesv1alpha1.WorkspaceAccessStrategySpec{
+			Spec: workspacev1alpha1.WorkspaceAccessStrategySpec{
 				DisplayName: "Test Routing Strategy",
-				MergeEnv: []workspacesv1alpha1.AccessEnvTemplate{
+				MergeEnv: []workspacev1alpha1.AccessEnvTemplate{
 					{
 						Name:          "JUPYTER_BASE_URL",
 						ValueTemplate: "/workspaces/{{ .Workspace.Namespace }}/{{ .Workspace.Name }}/",
@@ -354,7 +354,7 @@ var _ = Describe("DeploymentBuilderForAccess", func() {
 		It("Should be a no-op when strategy.Spec.MergeEnv is empty", func() {
 			// Create a copy with empty MergeEnv
 			strategyWithEmptyEnv := testAccessStrategy.DeepCopy()
-			strategyWithEmptyEnv.Spec.MergeEnv = []workspacesv1alpha1.AccessEnvTemplate{}
+			strategyWithEmptyEnv.Spec.MergeEnv = []workspacev1alpha1.AccessEnvTemplate{}
 
 			originalEnvVarCount := len(testDeployment.Spec.Template.Spec.Containers[0].Env)
 
@@ -394,11 +394,11 @@ var _ = Describe("DeploymentBuilderForAccess", func() {
 
 		It("Should add SSM sidecar container for aws-ssm-remote-access strategy", func() {
 			// Create SSM access strategy with required sidecar image
-			ssmAccessStrategy := &workspacesv1alpha1.WorkspaceAccessStrategy{
+			ssmAccessStrategy := &workspacev1alpha1.WorkspaceAccessStrategy{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "aws-ssm-remote-access",
 				},
-				Spec: workspacesv1alpha1.WorkspaceAccessStrategySpec{
+				Spec: workspacev1alpha1.WorkspaceAccessStrategySpec{
 					DisplayName: "AWS SSM Remote Access",
 					ControllerConfig: map[string]string{
 						"SSM_SIDECAR_IMAGE":     "amazon/aws-ssm-agent:latest",

--- a/internal/controller/deployment_builder_test.go
+++ b/internal/controller/deployment_builder_test.go
@@ -10,7 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	workspacesv1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
+	workspacev1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
 )
 
 var _ = Describe("DeploymentBuilder", func() {
@@ -24,7 +24,7 @@ var _ = Describe("DeploymentBuilder", func() {
 	BeforeEach(func() {
 		ctx = context.Background()
 		scheme = runtime.NewScheme()
-		Expect(workspacesv1alpha1.AddToScheme(scheme)).To(Succeed())
+		Expect(workspacev1alpha1.AddToScheme(scheme)).To(Succeed())
 
 		options = WorkspaceControllerOptions{
 			ApplicationImagesPullPolicy: corev1.PullIfNotPresent,
@@ -37,12 +37,12 @@ var _ = Describe("DeploymentBuilder", func() {
 	Context("Environment Variables", func() {
 		It("should pass environment variables from template to container", func() {
 			// Create workspace
-			workspace := &workspacesv1alpha1.Workspace{
+			workspace := &workspacev1alpha1.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-workspace",
 					Namespace: "default",
 				},
-				Spec: workspacesv1alpha1.WorkspaceSpec{},
+				Spec: workspacev1alpha1.WorkspaceSpec{},
 			}
 
 			// Create resolved template with environment variables
@@ -85,12 +85,12 @@ var _ = Describe("DeploymentBuilder", func() {
 		})
 
 		It("should not add environment variables when template has none", func() {
-			workspace := &workspacesv1alpha1.Workspace{
+			workspace := &workspacev1alpha1.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-workspace-no-env",
 					Namespace: "default",
 				},
-				Spec: workspacesv1alpha1.WorkspaceSpec{},
+				Spec: workspacev1alpha1.WorkspaceSpec{},
 			}
 
 			// Create resolved template without environment variables
@@ -116,12 +116,12 @@ var _ = Describe("DeploymentBuilder", func() {
 		})
 
 		It("should handle nil resolved template gracefully", func() {
-			workspace := &workspacesv1alpha1.Workspace{
+			workspace := &workspacev1alpha1.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-workspace-nil-template",
 					Namespace: "default",
 				},
-				Spec: workspacesv1alpha1.WorkspaceSpec{
+				Spec: workspacev1alpha1.WorkspaceSpec{
 					Resources: &corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
 							corev1.ResourceCPU:    resource.MustParse("500m"),
@@ -144,12 +144,12 @@ var _ = Describe("DeploymentBuilder", func() {
 
 	Context("Storage Configuration", func() {
 		It("should mount volume when storage is configured in template", func() {
-			workspace := &workspacesv1alpha1.Workspace{
+			workspace := &workspacev1alpha1.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-workspace-storage",
 					Namespace: "default",
 				},
-				Spec: workspacesv1alpha1.WorkspaceSpec{},
+				Spec: workspacev1alpha1.WorkspaceSpec{},
 			}
 
 			resolvedTemplate := &ResolvedTemplate{
@@ -160,7 +160,7 @@ var _ = Describe("DeploymentBuilder", func() {
 						corev1.ResourceMemory: resource.MustParse("1Gi"),
 					},
 				},
-				StorageConfiguration: &workspacesv1alpha1.StorageConfig{
+				StorageConfiguration: &workspacev1alpha1.StorageConfig{
 					DefaultSize: resource.MustParse("10Gi"),
 				},
 			}
@@ -181,13 +181,13 @@ var _ = Describe("DeploymentBuilder", func() {
 		})
 
 		It("should handle workspace storage override", func() {
-			workspace := &workspacesv1alpha1.Workspace{
+			workspace := &workspacev1alpha1.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-workspace-storage-override",
 					Namespace: "default",
 				},
-				Spec: workspacesv1alpha1.WorkspaceSpec{
-					Storage: &workspacesv1alpha1.StorageSpec{
+				Spec: workspacev1alpha1.WorkspaceSpec{
+					Storage: &workspacev1alpha1.StorageSpec{
 						Size: resource.MustParse("20Gi"), // Workspace storage takes precedence
 					},
 				},
@@ -201,7 +201,7 @@ var _ = Describe("DeploymentBuilder", func() {
 						corev1.ResourceMemory: resource.MustParse("1Gi"),
 					},
 				},
-				StorageConfiguration: &workspacesv1alpha1.StorageConfig{
+				StorageConfiguration: &workspacev1alpha1.StorageConfig{
 					DefaultSize: resource.MustParse("10Gi"),
 				},
 			}
@@ -218,16 +218,16 @@ var _ = Describe("DeploymentBuilder", func() {
 
 	Context("Additional Volumes", func() {
 		It("should mount additional PVC volumes", func() {
-			workspace := &workspacesv1alpha1.Workspace{
+			workspace := &workspacev1alpha1.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-workspace-volumes",
 					Namespace: "default",
 				},
-				Spec: workspacesv1alpha1.WorkspaceSpec{
-					Storage: &workspacesv1alpha1.StorageSpec{
+				Spec: workspacev1alpha1.WorkspaceSpec{
+					Storage: &workspacev1alpha1.StorageSpec{
 						Size: resource.MustParse("1Gi"),
 					},
-					Volumes: []workspacesv1alpha1.VolumeSpec{
+					Volumes: []workspacev1alpha1.VolumeSpec{
 						{
 							Name:                      "data-volume",
 							PersistentVolumeClaimName: "data-pvc",
@@ -250,7 +250,7 @@ var _ = Describe("DeploymentBuilder", func() {
 						corev1.ResourceMemory: resource.MustParse("256Mi"),
 					},
 				},
-				StorageConfiguration: &workspacesv1alpha1.StorageConfig{
+				StorageConfiguration: &workspacev1alpha1.StorageConfig{
 					DefaultSize: resource.MustParse("1Gi"),
 				},
 			}
@@ -289,13 +289,13 @@ var _ = Describe("DeploymentBuilder", func() {
 
 	Context("Container Configuration", func() {
 		It("should set custom command and args", func() {
-			workspace := &workspacesv1alpha1.Workspace{
+			workspace := &workspacev1alpha1.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-workspace-container-config",
 					Namespace: "default",
 				},
-				Spec: workspacesv1alpha1.WorkspaceSpec{
-					ContainerConfig: &workspacesv1alpha1.ContainerConfig{
+				Spec: workspacev1alpha1.WorkspaceSpec{
+					ContainerConfig: &workspacev1alpha1.ContainerConfig{
 						Command: []string{"/bin/bash"},
 						Args:    []string{"-c", "echo 'test' && sleep 3600"},
 					},
@@ -325,12 +325,12 @@ var _ = Describe("DeploymentBuilder", func() {
 
 	Context("Node Selector", func() {
 		It("should set node selector constraints", func() {
-			workspace := &workspacesv1alpha1.Workspace{
+			workspace := &workspacev1alpha1.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-workspace-node-selector",
 					Namespace: "default",
 				},
-				Spec: workspacesv1alpha1.WorkspaceSpec{
+				Spec: workspacev1alpha1.WorkspaceSpec{
 					NodeSelector: map[string]string{
 						"node.kubernetes.io/instance-type": "ml.t3.large",
 						"kubernetes.io/arch":               "amd64",
@@ -361,12 +361,12 @@ var _ = Describe("DeploymentBuilder", func() {
 
 	Context("Affinity", func() {
 		It("should set node affinity when specified", func() {
-			workspace := &workspacesv1alpha1.Workspace{
+			workspace := &workspacev1alpha1.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-workspace-affinity",
 					Namespace: "default",
 				},
-				Spec: workspacesv1alpha1.WorkspaceSpec{
+				Spec: workspacev1alpha1.WorkspaceSpec{
 					Affinity: &corev1.Affinity{
 						NodeAffinity: &corev1.NodeAffinity{
 							RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
@@ -399,12 +399,12 @@ var _ = Describe("DeploymentBuilder", func() {
 		})
 
 		It("should use template affinity when workspace doesn't specify", func() {
-			workspace := &workspacesv1alpha1.Workspace{
+			workspace := &workspacev1alpha1.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-workspace-template-affinity",
 					Namespace: "default",
 				},
-				Spec: workspacesv1alpha1.WorkspaceSpec{},
+				Spec: workspacev1alpha1.WorkspaceSpec{},
 			}
 
 			resolvedTemplate := &ResolvedTemplate{
@@ -440,12 +440,12 @@ var _ = Describe("DeploymentBuilder", func() {
 
 	Context("Tolerations", func() {
 		It("should set tolerations when specified", func() {
-			workspace := &workspacesv1alpha1.Workspace{
+			workspace := &workspacev1alpha1.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-workspace-tolerations",
 					Namespace: "default",
 				},
-				Spec: workspacesv1alpha1.WorkspaceSpec{
+				Spec: workspacev1alpha1.WorkspaceSpec{
 					Tolerations: []corev1.Toleration{
 						{
 							Key:      "nvidia.com/gpu",
@@ -477,12 +477,12 @@ var _ = Describe("DeploymentBuilder", func() {
 		})
 
 		It("should use template tolerations when workspace doesn't specify", func() {
-			workspace := &workspacesv1alpha1.Workspace{
+			workspace := &workspacev1alpha1.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-workspace-template-tolerations",
 					Namespace: "default",
 				},
-				Spec: workspacesv1alpha1.WorkspaceSpec{},
+				Spec: workspacev1alpha1.WorkspaceSpec{},
 			}
 
 			resolvedTemplate := &ResolvedTemplate{
@@ -507,12 +507,12 @@ var _ = Describe("DeploymentBuilder", func() {
 
 	Context("Lifecycle Hooks", func() {
 		It("should set lifecycle hooks", func() {
-			workspace := &workspacesv1alpha1.Workspace{
+			workspace := &workspacev1alpha1.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-workspace-lifecycle",
 					Namespace: "default",
 				},
-				Spec: workspacesv1alpha1.WorkspaceSpec{
+				Spec: workspacev1alpha1.WorkspaceSpec{
 					Lifecycle: &corev1.Lifecycle{
 						PostStart: &corev1.LifecycleHandler{
 							Exec: &corev1.ExecAction{

--- a/internal/controller/event_recording_test.go
+++ b/internal/controller/event_recording_test.go
@@ -26,7 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 
-	workspacesv1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
+	workspacev1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
 )
 
 var _ = Describe("Event Recording", func() {
@@ -54,12 +54,12 @@ var _ = Describe("Event Recording", func() {
 	Context("Template Validation Events", func() {
 		It("should record ValidationFailed event when validation fails", func() {
 			By("creating a workspace with invalid template overrides")
-			workspace := &workspacesv1alpha1.Workspace{
+			workspace := &workspacev1alpha1.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-validation-failed",
 					Namespace: "default",
 				},
-				Spec: workspacesv1alpha1.WorkspaceSpec{
+				Spec: workspacev1alpha1.WorkspaceSpec{
 					DisplayName: "Test Validation Failed",
 					TemplateRef: stringPtr("test-template"),
 					Image:       "disallowed-image:latest",
@@ -68,11 +68,11 @@ var _ = Describe("Event Recording", func() {
 			Expect(k8sClient.Create(ctx, workspace)).To(Succeed())
 
 			By("creating a template with image restrictions")
-			template := &workspacesv1alpha1.WorkspaceTemplate{
+			template := &workspacev1alpha1.WorkspaceTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-template",
 				},
-				Spec: workspacesv1alpha1.WorkspaceTemplateSpec{
+				Spec: workspacev1alpha1.WorkspaceTemplateSpec{
 					DisplayName:  "Test Template",
 					DefaultImage: "allowed-image:latest",
 					AllowedImages: []string{
@@ -125,12 +125,12 @@ var _ = Describe("Event Recording", func() {
 
 		It("should record Validated event when validation passes", func() {
 			By("creating a workspace with valid template overrides")
-			workspace := &workspacesv1alpha1.Workspace{
+			workspace := &workspacev1alpha1.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-validation-passed",
 					Namespace: "default",
 				},
-				Spec: workspacesv1alpha1.WorkspaceSpec{
+				Spec: workspacev1alpha1.WorkspaceSpec{
 					DisplayName: "Test Validation Passed",
 					TemplateRef: stringPtr("test-template-valid"),
 					Image:       "allowed-image:latest",
@@ -139,11 +139,11 @@ var _ = Describe("Event Recording", func() {
 			Expect(k8sClient.Create(ctx, workspace)).To(Succeed())
 
 			By("creating a template that allows the image")
-			template := &workspacesv1alpha1.WorkspaceTemplate{
+			template := &workspacev1alpha1.WorkspaceTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-template-valid",
 				},
-				Spec: workspacesv1alpha1.WorkspaceTemplateSpec{
+				Spec: workspacev1alpha1.WorkspaceTemplateSpec{
 					DisplayName:  "Test Template Valid",
 					DefaultImage: "allowed-image:latest",
 					AllowedImages: []string{
@@ -198,12 +198,12 @@ var _ = Describe("Event Recording", func() {
 	Context("Resource Bounds Validation Events", func() {
 		It("should record event when CPU exceeds bounds", func() {
 			By("creating a workspace with CPU exceeding template max")
-			workspace := &workspacesv1alpha1.Workspace{
+			workspace := &workspacev1alpha1.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-cpu-exceeded",
 					Namespace: "default",
 				},
-				Spec: workspacesv1alpha1.WorkspaceSpec{
+				Spec: workspacev1alpha1.WorkspaceSpec{
 					DisplayName: "Test CPU Exceeded",
 					TemplateRef: stringPtr("bounded-template"),
 					Resources: &corev1.ResourceRequirements{
@@ -216,15 +216,15 @@ var _ = Describe("Event Recording", func() {
 			Expect(k8sClient.Create(ctx, workspace)).To(Succeed())
 
 			By("creating a template with CPU bounds")
-			template := &workspacesv1alpha1.WorkspaceTemplate{
+			template := &workspacev1alpha1.WorkspaceTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "bounded-template",
 				},
-				Spec: workspacesv1alpha1.WorkspaceTemplateSpec{
+				Spec: workspacev1alpha1.WorkspaceTemplateSpec{
 					DisplayName:  "Bounded Template",
 					DefaultImage: "test-image:latest",
-					ResourceBounds: &workspacesv1alpha1.ResourceBounds{
-						CPU: &workspacesv1alpha1.ResourceRange{
+					ResourceBounds: &workspacev1alpha1.ResourceBounds{
+						CPU: &workspacev1alpha1.ResourceRange{
 							Min: resource.MustParse("250m"),
 							Max: resource.MustParse("2"),
 						},

--- a/internal/controller/image_resolver.go
+++ b/internal/controller/image_resolver.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	workspacesv1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
+	workspacev1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
 )
 
 // ImageResolver handles the resolution of image references
@@ -27,7 +27,7 @@ func NewImageResolver(registry string) *ImageResolver {
 // - Built-in image shortcuts
 // - Default image when none is specified
 // - Adding registry prefix in production environments
-func (r *ImageResolver) ResolveImage(workspace *workspacesv1alpha1.Workspace) string {
+func (r *ImageResolver) ResolveImage(workspace *workspacev1alpha1.Workspace) string {
 	// Get image from server spec
 	image := workspace.Spec.Image
 

--- a/internal/controller/pod_event_handler.go
+++ b/internal/controller/pod_event_handler.go
@@ -8,7 +8,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	workspacesv1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
+	workspacev1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
 	awsutil "github.com/jupyter-ai-contrib/jupyter-k8s/internal/aws"
 )
 
@@ -101,7 +101,7 @@ func (h *PodEventHandler) handlePodRunning(ctx context.Context, pod *corev1.Pod,
 	logger.Info("Workspace pod is now running")
 
 	// Get the workspace
-	workspace := &workspacesv1alpha1.Workspace{}
+	workspace := &workspacev1alpha1.Workspace{}
 	err := h.client.Get(ctx, client.ObjectKey{
 		Name:      workspaceName,
 		Namespace: pod.Namespace,

--- a/internal/controller/pod_event_handler_test.go
+++ b/internal/controller/pod_event_handler_test.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	workspacesv1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
+	workspacev1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
 	awsutil "github.com/jupyter-ai-contrib/jupyter-k8s/internal/aws"
 )
 
@@ -101,7 +101,7 @@ func TestNewPodEventHandler_SSMStrategyFailure(t *testing.T) {
 
 func TestHandleWorkspacePodEvents_PodRunning_SSMSuccess(t *testing.T) {
 	// Create workspace object
-	workspace := &workspacesv1alpha1.Workspace{
+	workspace := &workspacev1alpha1.Workspace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-workspace",
 			Namespace: "test-namespace",
@@ -110,7 +110,7 @@ func TestHandleWorkspacePodEvents_PodRunning_SSMSuccess(t *testing.T) {
 
 	// Create scheme and add our types
 	scheme := runtime.NewScheme()
-	_ = workspacesv1alpha1.AddToScheme(scheme)
+	_ = workspacev1alpha1.AddToScheme(scheme)
 
 	// Create fake client with workspace
 	fakeClient := fake.NewClientBuilder().
@@ -183,7 +183,7 @@ func TestHandleWorkspacePodEvents_PodRunning_WorkspaceNotFound(t *testing.T) {
 
 func TestHandleWorkspacePodEvents_PodRunning_SSMStrategyNil(t *testing.T) {
 	// Create workspace object
-	workspace := &workspacesv1alpha1.Workspace{
+	workspace := &workspacev1alpha1.Workspace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-workspace",
 			Namespace: "test-namespace",
@@ -192,7 +192,7 @@ func TestHandleWorkspacePodEvents_PodRunning_SSMStrategyNil(t *testing.T) {
 
 	// Create scheme and add our types
 	scheme := runtime.NewScheme()
-	_ = workspacesv1alpha1.AddToScheme(scheme)
+	_ = workspacev1alpha1.AddToScheme(scheme)
 
 	// Create fake client with workspace
 	fakeClient := fake.NewClientBuilder().

--- a/internal/controller/pvc_builder.go
+++ b/internal/controller/pvc_builder.go
@@ -3,7 +3,7 @@ package controller
 import (
 	"fmt"
 
-	workspacesv1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
+	workspacev1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -32,7 +32,7 @@ type ResolvedStorageConfig struct {
 }
 
 // resolveStorageSize returns the storage size from workspace or template, with fallback to default
-func resolveStorageSize(workspace *workspacesv1alpha1.Workspace, template *ResolvedTemplate) resource.Quantity {
+func resolveStorageSize(workspace *workspacev1alpha1.Workspace, template *ResolvedTemplate) resource.Quantity {
 	if workspace.Spec.Storage != nil && !workspace.Spec.Storage.Size.IsZero() {
 		return workspace.Spec.Storage.Size
 	}
@@ -43,7 +43,7 @@ func resolveStorageSize(workspace *workspacesv1alpha1.Workspace, template *Resol
 }
 
 // resolveStorageClassName returns the storage class name from workspace or template
-func resolveStorageClassName(workspace *workspacesv1alpha1.Workspace, template *ResolvedTemplate) *string {
+func resolveStorageClassName(workspace *workspacev1alpha1.Workspace, template *ResolvedTemplate) *string {
 	if workspace.Spec.Storage != nil && workspace.Spec.Storage.StorageClassName != nil {
 		return workspace.Spec.Storage.StorageClassName
 	}
@@ -54,7 +54,7 @@ func resolveStorageClassName(workspace *workspacesv1alpha1.Workspace, template *
 }
 
 // resolveMountPath returns the mount path from workspace or template, with fallback to default
-func resolveMountPath(workspace *workspacesv1alpha1.Workspace, template *ResolvedTemplate) string {
+func resolveMountPath(workspace *workspacev1alpha1.Workspace, template *ResolvedTemplate) string {
 	if workspace.Spec.Storage != nil && workspace.Spec.Storage.MountPath != "" {
 		return workspace.Spec.Storage.MountPath
 	}
@@ -66,7 +66,7 @@ func resolveMountPath(workspace *workspacesv1alpha1.Workspace, template *Resolve
 
 // ResolveStorageConfig determines storage configuration from workspace or template
 // Returns nil if no storage is requested from either source
-func ResolveStorageConfig(workspace *workspacesv1alpha1.Workspace, resolvedTemplate *ResolvedTemplate) *ResolvedStorageConfig {
+func ResolveStorageConfig(workspace *workspacev1alpha1.Workspace, resolvedTemplate *ResolvedTemplate) *ResolvedStorageConfig {
 	// Check if storage is requested from either source
 	if (workspace.Spec.Storage == nil) && (resolvedTemplate == nil || resolvedTemplate.StorageConfiguration == nil) {
 		return nil
@@ -81,7 +81,7 @@ func ResolveStorageConfig(workspace *workspacesv1alpha1.Workspace, resolvedTempl
 
 // BuildPVC creates a PersistentVolumeClaim resource for the given Workspace
 // It uses workspace storage if specified, otherwise falls back to template storage configuration
-func (pb *PVCBuilder) BuildPVC(workspace *workspacesv1alpha1.Workspace, resolvedTemplate *ResolvedTemplate) (*corev1.PersistentVolumeClaim, error) {
+func (pb *PVCBuilder) BuildPVC(workspace *workspacev1alpha1.Workspace, resolvedTemplate *ResolvedTemplate) (*corev1.PersistentVolumeClaim, error) {
 	storageConfig := ResolveStorageConfig(workspace, resolvedTemplate)
 	if storageConfig == nil {
 		return nil, nil // No storage requested
@@ -101,7 +101,7 @@ func (pb *PVCBuilder) BuildPVC(workspace *workspacesv1alpha1.Workspace, resolved
 }
 
 // buildObjectMeta creates the metadata for the PVC
-func (pb *PVCBuilder) buildObjectMeta(workspace *workspacesv1alpha1.Workspace) metav1.ObjectMeta {
+func (pb *PVCBuilder) buildObjectMeta(workspace *workspacev1alpha1.Workspace) metav1.ObjectMeta {
 	return metav1.ObjectMeta{
 		Name:      GeneratePVCName(workspace.Name),
 		Namespace: workspace.Namespace,

--- a/internal/controller/pvc_builder_test.go
+++ b/internal/controller/pvc_builder_test.go
@@ -3,7 +3,7 @@ package controller
 import (
 	"testing"
 
-	workspacesv1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
+	workspacev1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -15,25 +15,25 @@ func TestPVCBuilder_BuildPVC(t *testing.T) {
 	// Register our types with the scheme
 	s := runtime.NewScheme()
 	_ = scheme.AddToScheme(s)
-	_ = workspacesv1alpha1.AddToScheme(s)
+	_ = workspacev1alpha1.AddToScheme(s)
 
 	builder := NewPVCBuilder(s)
 
 	t.Run("workspace with explicit storage should use workspace storage", func(t *testing.T) {
-		workspace := &workspacesv1alpha1.Workspace{
+		workspace := &workspacev1alpha1.Workspace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-workspace",
 				Namespace: "default",
 			},
-			Spec: workspacesv1alpha1.WorkspaceSpec{
-				Storage: &workspacesv1alpha1.StorageSpec{
+			Spec: workspacev1alpha1.WorkspaceSpec{
+				Storage: &workspacev1alpha1.StorageSpec{
 					Size: resource.MustParse("5Gi"),
 				},
 			},
 		}
 
 		template := &ResolvedTemplate{
-			StorageConfiguration: &workspacesv1alpha1.StorageConfig{
+			StorageConfiguration: &workspacev1alpha1.StorageConfig{
 				DefaultSize: resource.MustParse("50Gi"),
 			},
 		}
@@ -54,18 +54,18 @@ func TestPVCBuilder_BuildPVC(t *testing.T) {
 	})
 
 	t.Run("workspace without explicit storage should use template storage", func(t *testing.T) {
-		workspace := &workspacesv1alpha1.Workspace{
+		workspace := &workspacev1alpha1.Workspace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-workspace",
 				Namespace: "default",
 			},
-			Spec: workspacesv1alpha1.WorkspaceSpec{
+			Spec: workspacev1alpha1.WorkspaceSpec{
 				// No Storage field
 			},
 		}
 
 		template := &ResolvedTemplate{
-			StorageConfiguration: &workspacesv1alpha1.StorageConfig{
+			StorageConfiguration: &workspacev1alpha1.StorageConfig{
 				DefaultSize: resource.MustParse("50Gi"),
 			},
 		}
@@ -86,12 +86,12 @@ func TestPVCBuilder_BuildPVC(t *testing.T) {
 	})
 
 	t.Run("workspace without storage and no template should return nil", func(t *testing.T) {
-		workspace := &workspacesv1alpha1.Workspace{
+		workspace := &workspacev1alpha1.Workspace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-workspace",
 				Namespace: "default",
 			},
-			Spec: workspacesv1alpha1.WorkspaceSpec{
+			Spec: workspacev1alpha1.WorkspaceSpec{
 				// No Storage field
 			},
 		}
@@ -107,12 +107,12 @@ func TestPVCBuilder_BuildPVC(t *testing.T) {
 	})
 
 	t.Run("workspace without storage and template without storage should return nil", func(t *testing.T) {
-		workspace := &workspacesv1alpha1.Workspace{
+		workspace := &workspacev1alpha1.Workspace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-workspace",
 				Namespace: "default",
 			},
-			Spec: workspacesv1alpha1.WorkspaceSpec{
+			Spec: workspacev1alpha1.WorkspaceSpec{
 				// No Storage field
 			},
 		}
@@ -132,13 +132,13 @@ func TestPVCBuilder_BuildPVC(t *testing.T) {
 	})
 
 	t.Run("workspace with zero size should default to 10Gi", func(t *testing.T) {
-		workspace := &workspacesv1alpha1.Workspace{
+		workspace := &workspacev1alpha1.Workspace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-workspace",
 				Namespace: "default",
 			},
-			Spec: workspacesv1alpha1.WorkspaceSpec{
-				Storage: &workspacesv1alpha1.StorageSpec{
+			Spec: workspacev1alpha1.WorkspaceSpec{
+				Storage: &workspacev1alpha1.StorageSpec{
 					Size: resource.Quantity{}, // Zero value
 				},
 			},
@@ -161,13 +161,13 @@ func TestPVCBuilder_BuildPVC(t *testing.T) {
 
 	t.Run("workspace with storage class name should set storage class", func(t *testing.T) {
 		storageClassName := "fast-ssd"
-		workspace := &workspacesv1alpha1.Workspace{
+		workspace := &workspacev1alpha1.Workspace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-workspace",
 				Namespace: "default",
 			},
-			Spec: workspacesv1alpha1.WorkspaceSpec{
-				Storage: &workspacesv1alpha1.StorageSpec{
+			Spec: workspacev1alpha1.WorkspaceSpec{
+				Storage: &workspacev1alpha1.StorageSpec{
 					Size:             resource.MustParse("10Gi"),
 					StorageClassName: &storageClassName,
 				},
@@ -193,13 +193,13 @@ func TestPVCBuilder_BuildPVC(t *testing.T) {
 	})
 
 	t.Run("PVC should have correct metadata", func(t *testing.T) {
-		workspace := &workspacesv1alpha1.Workspace{
+		workspace := &workspacev1alpha1.Workspace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-workspace",
 				Namespace: "test-namespace",
 			},
-			Spec: workspacesv1alpha1.WorkspaceSpec{
-				Storage: &workspacesv1alpha1.StorageSpec{
+			Spec: workspacev1alpha1.WorkspaceSpec{
+				Storage: &workspacev1alpha1.StorageSpec{
 					Size: resource.MustParse("5Gi"),
 				},
 			},
@@ -234,14 +234,14 @@ func TestPVCBuilder_BuildPVC(t *testing.T) {
 	})
 
 	t.Run("PVC should have owner reference", func(t *testing.T) {
-		workspace := &workspacesv1alpha1.Workspace{
+		workspace := &workspacev1alpha1.Workspace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-workspace",
 				Namespace: "default",
 				UID:       "test-uid",
 			},
-			Spec: workspacesv1alpha1.WorkspaceSpec{
-				Storage: &workspacesv1alpha1.StorageSpec{
+			Spec: workspacev1alpha1.WorkspaceSpec{
+				Storage: &workspacev1alpha1.StorageSpec{
 					Size: resource.MustParse("5Gi"),
 				},
 			},

--- a/internal/controller/resource_manager.go
+++ b/internal/controller/resource_manager.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	workspacesv1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
+	workspacev1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -48,7 +48,7 @@ func NewResourceManager(
 }
 
 // GetDeployment retrieves the deployment for a Workspace
-func (rm *ResourceManager) getDeployment(ctx context.Context, workspace *workspacesv1alpha1.Workspace) (*appsv1.Deployment, error) {
+func (rm *ResourceManager) getDeployment(ctx context.Context, workspace *workspacev1alpha1.Workspace) (*appsv1.Deployment, error) {
 	deployment := &appsv1.Deployment{}
 	deploymentName := GenerateDeploymentName(workspace.Name)
 
@@ -61,7 +61,7 @@ func (rm *ResourceManager) getDeployment(ctx context.Context, workspace *workspa
 }
 
 // GetService retrieves the service for a Workspace
-func (rm *ResourceManager) getService(ctx context.Context, workspace *workspacesv1alpha1.Workspace) (*corev1.Service, error) {
+func (rm *ResourceManager) getService(ctx context.Context, workspace *workspacev1alpha1.Workspace) (*corev1.Service, error) {
 	service := &corev1.Service{}
 	serviceName := GenerateServiceName(workspace.Name)
 
@@ -74,7 +74,7 @@ func (rm *ResourceManager) getService(ctx context.Context, workspace *workspaces
 }
 
 // getPVC retrieves the PVC for a Workspace
-func (rm *ResourceManager) getPVC(ctx context.Context, workspace *workspacesv1alpha1.Workspace) (*corev1.PersistentVolumeClaim, error) {
+func (rm *ResourceManager) getPVC(ctx context.Context, workspace *workspacev1alpha1.Workspace) (*corev1.PersistentVolumeClaim, error) {
 	pvc := &corev1.PersistentVolumeClaim{}
 	pvcName := GeneratePVCName(workspace.Name)
 
@@ -87,7 +87,7 @@ func (rm *ResourceManager) getPVC(ctx context.Context, workspace *workspacesv1al
 }
 
 // CreateDeployment creates a new deployment for the Workspace
-func (rm *ResourceManager) createDeployment(ctx context.Context, workspace *workspacesv1alpha1.Workspace, resolvedTemplate *ResolvedTemplate) (*appsv1.Deployment, error) {
+func (rm *ResourceManager) createDeployment(ctx context.Context, workspace *workspacev1alpha1.Workspace, resolvedTemplate *ResolvedTemplate) (*appsv1.Deployment, error) {
 	logger := logf.FromContext(ctx)
 
 	deployment, err := rm.deploymentBuilder.BuildDeployment(ctx, workspace, resolvedTemplate)
@@ -118,7 +118,7 @@ func (rm *ResourceManager) createDeployment(ctx context.Context, workspace *work
 }
 
 // CreateService creates a new service for the Workspace
-func (rm *ResourceManager) createService(ctx context.Context, workspace *workspacesv1alpha1.Workspace) (*corev1.Service, error) {
+func (rm *ResourceManager) createService(ctx context.Context, workspace *workspacev1alpha1.Workspace) (*corev1.Service, error) {
 	logger := logf.FromContext(ctx)
 
 	service, err := rm.serviceBuilder.BuildService(workspace)
@@ -138,7 +138,7 @@ func (rm *ResourceManager) createService(ctx context.Context, workspace *workspa
 }
 
 // createPVC creates a new PVC for the Workspace
-func (rm *ResourceManager) createPVC(ctx context.Context, workspace *workspacesv1alpha1.Workspace, resolvedTemplate *ResolvedTemplate) (*corev1.PersistentVolumeClaim, error) {
+func (rm *ResourceManager) createPVC(ctx context.Context, workspace *workspacev1alpha1.Workspace, resolvedTemplate *ResolvedTemplate) (*corev1.PersistentVolumeClaim, error) {
 	logger := logf.FromContext(ctx)
 
 	pvc, err := rm.pvcBuilder.BuildPVC(workspace, resolvedTemplate)
@@ -246,7 +246,7 @@ func (rm *ResourceManager) IsServiceMissingOrDeleting(service *corev1.Service) b
 }
 
 // EnsureDeploymentExists creates a deployment if it doesn't exist
-func (rm *ResourceManager) EnsureDeploymentExists(ctx context.Context, workspace *workspacesv1alpha1.Workspace, resolvedTemplate *ResolvedTemplate) (*appsv1.Deployment, error) {
+func (rm *ResourceManager) EnsureDeploymentExists(ctx context.Context, workspace *workspacev1alpha1.Workspace, resolvedTemplate *ResolvedTemplate) (*appsv1.Deployment, error) {
 	deployment, err := rm.getDeployment(ctx, workspace)
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -258,7 +258,7 @@ func (rm *ResourceManager) EnsureDeploymentExists(ctx context.Context, workspace
 }
 
 // EnsureServiceExists creates a service if it doesn't exist
-func (rm *ResourceManager) EnsureServiceExists(ctx context.Context, workspace *workspacesv1alpha1.Workspace) (*corev1.Service, error) {
+func (rm *ResourceManager) EnsureServiceExists(ctx context.Context, workspace *workspacev1alpha1.Workspace) (*corev1.Service, error) {
 	service, err := rm.getService(ctx, workspace)
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -270,7 +270,7 @@ func (rm *ResourceManager) EnsureServiceExists(ctx context.Context, workspace *w
 }
 
 // EnsureDeploymentDeleted initiates deletion, or returns the deployment if it is already being deleted
-func (rm *ResourceManager) EnsureDeploymentDeleted(ctx context.Context, workspace *workspacesv1alpha1.Workspace) (*appsv1.Deployment, error) {
+func (rm *ResourceManager) EnsureDeploymentDeleted(ctx context.Context, workspace *workspacev1alpha1.Workspace) (*appsv1.Deployment, error) {
 	deployment, err := rm.getDeployment(ctx, workspace)
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -286,7 +286,7 @@ func (rm *ResourceManager) EnsureDeploymentDeleted(ctx context.Context, workspac
 }
 
 // EnsureServiceDeleted initiates deletion, or returns the service if it is already being deleted
-func (rm *ResourceManager) EnsureServiceDeleted(ctx context.Context, workspace *workspacesv1alpha1.Workspace) (*corev1.Service, error) {
+func (rm *ResourceManager) EnsureServiceDeleted(ctx context.Context, workspace *workspacev1alpha1.Workspace) (*corev1.Service, error) {
 	service, err := rm.getService(ctx, workspace)
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -302,7 +302,7 @@ func (rm *ResourceManager) EnsureServiceDeleted(ctx context.Context, workspace *
 
 // EnsurePVCExists creates a PVC if it doesn't exist
 // It uses workspace storage if specified, otherwise falls back to template storage configuration
-func (rm *ResourceManager) EnsurePVCExists(ctx context.Context, workspace *workspacesv1alpha1.Workspace, resolvedTemplate *ResolvedTemplate) (*corev1.PersistentVolumeClaim, error) {
+func (rm *ResourceManager) EnsurePVCExists(ctx context.Context, workspace *workspacev1alpha1.Workspace, resolvedTemplate *ResolvedTemplate) (*corev1.PersistentVolumeClaim, error) {
 	// Check if storage is needed from either workspace or template
 	hasStorage := workspace.Spec.Storage != nil ||
 		(resolvedTemplate != nil && resolvedTemplate.StorageConfiguration != nil)

--- a/internal/controller/service_builder.go
+++ b/internal/controller/service_builder.go
@@ -3,7 +3,7 @@ package controller
 import (
 	"fmt"
 
-	workspacesv1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
+	workspacev1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,7 +25,7 @@ func NewServiceBuilder(scheme *runtime.Scheme) *ServiceBuilder {
 }
 
 // BuildService creates a Service resource for the given Workspace
-func (sb *ServiceBuilder) BuildService(workspace *workspacesv1alpha1.Workspace) (*corev1.Service, error) {
+func (sb *ServiceBuilder) BuildService(workspace *workspacev1alpha1.Workspace) (*corev1.Service, error) {
 	service := &corev1.Service{
 		ObjectMeta: sb.buildObjectMeta(workspace),
 		Spec:       sb.buildServiceSpec(workspace),
@@ -40,7 +40,7 @@ func (sb *ServiceBuilder) BuildService(workspace *workspacesv1alpha1.Workspace) 
 }
 
 // buildObjectMeta creates the metadata for the Service
-func (sb *ServiceBuilder) buildObjectMeta(workspace *workspacesv1alpha1.Workspace) metav1.ObjectMeta {
+func (sb *ServiceBuilder) buildObjectMeta(workspace *workspacev1alpha1.Workspace) metav1.ObjectMeta {
 	return metav1.ObjectMeta{
 		Name:      GenerateServiceName(workspace.Name),
 		Namespace: workspace.Namespace,
@@ -49,7 +49,7 @@ func (sb *ServiceBuilder) buildObjectMeta(workspace *workspacesv1alpha1.Workspac
 }
 
 // buildServiceSpec creates the service specification
-func (sb *ServiceBuilder) buildServiceSpec(workspace *workspacesv1alpha1.Workspace) corev1.ServiceSpec {
+func (sb *ServiceBuilder) buildServiceSpec(workspace *workspacev1alpha1.Workspace) corev1.ServiceSpec {
 	return corev1.ServiceSpec{
 		Type:     corev1.ServiceTypeClusterIP,
 		Selector: GenerateLabels(workspace.Name),

--- a/internal/controller/state_machine.go
+++ b/internal/controller/state_machine.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	workspacesv1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
+	workspacev1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/record"
@@ -32,7 +32,7 @@ func NewStateMachine(resourceManager *ResourceManager, statusManager *StatusMana
 
 // ReconcileDesiredState handles the state machine logic for Workspace
 func (sm *StateMachine) ReconcileDesiredState(
-	ctx context.Context, workspace *workspacesv1alpha1.Workspace) (ctrl.Result, error) {
+	ctx context.Context, workspace *workspacev1alpha1.Workspace) (ctrl.Result, error) {
 	logger := logf.FromContext(ctx)
 
 	desiredStatus := sm.getDesiredStatus(workspace)
@@ -55,7 +55,7 @@ func (sm *StateMachine) ReconcileDesiredState(
 }
 
 // getDesiredStatus returns the desired status with default fallback
-func (sm *StateMachine) getDesiredStatus(workspace *workspacesv1alpha1.Workspace) string {
+func (sm *StateMachine) getDesiredStatus(workspace *workspacev1alpha1.Workspace) string {
 	if workspace.Spec.DesiredStatus == "" {
 		return DefaultDesiredStatus
 	}
@@ -64,8 +64,8 @@ func (sm *StateMachine) getDesiredStatus(workspace *workspacesv1alpha1.Workspace
 
 func (sm *StateMachine) reconcileDesiredStoppedStatus(
 	ctx context.Context,
-	workspace *workspacesv1alpha1.Workspace,
-	snapshotStatus *workspacesv1alpha1.WorkspaceStatus) (ctrl.Result, error) {
+	workspace *workspacev1alpha1.Workspace,
+	snapshotStatus *workspacev1alpha1.WorkspaceStatus) (ctrl.Result, error) {
 	logger := logf.FromContext(ctx)
 	logger.Info("Attempting to bring Workspace status to 'Stopped'")
 
@@ -172,8 +172,8 @@ func (sm *StateMachine) reconcileDesiredStoppedStatus(
 
 func (sm *StateMachine) reconcileDesiredRunningStatus(
 	ctx context.Context,
-	workspace *workspacesv1alpha1.Workspace,
-	snapshotStatus *workspacesv1alpha1.WorkspaceStatus) (ctrl.Result, error) {
+	workspace *workspacev1alpha1.Workspace,
+	snapshotStatus *workspacev1alpha1.WorkspaceStatus) (ctrl.Result, error) {
 	logger := logf.FromContext(ctx)
 	logger.Info("Attempting to bring Workspace status to 'Running'")
 
@@ -273,8 +273,8 @@ func (sm *StateMachine) reconcileDesiredRunningStatus(
 // On success, it returns the resolved template with shouldContinue=true.
 func (sm *StateMachine) handleTemplateValidation(
 	ctx context.Context,
-	workspace *workspacesv1alpha1.Workspace,
-	snapshotStatus *workspacesv1alpha1.WorkspaceStatus) (template *ResolvedTemplate, shouldContinue bool, err error) {
+	workspace *workspacev1alpha1.Workspace,
+	snapshotStatus *workspacev1alpha1.WorkspaceStatus) (template *ResolvedTemplate, shouldContinue bool, err error) {
 	logger := logf.FromContext(ctx)
 
 	// No template reference - continue with default configuration

--- a/internal/controller/state_machine_access.go
+++ b/internal/controller/state_machine_access.go
@@ -3,13 +3,13 @@ package controller
 import (
 	"context"
 
-	workspacesv1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
+	workspacev1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // ReconcileAccessForDesiredRunningStatus reconciles the access strategy for a Workspace whose desired state is Running
-func (sm *StateMachine) ReconcileAccessForDesiredRunningStatus(ctx context.Context, workspace *workspacesv1alpha1.Workspace, service *corev1.Service) error {
+func (sm *StateMachine) ReconcileAccessForDesiredRunningStatus(ctx context.Context, workspace *workspacev1alpha1.Workspace, service *corev1.Service) error {
 	logger := logf.FromContext(ctx)
 	accessStrategyRef := workspace.Spec.AccessStrategy
 
@@ -53,7 +53,7 @@ func (sm *StateMachine) ReconcileAccessForDesiredRunningStatus(ctx context.Conte
 }
 
 // ReconcileAccessForDesiredStoppedStatus reconciles the access strategy for a Workspace whose desired state is Stopped
-func (sm *StateMachine) ReconcileAccessForDesiredStoppedStatus(ctx context.Context, workspace *workspacesv1alpha1.Workspace) error {
+func (sm *StateMachine) ReconcileAccessForDesiredStoppedStatus(ctx context.Context, workspace *workspacev1alpha1.Workspace) error {
 	logger := logf.FromContext(ctx)
 
 	workspace.Status.AccessURL = ""

--- a/internal/controller/status_manager.go
+++ b/internal/controller/status_manager.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"reflect"
 
-	workspacesv1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
+	workspacev1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -26,9 +26,9 @@ func NewStatusManager(k8sClient client.Client) *StatusManager {
 
 func (sm *StatusManager) updateStatus(
 	ctx context.Context,
-	workspace *workspacesv1alpha1.Workspace,
+	workspace *workspacev1alpha1.Workspace,
 	conditionsToUpdate *[]metav1.Condition,
-	snapshotStatus *workspacesv1alpha1.WorkspaceStatus,
+	snapshotStatus *workspacev1alpha1.WorkspaceStatus,
 ) error {
 	logger := logf.FromContext(ctx)
 	if len(*conditionsToUpdate) > 0 {
@@ -59,9 +59,9 @@ type WorkspaceRunningReadiness struct {
 // UpdateStartingStatus sets Available to false and Progressing to true
 func (sm *StatusManager) UpdateStartingStatus(
 	ctx context.Context,
-	workspace *workspacesv1alpha1.Workspace,
+	workspace *workspacev1alpha1.Workspace,
 	readiness WorkspaceRunningReadiness,
-	snapshotStatus *workspacesv1alpha1.WorkspaceStatus,
+	snapshotStatus *workspacev1alpha1.WorkspaceStatus,
 ) error {
 	// default: nothing is started yet
 	startingReason := ReasonResourcesNotReady
@@ -141,10 +141,10 @@ func (sm *StatusManager) UpdateStartingStatus(
 // UpdateErrorStatus sets the Degraded condition to true with the specified error reason and message
 func (sm *StatusManager) UpdateErrorStatus(
 	ctx context.Context,
-	workspace *workspacesv1alpha1.Workspace,
+	workspace *workspacev1alpha1.Workspace,
 	reason string,
 	message string,
-	snapshotStatus *workspacesv1alpha1.WorkspaceStatus) error {
+	snapshotStatus *workspacev1alpha1.WorkspaceStatus) error {
 	// Set DegradedCondition to true with the provided error reason and message
 	degradedCondition := NewCondition(
 		ConditionTypeDegraded,
@@ -159,9 +159,9 @@ func (sm *StatusManager) UpdateErrorStatus(
 // SetInvalid sets the Valid condition to false when policy validation fails
 func (sm *StatusManager) SetInvalid(
 	ctx context.Context,
-	workspace *workspacesv1alpha1.Workspace,
+	workspace *workspacev1alpha1.Workspace,
 	validation *TemplateValidationResult,
-	snapshotStatus *workspacesv1alpha1.WorkspaceStatus) error {
+	snapshotStatus *workspacev1alpha1.WorkspaceStatus) error {
 	// Build violation message
 	message := fmt.Sprintf("Validation failed: %d violation(s)", len(validation.Violations))
 	if len(validation.Violations) > 0 {
@@ -217,8 +217,8 @@ func (sm *StatusManager) SetInvalid(
 // UpdateRunningStatus sets the Available condition to true and Progressing to false
 func (sm *StatusManager) UpdateRunningStatus(
 	ctx context.Context,
-	workspace *workspacesv1alpha1.Workspace,
-	snapshotStatus *workspacesv1alpha1.WorkspaceStatus) error {
+	workspace *workspacev1alpha1.Workspace,
+	snapshotStatus *workspacev1alpha1.WorkspaceStatus) error {
 	// ensure AvailableCondition is set to true with ReasonResourcesReady
 	availableCondition := NewCondition(
 		ConditionTypeAvailable,
@@ -282,9 +282,9 @@ type WorkspaceStoppingReadiness struct {
 // UpdateStoppingStatus sets Available to false and Progressing to true
 func (sm *StatusManager) UpdateStoppingStatus(
 	ctx context.Context,
-	workspace *workspacesv1alpha1.Workspace,
+	workspace *workspacev1alpha1.Workspace,
 	readiness WorkspaceStoppingReadiness,
-	snapshotStatus *workspacesv1alpha1.WorkspaceStatus) error {
+	snapshotStatus *workspacev1alpha1.WorkspaceStatus) error {
 	// default: nothing is stopped yet
 	stoppingReason := ReasonResourcesNotStopped
 	stoppingMessage := "Resources are still running"
@@ -365,8 +365,8 @@ func (sm *StatusManager) UpdateStoppingStatus(
 // UpdateStoppedStatus sets Available and Progressing to false, Stopped to true
 func (sm *StatusManager) UpdateStoppedStatus(
 	ctx context.Context,
-	workspace *workspacesv1alpha1.Workspace,
-	snapshotStatus *workspacesv1alpha1.WorkspaceStatus) error {
+	workspace *workspacev1alpha1.Workspace,
+	snapshotStatus *workspacev1alpha1.WorkspaceStatus) error {
 	// ensure AvailableCondition is set to false with ReasonDesiredStateStopped
 	availableCondition := NewCondition(
 		ConditionTypeAvailable,

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -32,7 +32,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	workspacesv1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
+	workspacev1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -59,7 +59,7 @@ var _ = BeforeSuite(func() {
 	ctx, cancel = context.WithCancel(context.TODO())
 
 	var err error
-	err = workspacesv1alpha1.AddToScheme(scheme.Scheme)
+	err = workspacev1alpha1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	// +kubebuilder:scaffold:scheme

--- a/internal/controller/template_validation_test.go
+++ b/internal/controller/template_validation_test.go
@@ -26,7 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	workspacesv1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
+	workspacev1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
 )
 
 var _ = Describe("Template Validation", func() {
@@ -35,7 +35,7 @@ var _ = Describe("Template Validation", func() {
 			ctx              context.Context
 			templateResolver *TemplateResolver
 			templateName     string
-			template         *workspacesv1alpha1.WorkspaceTemplate
+			template         *workspacev1alpha1.WorkspaceTemplate
 		)
 
 		BeforeEach(func() {
@@ -44,11 +44,11 @@ var _ = Describe("Template Validation", func() {
 			templateName = "validation-template"
 
 			// Create a comprehensive test template
-			template = &workspacesv1alpha1.WorkspaceTemplate{
+			template = &workspacev1alpha1.WorkspaceTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: templateName,
 				},
-				Spec: workspacesv1alpha1.WorkspaceTemplateSpec{
+				Spec: workspacev1alpha1.WorkspaceTemplateSpec{
 					DisplayName:  "Validation Test Template",
 					Description:  "Template for validation testing",
 					DefaultImage: "quay.io/jupyter/minimal-notebook:latest",
@@ -67,21 +67,21 @@ var _ = Describe("Template Validation", func() {
 							corev1.ResourceMemory: resource.MustParse("4Gi"),
 						},
 					},
-					ResourceBounds: &workspacesv1alpha1.ResourceBounds{
-						CPU: &workspacesv1alpha1.ResourceRange{
+					ResourceBounds: &workspacev1alpha1.ResourceBounds{
+						CPU: &workspacev1alpha1.ResourceRange{
 							Min: resource.MustParse("100m"),
 							Max: resource.MustParse("4"),
 						},
-						Memory: &workspacesv1alpha1.ResourceRange{
+						Memory: &workspacev1alpha1.ResourceRange{
 							Min: resource.MustParse("256Mi"),
 							Max: resource.MustParse("8Gi"),
 						},
-						GPU: &workspacesv1alpha1.ResourceRange{
+						GPU: &workspacev1alpha1.ResourceRange{
 							Min: resource.MustParse("0"),
 							Max: resource.MustParse("2"),
 						},
 					},
-					PrimaryStorage: &workspacesv1alpha1.StorageConfig{
+					PrimaryStorage: &workspacev1alpha1.StorageConfig{
 						DefaultSize: resource.MustParse("10Gi"),
 						MinSize:     &[]resource.Quantity{resource.MustParse("1Gi")}[0],
 						MaxSize:     &[]resource.Quantity{resource.MustParse("100Gi")}[0],
@@ -103,12 +103,12 @@ var _ = Describe("Template Validation", func() {
 		})
 
 		It("should validate workspace without template reference but with image", func() {
-			workspace := &workspacesv1alpha1.Workspace{
+			workspace := &workspacev1alpha1.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "no-template-workspace",
 					Namespace: "default",
 				},
-				Spec: workspacesv1alpha1.WorkspaceSpec{
+				Spec: workspacev1alpha1.WorkspaceSpec{
 					// No TemplateRef but has Image
 					Image: "my-registry.com/jupyter:v1.0",
 				},
@@ -122,12 +122,12 @@ var _ = Describe("Template Validation", func() {
 		})
 
 		It("should validate workspace with valid template reference", func() {
-			workspace := &workspacesv1alpha1.Workspace{
+			workspace := &workspacev1alpha1.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "valid-template-workspace",
 					Namespace: "default",
 				},
-				Spec: workspacesv1alpha1.WorkspaceSpec{
+				Spec: workspacev1alpha1.WorkspaceSpec{
 					TemplateRef: &templateName,
 				},
 			}
@@ -143,11 +143,11 @@ var _ = Describe("Template Validation", func() {
 		It("should handle template without DefaultResources", func() {
 			// Create a template without DefaultResources
 			minimalTemplateName := "minimal-template"
-			minimalTemplate := &workspacesv1alpha1.WorkspaceTemplate{
+			minimalTemplate := &workspacev1alpha1.WorkspaceTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: minimalTemplateName,
 				},
-				Spec: workspacesv1alpha1.WorkspaceTemplateSpec{
+				Spec: workspacev1alpha1.WorkspaceTemplateSpec{
 					DisplayName:  "Minimal Template",
 					Description:  "Template without default resources",
 					DefaultImage: "quay.io/jupyter/minimal-notebook:latest", // Required field
@@ -155,7 +155,7 @@ var _ = Describe("Template Validation", func() {
 					AllowedImages: []string{
 						"quay.io/jupyter/minimal-notebook:latest",
 					},
-					PrimaryStorage: &workspacesv1alpha1.StorageConfig{
+					PrimaryStorage: &workspacev1alpha1.StorageConfig{
 						DefaultSize: resource.MustParse("10Gi"),
 					},
 				},
@@ -165,12 +165,12 @@ var _ = Describe("Template Validation", func() {
 				Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, minimalTemplate))).To(Succeed())
 			}()
 
-			workspace := &workspacesv1alpha1.Workspace{
+			workspace := &workspacev1alpha1.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "minimal-template-workspace",
 					Namespace: "default",
 				},
-				Spec: workspacesv1alpha1.WorkspaceSpec{
+				Spec: workspacev1alpha1.WorkspaceSpec{
 					TemplateRef: &minimalTemplateName,
 				},
 			}
@@ -187,12 +187,12 @@ var _ = Describe("Template Validation", func() {
 
 		It("should return error for non-existent template", func() {
 			nonExistentTemplate := "non-existent-template"
-			workspace := &workspacesv1alpha1.Workspace{
+			workspace := &workspacev1alpha1.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "invalid-template-workspace",
 					Namespace: "default",
 				},
-				Spec: workspacesv1alpha1.WorkspaceSpec{
+				Spec: workspacev1alpha1.WorkspaceSpec{
 					TemplateRef: &nonExistentTemplate,
 				},
 			}
@@ -207,12 +207,12 @@ var _ = Describe("Template Validation", func() {
 
 		Context("Image Validation", func() {
 			It("should allow images in the allowed list", func() {
-				workspace := &workspacesv1alpha1.Workspace{
+				workspace := &workspacev1alpha1.Workspace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "allowed-image-workspace",
 						Namespace: "default",
 					},
-					Spec: workspacesv1alpha1.WorkspaceSpec{
+					Spec: workspacev1alpha1.WorkspaceSpec{
 						TemplateRef: &templateName,
 						Image:       "quay.io/jupyter/scipy-notebook:latest",
 					},
@@ -226,12 +226,12 @@ var _ = Describe("Template Validation", func() {
 			})
 
 			It("should reject images not in the allowed list", func() {
-				workspace := &workspacesv1alpha1.Workspace{
+				workspace := &workspacev1alpha1.Workspace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "disallowed-image-workspace",
 						Namespace: "default",
 					},
-					Spec: workspacesv1alpha1.WorkspaceSpec{
+					Spec: workspacev1alpha1.WorkspaceSpec{
 						TemplateRef: &templateName,
 						Image:       "malicious/image:latest",
 					},
@@ -248,12 +248,12 @@ var _ = Describe("Template Validation", func() {
 
 		Context("Resource Validation", func() {
 			It("should allow resources within bounds", func() {
-				workspace := &workspacesv1alpha1.Workspace{
+				workspace := &workspacev1alpha1.Workspace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "valid-resources-workspace",
 						Namespace: "default",
 					},
-					Spec: workspacesv1alpha1.WorkspaceSpec{
+					Spec: workspacev1alpha1.WorkspaceSpec{
 						TemplateRef: &templateName,
 						Resources: &corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
@@ -272,12 +272,12 @@ var _ = Describe("Template Validation", func() {
 			})
 
 			It("should reject CPU requests above maximum", func() {
-				workspace := &workspacesv1alpha1.Workspace{
+				workspace := &workspacev1alpha1.Workspace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "cpu-exceeded-workspace",
 						Namespace: "default",
 					},
-					Spec: workspacesv1alpha1.WorkspaceSpec{
+					Spec: workspacev1alpha1.WorkspaceSpec{
 						TemplateRef: &templateName,
 						Resources: &corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
@@ -296,12 +296,12 @@ var _ = Describe("Template Validation", func() {
 			})
 
 			It("should reject CPU requests below minimum", func() {
-				workspace := &workspacesv1alpha1.Workspace{
+				workspace := &workspacev1alpha1.Workspace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "cpu-below-min-workspace",
 						Namespace: "default",
 					},
-					Spec: workspacesv1alpha1.WorkspaceSpec{
+					Spec: workspacev1alpha1.WorkspaceSpec{
 						TemplateRef: &templateName,
 						Resources: &corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
@@ -320,12 +320,12 @@ var _ = Describe("Template Validation", func() {
 			})
 
 			It("should reject memory requests above maximum", func() {
-				workspace := &workspacesv1alpha1.Workspace{
+				workspace := &workspacev1alpha1.Workspace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "memory-exceeded-workspace",
 						Namespace: "default",
 					},
-					Spec: workspacesv1alpha1.WorkspaceSpec{
+					Spec: workspacev1alpha1.WorkspaceSpec{
 						TemplateRef: &templateName,
 						Resources: &corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
@@ -344,12 +344,12 @@ var _ = Describe("Template Validation", func() {
 			})
 
 			It("should validate GPU resources", func() {
-				workspace := &workspacesv1alpha1.Workspace{
+				workspace := &workspacev1alpha1.Workspace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "gpu-workspace",
 						Namespace: "default",
 					},
-					Spec: workspacesv1alpha1.WorkspaceSpec{
+					Spec: workspacev1alpha1.WorkspaceSpec{
 						TemplateRef: &templateName,
 						Resources: &corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
@@ -366,12 +366,12 @@ var _ = Describe("Template Validation", func() {
 			})
 
 			It("should reject GPU requests above maximum", func() {
-				workspace := &workspacesv1alpha1.Workspace{
+				workspace := &workspacev1alpha1.Workspace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "gpu-exceeded-workspace",
 						Namespace: "default",
 					},
-					Spec: workspacesv1alpha1.WorkspaceSpec{
+					Spec: workspacev1alpha1.WorkspaceSpec{
 						TemplateRef: &templateName,
 						Resources: &corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
@@ -392,14 +392,14 @@ var _ = Describe("Template Validation", func() {
 
 		Context("Storage Validation", func() {
 			It("should allow storage size within bounds", func() {
-				workspace := &workspacesv1alpha1.Workspace{
+				workspace := &workspacev1alpha1.Workspace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "valid-storage-workspace",
 						Namespace: "default",
 					},
-					Spec: workspacesv1alpha1.WorkspaceSpec{
+					Spec: workspacev1alpha1.WorkspaceSpec{
 						TemplateRef: &templateName,
-						Storage: &workspacesv1alpha1.StorageSpec{
+						Storage: &workspacev1alpha1.StorageSpec{
 							Size: resource.MustParse("50Gi"),
 						},
 					},
@@ -413,14 +413,14 @@ var _ = Describe("Template Validation", func() {
 			})
 
 			It("should reject storage size above maximum", func() {
-				workspace := &workspacesv1alpha1.Workspace{
+				workspace := &workspacev1alpha1.Workspace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "storage-exceeded-workspace",
 						Namespace: "default",
 					},
-					Spec: workspacesv1alpha1.WorkspaceSpec{
+					Spec: workspacev1alpha1.WorkspaceSpec{
 						TemplateRef: &templateName,
-						Storage: &workspacesv1alpha1.StorageSpec{
+						Storage: &workspacev1alpha1.StorageSpec{
 							Size: resource.MustParse("200Gi"), // Exceeds max of 100Gi
 						},
 					},
@@ -435,14 +435,14 @@ var _ = Describe("Template Validation", func() {
 			})
 
 			It("should reject storage size below minimum", func() {
-				workspace := &workspacesv1alpha1.Workspace{
+				workspace := &workspacev1alpha1.Workspace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "storage-below-min-workspace",
 						Namespace: "default",
 					},
-					Spec: workspacesv1alpha1.WorkspaceSpec{
+					Spec: workspacev1alpha1.WorkspaceSpec{
 						TemplateRef: &templateName,
-						Storage: &workspacesv1alpha1.StorageSpec{
+						Storage: &workspacev1alpha1.StorageSpec{
 							Size: resource.MustParse("500Mi"), // Below min of 1Gi
 						},
 					},
@@ -460,14 +460,14 @@ var _ = Describe("Template Validation", func() {
 				// Note: This test now relies on CRD validation rejecting invalid quantities at API level
 				// resource.Quantity type in Go automatically validates format
 				// Keeping test structure for documentation, but it would fail at creation time
-				workspace := &workspacesv1alpha1.Workspace{
+				workspace := &workspacev1alpha1.Workspace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "invalid-storage-format-workspace",
 						Namespace: "default",
 					},
-					Spec: workspacesv1alpha1.WorkspaceSpec{
+					Spec: workspacev1alpha1.WorkspaceSpec{
 						TemplateRef: &templateName,
-						Storage: &workspacesv1alpha1.StorageSpec{
+						Storage: &workspacev1alpha1.StorageSpec{
 							Size: resource.MustParse("1Gi"), // Valid size for test (invalid would fail parse)
 						},
 					},
@@ -481,12 +481,12 @@ var _ = Describe("Template Validation", func() {
 
 		Context("Multiple Violations", func() {
 			It("should collect all validation failures", func() {
-				workspace := &workspacesv1alpha1.Workspace{
+				workspace := &workspacev1alpha1.Workspace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "multiple-violations-workspace",
 						Namespace: "default",
 					},
-					Spec: workspacesv1alpha1.WorkspaceSpec{
+					Spec: workspacev1alpha1.WorkspaceSpec{
 						TemplateRef: &templateName,
 						Image:       "forbidden/image:latest",
 						Resources: &corev1.ResourceRequirements{
@@ -495,7 +495,7 @@ var _ = Describe("Template Validation", func() {
 								corev1.ResourceMemory: resource.MustParse("50Mi"), // Below min
 							},
 						},
-						Storage: &workspacesv1alpha1.StorageSpec{
+						Storage: &workspacev1alpha1.StorageSpec{
 							Size: resource.MustParse("200Gi"), // Exceeds max
 						},
 					},
@@ -518,12 +518,12 @@ var _ = Describe("Template Validation", func() {
 
 		Context("Template Resolution", func() {
 			It("should properly resolve all template fields", func() {
-				workspace := &workspacesv1alpha1.Workspace{
+				workspace := &workspacev1alpha1.Workspace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "full-resolution-workspace",
 						Namespace: "default",
 					},
-					Spec: workspacesv1alpha1.WorkspaceSpec{
+					Spec: workspacev1alpha1.WorkspaceSpec{
 						TemplateRef: &templateName,
 					},
 				}
@@ -543,12 +543,12 @@ var _ = Describe("Template Validation", func() {
 			})
 
 			It("should handle AllowSecondaryStorages field from template", func() {
-				workspace := &workspacesv1alpha1.Workspace{
+				workspace := &workspacev1alpha1.Workspace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "secondary-storage-workspace",
 						Namespace: "default",
 					},
-					Spec: workspacesv1alpha1.WorkspaceSpec{
+					Spec: workspacev1alpha1.WorkspaceSpec{
 						TemplateRef: &templateName,
 					},
 				}
@@ -563,11 +563,11 @@ var _ = Describe("Template Validation", func() {
 			It("should handle template with AllowSecondaryStorages set to false", func() {
 				// Create a template with AllowSecondaryStorages disabled
 				restrictedTemplateName := "restricted-template"
-				restrictedTemplate := &workspacesv1alpha1.WorkspaceTemplate{
+				restrictedTemplate := &workspacev1alpha1.WorkspaceTemplate{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: restrictedTemplateName,
 					},
-					Spec: workspacesv1alpha1.WorkspaceTemplateSpec{
+					Spec: workspacev1alpha1.WorkspaceTemplateSpec{
 						DisplayName:            "Restricted Template",
 						DefaultImage:           "quay.io/jupyter/minimal-notebook:latest", // Required field
 						AllowSecondaryStorages: &[]bool{false}[0],
@@ -578,12 +578,12 @@ var _ = Describe("Template Validation", func() {
 					Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, restrictedTemplate))).To(Succeed())
 				}()
 
-				workspace := &workspacesv1alpha1.Workspace{
+				workspace := &workspacev1alpha1.Workspace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "restricted-workspace",
 						Namespace: "default",
 					},
-					Spec: workspacesv1alpha1.WorkspaceSpec{
+					Spec: workspacev1alpha1.WorkspaceSpec{
 						TemplateRef: &restrictedTemplateName,
 					},
 				}
@@ -598,11 +598,11 @@ var _ = Describe("Template Validation", func() {
 
 		Context("Image Requirement Enforcement", func() {
 			It("should reject template with empty DefaultImage at CRD level", func() {
-				emptyImageTemplate := &workspacesv1alpha1.WorkspaceTemplate{
+				emptyImageTemplate := &workspacev1alpha1.WorkspaceTemplate{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "empty-image-template",
 					},
-					Spec: workspacesv1alpha1.WorkspaceTemplateSpec{
+					Spec: workspacev1alpha1.WorkspaceTemplateSpec{
 						DisplayName:  "Empty Image Template",
 						DefaultImage: "", // Intentionally empty
 					},
@@ -615,12 +615,12 @@ var _ = Describe("Template Validation", func() {
 			})
 
 			It("should reject workspace without template and without image", func() {
-				workspace := &workspacesv1alpha1.Workspace{
+				workspace := &workspacev1alpha1.Workspace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "no-template-no-image-workspace",
 						Namespace: "default",
 					},
-					Spec: workspacesv1alpha1.WorkspaceSpec{
+					Spec: workspacev1alpha1.WorkspaceSpec{
 						// No TemplateRef and no Image
 					},
 				}

--- a/internal/controller/workspace_controller.go
+++ b/internal/controller/workspace_controller.go
@@ -19,7 +19,7 @@ package controller
 import (
 	"context"
 
-	workspacesv1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
+	workspacev1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -75,7 +75,7 @@ func (r *WorkspaceReconciler) SetStateMachine(sm *StateMachine) {
 	r.stateMachine = sm
 }
 
-// +kubebuilder:rbac:groups=workspaces.jupyter.org,resources=*,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=workspace.jupyter.org,resources=*,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
@@ -114,7 +114,7 @@ func (r *WorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		if workspace.Labels == nil {
 			workspace.Labels = make(map[string]string)
 		}
-		expectedLabel := "workspaces.jupyter.org/template"
+		expectedLabel := "workspace.jupyter.org/template"
 		if workspace.Labels[expectedLabel] != *workspace.Spec.TemplateRef {
 			logger.Info("Adding template label to workspace", "template", *workspace.Spec.TemplateRef)
 			workspace.Labels[expectedLabel] = *workspace.Spec.TemplateRef
@@ -141,7 +141,7 @@ func (r *WorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 // SetupWithManager sets up the controller with the Manager.
 func (r *WorkspaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	builder := ctrl.NewControllerManagedBy(mgr).
-		For(&workspacesv1alpha1.Workspace{}).
+		For(&workspacev1alpha1.Workspace{}).
 		Named("workspace").
 		// Watch for standard Kubernetes resources
 		Owns(&appsv1.Deployment{}).
@@ -235,8 +235,8 @@ func SetupWorkspaceController(mgr mngr.Manager, options WorkspaceControllerOptio
 }
 
 // getWorkspace retrieves the Workspace resource
-func (r *WorkspaceReconciler) getWorkspace(ctx context.Context, req ctrl.Request) (*workspacesv1alpha1.Workspace, error) {
-	workspace := &workspacesv1alpha1.Workspace{}
+func (r *WorkspaceReconciler) getWorkspace(ctx context.Context, req ctrl.Request) (*workspacev1alpha1.Workspace, error) {
+	workspace := &workspacev1alpha1.Workspace{}
 	err := r.Get(ctx, req.NamespacedName, workspace)
 	return workspace, err
 }

--- a/internal/controller/workspace_controller_test.go
+++ b/internal/controller/workspace_controller_test.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	workspacesv1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
+	workspacev1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -40,13 +40,13 @@ var _ = Describe("Workspace Controller", func() {
 			Name:      resourceName,
 			Namespace: "default", // TODO(user):Modify as needed
 		}
-		workspace := &workspacesv1alpha1.Workspace{}
+		workspace := &workspacev1alpha1.Workspace{}
 
 		BeforeEach(func() {
 			By("creating the custom resource for the Kind Workspace")
 			err := k8sClient.Get(ctx, typeNamespacedName, workspace)
 			if err != nil && errors.IsNotFound(err) {
-				resource := &workspacesv1alpha1.Workspace{
+				resource := &workspacev1alpha1.Workspace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      resourceName,
 						Namespace: "default",
@@ -59,7 +59,7 @@ var _ = Describe("Workspace Controller", func() {
 
 		AfterEach(func() {
 			// TODO(user): Cleanup logic after each test, like removing the resource instance.
-			resource := &workspacesv1alpha1.Workspace{}
+			resource := &workspacev1alpha1.Workspace{}
 			err := k8sClient.Get(ctx, typeNamespacedName, resource)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/internal/extensionapi/subject_access_review.go
+++ b/internal/extensionapi/subject_access_review.go
@@ -33,7 +33,7 @@ func (s *ExtensionServer) CheckRBACPermission(
 			ResourceAttributes: &authorizationv1.ResourceAttributes{
 				Namespace: namespace,
 				Verb:      "create",
-				Group:     "workspaces.jupyter.org",
+				Group:     "workspace.jupyter.org",
 				Resource:  "workspaces/connection",
 			},
 			User:   username,

--- a/internal/extensionapi/workspace_admission.go
+++ b/internal/extensionapi/workspace_admission.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"fmt"
 
-	workspacesv1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
+	workspacev1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -23,7 +23,7 @@ const (
 	DefaultAccessType = AccessTypePrivate
 
 	// OwnerAnnotation is the annotation key for workspace owner
-	OwnerAnnotation = "workspaces.jupyter.org/created-by"
+	OwnerAnnotation = "workspace.jupyter.org/created-by"
 )
 
 // WorkspaceAdmissionResult contains the result of a workspace access check
@@ -47,7 +47,7 @@ func (s *ExtensionServer) CheckWorkspaceAccess(
 	k8sClient := s.k8sClient
 
 	// Get the workspace
-	var workspace workspacesv1alpha1.Workspace
+	var workspace workspacev1alpha1.Workspace
 	if err := k8sClient.Get(
 		context.Background(),
 		client.ObjectKey{Namespace: namespace, Name: workspaceName},
@@ -110,7 +110,7 @@ func (s *ExtensionServer) CheckWorkspaceAccess(
 }
 
 // getWorkspaceAccessType determines the ownership type of a workspace
-func getWorkspaceAccessType(workspace *workspacesv1alpha1.Workspace) string {
+func getWorkspaceAccessType(workspace *workspacev1alpha1.Workspace) string {
 	if workspace != nil {
 		accessType := workspace.Spec.OwnershipType
 		if accessType == "" {
@@ -128,7 +128,7 @@ func getWorkspaceAccessType(workspace *workspacesv1alpha1.Workspace) string {
 }
 
 // getWorkspaceOwner gets the username of the workspace owner
-func getWorkspaceOwner(workspace *workspacesv1alpha1.Workspace) string {
+func getWorkspaceOwner(workspace *workspacev1alpha1.Workspace) string {
 	// Look for owner annotation
 	if workspace.Annotations != nil {
 		if owner, exists := workspace.Annotations[OwnerAnnotation]; exists && owner != "" {

--- a/internal/webhook/v1alpha1/webhook_suite_test.go
+++ b/internal/webhook/v1alpha1/webhook_suite_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v1alpha1 contains webhook implementations for workspaces.jupyter.org/v1alpha1 resources.
+// Package v1alpha1 contains webhook implementations for workspace.jupyter.org/v1alpha1 resources.
 package v1alpha1
 
 import (
@@ -40,7 +40,7 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
-	workspacesv1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
+	workspacev1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -67,7 +67,7 @@ var _ = BeforeSuite(func() {
 	ctx, cancel = context.WithCancel(context.TODO())
 
 	var err error
-	err = workspacesv1alpha1.AddToScheme(scheme.Scheme)
+	err = workspacev1alpha1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	// +kubebuilder:scaffold:scheme

--- a/internal/webhook/v1alpha1/workspace_webhook.go
+++ b/internal/webhook/v1alpha1/workspace_webhook.go
@@ -28,7 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	workspacesv1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
+	workspacev1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
 	"github.com/jupyter-ai-contrib/jupyter-k8s/internal/controller"
 	webhookconst "github.com/jupyter-ai-contrib/jupyter-k8s/internal/webhook"
 )
@@ -70,7 +70,7 @@ func isAdminUser(groups []string) bool {
 }
 
 // validateOwnershipPermission checks if the user has permission to modify/delete an OwnerOnly workspace
-func validateOwnershipPermission(ctx context.Context, workspace *workspacesv1alpha1.Workspace) error {
+func validateOwnershipPermission(ctx context.Context, workspace *workspacev1alpha1.Workspace) error {
 	req, err := admission.RequestFromContext(ctx)
 	if err != nil {
 		return fmt.Errorf("unable to extract user information from request context: %w", err)
@@ -101,13 +101,13 @@ func validateOwnershipPermission(ctx context.Context, workspace *workspacesv1alp
 
 // SetupWorkspaceWebhookWithManager registers the webhook for Workspace in the manager.
 func SetupWorkspaceWebhookWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewWebhookManagedBy(mgr).For(&workspacesv1alpha1.Workspace{}).
+	return ctrl.NewWebhookManagedBy(mgr).For(&workspacev1alpha1.Workspace{}).
 		WithValidator(&WorkspaceCustomValidator{}).
 		WithDefaulter(&WorkspaceCustomDefaulter{}).
 		Complete()
 }
 
-// +kubebuilder:webhook:path=/mutate-workspaces-jupyter-org-v1alpha1-workspace,mutating=true,failurePolicy=fail,sideEffects=None,groups=workspaces.jupyter.org,resources=workspaces,verbs=create;update,versions=v1alpha1,name=mworkspace-v1alpha1.kb.io,admissionReviewVersions=v1,serviceName=jupyter-k8s-controller-manager,servicePort=9443
+// +kubebuilder:webhook:path=/mutate-workspace-jupyter-org-v1alpha1-workspace,mutating=true,failurePolicy=fail,sideEffects=None,groups=workspace.jupyter.org,resources=workspaces,verbs=create;update,versions=v1alpha1,name=mworkspace-v1alpha1.kb.io,admissionReviewVersions=v1,serviceName=jupyter-k8s-controller-manager,servicePort=9443
 
 // WorkspaceCustomDefaulter struct is responsible for setting default values on the custom resource of the
 // Kind Workspace when those are created or updated.
@@ -122,7 +122,7 @@ var _ webhook.CustomDefaulter = &WorkspaceCustomDefaulter{}
 
 // Default implements webhook.CustomDefaulter so a webhook will be registered for the Kind Workspace.
 func (d *WorkspaceCustomDefaulter) Default(ctx context.Context, obj runtime.Object) error {
-	workspace, ok := obj.(*workspacesv1alpha1.Workspace)
+	workspace, ok := obj.(*workspacev1alpha1.Workspace)
 
 	if !ok {
 		return fmt.Errorf("expected an Workspace object but got %T", obj)
@@ -155,7 +155,7 @@ func (d *WorkspaceCustomDefaulter) Default(ctx context.Context, obj runtime.Obje
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
 // NOTE: The 'path' attribute must follow a specific pattern and should not be modified directly here.
 // Modifying the path for an invalid path can cause API server errors; failing to locate the webhook.
-// +kubebuilder:webhook:path=/validate-workspaces-jupyter-org-v1alpha1-workspace,mutating=false,failurePolicy=fail,sideEffects=None,groups=workspaces.jupyter.org,resources=workspaces,verbs=create;update;delete,versions=v1alpha1,name=vworkspace-v1alpha1.kb.io,admissionReviewVersions=v1,serviceName=jupyter-k8s-controller-manager,servicePort=9443
+// +kubebuilder:webhook:path=/validate-workspace-jupyter-org-v1alpha1-workspace,mutating=false,failurePolicy=fail,sideEffects=None,groups=workspace.jupyter.org,resources=workspaces,verbs=create;update;delete,versions=v1alpha1,name=vworkspace-v1alpha1.kb.io,admissionReviewVersions=v1,serviceName=jupyter-k8s-controller-manager,servicePort=9443
 
 // WorkspaceCustomValidator struct is responsible for validating the Workspace resource
 // when it is created, updated, or deleted.
@@ -170,7 +170,7 @@ var _ webhook.CustomValidator = &WorkspaceCustomValidator{}
 
 // ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type Workspace.
 func (v *WorkspaceCustomValidator) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
-	workspace, ok := obj.(*workspacesv1alpha1.Workspace)
+	workspace, ok := obj.(*workspacev1alpha1.Workspace)
 	if !ok {
 		return nil, fmt.Errorf("expected a Workspace object but got %T", obj)
 	}
@@ -183,11 +183,11 @@ func (v *WorkspaceCustomValidator) ValidateCreate(_ context.Context, obj runtime
 
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type Workspace.
 func (v *WorkspaceCustomValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
-	oldWorkspace, ok := oldObj.(*workspacesv1alpha1.Workspace)
+	oldWorkspace, ok := oldObj.(*workspacev1alpha1.Workspace)
 	if !ok {
 		return nil, fmt.Errorf("expected a Workspace object for the oldObj but got %T", oldObj)
 	}
-	newWorkspace, ok := newObj.(*workspacesv1alpha1.Workspace)
+	newWorkspace, ok := newObj.(*workspacev1alpha1.Workspace)
 	if !ok {
 		return nil, fmt.Errorf("expected a Workspace object for the newObj but got %T", newObj)
 	}
@@ -236,7 +236,7 @@ func (v *WorkspaceCustomValidator) ValidateUpdate(ctx context.Context, oldObj, n
 
 // ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type Workspace.
 func (v *WorkspaceCustomValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
-	workspace, ok := obj.(*workspacesv1alpha1.Workspace)
+	workspace, ok := obj.(*workspacev1alpha1.Workspace)
 	if !ok {
 		return nil, fmt.Errorf("expected a Workspace object but got %T", obj)
 	}

--- a/internal/webhook/v1alpha1/workspace_webhook_test.go
+++ b/internal/webhook/v1alpha1/workspace_webhook_test.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	workspacesv1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
+	workspacev1alpha1 "github.com/jupyter-ai-contrib/jupyter-k8s/api/v1alpha1"
 	"github.com/jupyter-ai-contrib/jupyter-k8s/internal/controller"
 	webhookconst "github.com/jupyter-ai-contrib/jupyter-k8s/internal/webhook"
 )
@@ -42,19 +42,19 @@ func createUserContext(baseCtx context.Context, operation, username string, grou
 
 var _ = Describe("Workspace Webhook", func() {
 	var (
-		workspace *workspacesv1alpha1.Workspace
+		workspace *workspacev1alpha1.Workspace
 		defaulter WorkspaceCustomDefaulter
 		validator WorkspaceCustomValidator
 		ctx       context.Context
 	)
 
 	BeforeEach(func() {
-		workspace = &workspacesv1alpha1.Workspace{
+		workspace = &workspacev1alpha1.Workspace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-workspace",
 				Namespace: "default",
 			},
-			Spec: workspacesv1alpha1.WorkspaceSpec{
+			Spec: workspacev1alpha1.WorkspaceSpec{
 				DisplayName:   "Test Workspace",
 				Image:         "jupyter/base-notebook:latest",
 				DesiredStatus: "Running",
@@ -430,7 +430,7 @@ var _ = Describe("Workspace Webhook", func() {
 	})
 
 	Context("validateOwnershipPermission", func() {
-		var ownerOnlyWorkspace *workspacesv1alpha1.Workspace
+		var ownerOnlyWorkspace *workspacev1alpha1.Workspace
 
 		BeforeEach(func() {
 			ownerOnlyWorkspace = workspace.DeepCopy()

--- a/test/e2e/webhook_owner_test.go
+++ b/test/e2e/webhook_owner_test.go
@@ -78,13 +78,13 @@ var _ = Describe("Webhook Owner", Ordered, func() {
 	Context("Ownership Annotation", func() {
 		It("should add created-by annotation to new workspace", func() {
 			By("creating a workspace")
-			cmd := exec.Command("kubectl", "apply", "-f", "config/samples/workspaces_v1alpha1_workspace.yaml")
+			cmd := exec.Command("kubectl", "apply", "-f", "config/samples/workspace_v1alpha1_workspace.yaml")
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("verifying created-by annotation exists")
 			cmd = exec.Command("kubectl", "get", "workspace", "workspace-sample",
-				"-o", "jsonpath={.metadata.annotations.workspaces\\.jupyter\\.org/created-by}")
+				"-o", "jsonpath={.metadata.annotations.workspace\\.jupyter\\.org/created-by}")
 			output, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 			annotation := strings.TrimSpace(string(output))
@@ -97,7 +97,7 @@ var _ = Describe("Webhook Owner", Ordered, func() {
 
 		It("should preserve existing annotations when adding created-by", func() {
 			By("creating workspace with existing annotation")
-			workspaceYAML := `apiVersion: workspaces.jupyter.org/v1alpha1
+			workspaceYAML := `apiVersion: workspace.jupyter.org/v1alpha1
 kind: Workspace
 metadata:
   name: workspace-with-annotations

--- a/test/e2e/workspace_scheduling_test.go
+++ b/test/e2e/workspace_scheduling_test.go
@@ -73,7 +73,7 @@ var _ = XDescribe("Workspace Scheduling", Ordered, func() {
 	Context("Node Affinity", func() {
 		It("should create workspace with node affinity and apply it to deployment", func() {
 			By("creating workspace with node affinity")
-			workspaceYaml := `apiVersion: workspaces.jupyter.org/v1alpha1
+			workspaceYaml := `apiVersion: workspace.jupyter.org/v1alpha1
 kind: Workspace
 metadata:
   name: workspace-with-affinity
@@ -108,7 +108,7 @@ spec:
 	Context("Tolerations", func() {
 		It("should create workspace with tolerations and apply them to deployment", func() {
 			By("creating workspace with tolerations")
-			workspaceYaml := `apiVersion: workspaces.jupyter.org/v1alpha1
+			workspaceYaml := `apiVersion: workspace.jupyter.org/v1alpha1
 kind: Workspace
 metadata:
   name: workspace-with-tolerations
@@ -139,7 +139,7 @@ spec:
 	Context("Node Selector", func() {
 		It("should create workspace with node selector and apply it to deployment", func() {
 			By("creating workspace with node selector")
-			workspaceYaml := `apiVersion: workspaces.jupyter.org/v1alpha1
+			workspaceYaml := `apiVersion: workspace.jupyter.org/v1alpha1
 kind: Workspace
 metadata:
   name: workspace-with-node-selector

--- a/test/e2e/workspacetemplate_test.go
+++ b/test/e2e/workspacetemplate_test.go
@@ -87,7 +87,7 @@ var _ = Describe("WorkspaceTemplate", Ordered, func() {
 			g.Expect(caBundle).NotTo(BeEmpty(), "webhook CA bundle should be injected by cert-manager")
 
 			// Verify webhook endpoint is reachable by attempting a dry-run resource creation
-			testWorkspaceYaml := `apiVersion: workspaces.jupyter.org/v1alpha1
+			testWorkspaceYaml := `apiVersion: workspace.jupyter.org/v1alpha1
 kind: Workspace
 metadata:
   name: webhook-readiness-test
@@ -103,7 +103,7 @@ spec:
 		By("installing WorkspaceTemplate samples")
 		_, _ = fmt.Fprintf(GinkgoWriter, "Applying production template...\n")
 		cmd = exec.Command("kubectl", "apply", "-f",
-			"config/samples/workspaces_v1alpha1_workspacetemplate_production.yaml")
+			"config/samples/workspace_v1alpha1_workspacetemplate_production.yaml")
 		_, err = utils.Run(cmd)
 		Expect(err).NotTo(HaveOccurred(), "Failed to create production template")
 
@@ -150,7 +150,7 @@ spec:
 	var deleteAllWorkspacesUsingTemplate = func(templateName string) {
 		By("deleting all workspaces using template: " + templateName)
 		cmd := exec.Command("kubectl", "get", "workspace",
-			"-l", "workspaces.jupyter.org/template="+templateName,
+			"-l", "workspace.jupyter.org/template="+templateName,
 			"-o", "jsonpath={.items[*].metadata.name}")
 		output, err := utils.Run(cmd)
 		if err != nil || strings.TrimSpace(output) == "" {
@@ -194,7 +194,7 @@ spec:
 
 			By("applying workspace with template reference")
 			cmd := exec.Command("kubectl", "apply", "-f",
-				"config/samples/workspaces_v1alpha1_workspace_with_template.yaml")
+				"config/samples/workspace_v1alpha1_workspace_with_template.yaml")
 			_, err = utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -283,7 +283,7 @@ spec:
 
 			By("verifying NO pod was created for rejected workspace")
 			cmd = exec.Command("kubectl", "get", "pods", "-l",
-				"workspace.workspaces.jupyter.org/name=test-rejected-workspace",
+				"workspace.workspace.jupyter.org/name=test-rejected-workspace",
 				"-o", "jsonpath={.items}")
 			output, err = utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
@@ -295,7 +295,7 @@ spec:
 			var err error
 
 			By("creating workspace with CPU exceeding template max")
-			workspaceYaml := `apiVersion: workspaces.jupyter.org/v1alpha1
+			workspaceYaml := `apiVersion: workspace.jupyter.org/v1alpha1
 kind: Workspace
 metadata:
   name: cpu-exceed-test
@@ -334,7 +334,7 @@ spec:
 
 			By("verifying NO pod was created")
 			cmd = exec.Command("kubectl", "get", "pods", "-l",
-				"workspace.workspaces.jupyter.org/name=cpu-exceed-test",
+				"workspace.workspace.jupyter.org/name=cpu-exceed-test",
 				"-o", "jsonpath={.items}")
 			output, err = utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
@@ -346,7 +346,7 @@ spec:
 			var err error
 
 			By("creating workspace with valid resource overrides")
-			workspaceYaml := `apiVersion: workspaces.jupyter.org/v1alpha1
+			workspaceYaml := `apiVersion: workspace.jupyter.org/v1alpha1
 kind: Workspace
 metadata:
   name: valid-overrides-test
@@ -397,7 +397,7 @@ spec:
 			var err error
 
 			By("creating a workspace using production template")
-			workspaceYaml := `apiVersion: workspaces.jupyter.org/v1alpha1
+			workspaceYaml := `apiVersion: workspace.jupyter.org/v1alpha1
 kind: Workspace
 metadata:
   name: deletion-protection-test
@@ -436,7 +436,7 @@ spec:
 					"-o", "jsonpath={.metadata.finalizers[0]}")
 				output, err := utils.Run(cmd)
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(output).To(Equal("workspaces.jupyter.org/template-protection"))
+				g.Expect(output).To(Equal("workspace.jupyter.org/template-protection"))
 			}
 			Eventually(verifyFinalizerAdded).
 				WithPolling(500 * time.Millisecond).
@@ -464,7 +464,7 @@ spec:
 				"-o", "jsonpath={.metadata.finalizers[0]}")
 			output, err = utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(output).To(Equal("workspaces.jupyter.org/template-protection"))
+			Expect(output).To(Equal("workspace.jupyter.org/template-protection"))
 
 			// Delete all workspaces using the template (including deletion-protection-test)
 			deleteAllWorkspacesUsingTemplate("production-notebook-template")
@@ -487,12 +487,12 @@ spec:
 
 			By("re-creating production template for CEL tests")
 			cmd := exec.Command("kubectl", "apply", "-f",
-				"config/samples/workspaces_v1alpha1_workspacetemplate_production.yaml")
+				"config/samples/workspace_v1alpha1_workspacetemplate_production.yaml")
 			_, err = utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("creating workspace using production template")
-			workspaceYaml := `apiVersion: workspaces.jupyter.org/v1alpha1
+			workspaceYaml := `apiVersion: workspace.jupyter.org/v1alpha1
 kind: Workspace
 metadata:
   name: cel-immutability-test
@@ -521,7 +521,7 @@ spec:
 
 		It("should reject WorkspaceTemplate spec modification via CEL validation", func() {
 			By("creating a template specifically for immutability testing")
-			templateYaml := `apiVersion: workspaces.jupyter.org/v1alpha1
+			templateYaml := `apiVersion: workspace.jupyter.org/v1alpha1
 kind: WorkspaceTemplate
 metadata:
   name: immutability-test-template


### PR DESCRIPTION
Changing API group from workspaces.jupyter.org to workspace.jupyter.org to maintain consistency with other kubernetes resources

Testing done:

Deployed to my personal cluster and validated basic functionality (CRUD operations, webhook functionality). 