### PR TITLE
Add web-ui url generation logic

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -286,6 +286,8 @@ func main() {
 		config := extensionapi.NewConfig(
 			extensionapi.WithServerPort(7443),
 			extensionapi.WithClusterId(os.Getenv("CLUSTER_ID")),
+			extensionapi.WithKMSKeyID(os.Getenv("KMS_KEY_ID")),
+			extensionapi.WithDomain(os.Getenv("DOMAIN")),
 		)
 		if err := extensionapi.SetupExtensionAPIServerWithManager(mgr, config); err != nil {
 			setupLog.Error(err, "unable to create extension API server", "extensionapi", "Server")

--- a/internal/extensionapi/config.go
+++ b/internal/extensionapi/config.go
@@ -28,6 +28,8 @@ type ExtensionConfig struct {
 	AllowedOrigin       string
 	// AWS section
 	ClusterId string
+	KMSKeyID  string
+	Domain    string
 }
 
 // ConfigOption is a function that modifies an ExtensionConfig
@@ -93,6 +95,20 @@ func WithWriteTimeoutSeconds(timeoutSeconds int) ConfigOption {
 func WithAllowedOrigin(origin string) ConfigOption {
 	return func(c *ExtensionConfig) {
 		c.AllowedOrigin = origin
+	}
+}
+
+// WithKMSKeyID sets the KMS key ID for JWT token encryption
+func WithKMSKeyID(keyID string) ConfigOption {
+	return func(c *ExtensionConfig) {
+		c.KMSKeyID = keyID
+	}
+}
+
+// WithDomain sets the domain for Web UI URLs
+func WithDomain(domain string) ConfigOption {
+	return func(c *ExtensionConfig) {
+		c.Domain = domain
 	}
 }
 

--- a/internal/extensionapi/connection_route.go
+++ b/internal/extensionapi/connection_route.go
@@ -24,6 +24,26 @@ func (n *noOpPodExec) ExecInPod(ctx context.Context, pod *corev1.Pod, containerN
 	return "", fmt.Errorf("pod exec not supported in connection URL generation")
 }
 
+// generateWebUIBearerTokenURL generates a Web UI connection URL with JWT token
+// Returns (connectionType, connectionURL, error)
+func (s *ExtensionServer) generateWebUIBearerTokenURL(r *http.Request, workspaceName, namespace string) (string, string, error) {
+	user := GetUserFromHeaders(r)
+	if user == "" {
+		return "", "", fmt.Errorf("user information not found in request headers")
+	}
+
+	// Generate JWT token for the user and workspace
+	token, err := s.jwtManager.GenerateToken(user, []string{}, workspaceName, namespace, "webui")
+	if err != nil {
+		return "", "", fmt.Errorf("failed to generate JWT token: %w", err)
+	}
+
+	// Construct the Web UI URL using the format: $DOMAIN/workspaces/{{ .Workspace.Namespace }}/{{ .Workspace.Name }}/bearer-auth?token=<token>
+	webUIURL := fmt.Sprintf(WebUIURLFormat, s.config.Domain, namespace, workspaceName, token)
+
+	return connectionv1alpha1.ConnectionTypeWebUI, webUIURL, nil
+}
+
 // HandleConnectionCreate handles POST requests to create a connection
 func (s *ExtensionServer) HandleConnectionCreate(w http.ResponseWriter, r *http.Request) {
 	logger := GetLoggerFromContext(r.Context())
@@ -86,7 +106,7 @@ func (s *ExtensionServer) HandleConnectionCreate(w http.ResponseWriter, r *http.
 	case connectionv1alpha1.ConnectionTypeVSCodeRemote:
 		responseType, responseURL, err = s.generateVSCodeURL(r, req.Spec.WorkspaceName, namespace)
 	case connectionv1alpha1.ConnectionTypeWebUI:
-		responseType, responseURL, err = s.generateWebUIURL(r, req.Spec.WorkspaceName, namespace)
+		responseType, responseURL, err = s.generateWebUIBearerTokenURL(r, req.Spec.WorkspaceName, namespace)
 	default:
 		logger.Error(nil, "Invalid workspace connection type", "connectionType", req.Spec.WorkspaceConnectionType)
 		WriteKubernetesError(w, http.StatusBadRequest, "Invalid workspace connection type")
@@ -135,7 +155,7 @@ func validateWorkspaceConnectionRequest(req *connectionv1alpha1.WorkspaceConnect
 	case connectionv1alpha1.ConnectionTypeVSCodeRemote, connectionv1alpha1.ConnectionTypeWebUI:
 		// Valid types
 	default:
-		return fmt.Errorf("invalid workspaceConnectionType: %s", req.Spec.WorkspaceConnectionType)
+		return fmt.Errorf("invalid workspaceConnectionType: '%s'. Valid types are: 'vscode-remote', 'web-ui'", req.Spec.WorkspaceConnectionType)
 	}
 
 	return nil
@@ -177,11 +197,4 @@ func (s *ExtensionServer) generateVSCodeURL(r *http.Request, workspaceName, name
 	}
 
 	return connectionv1alpha1.ConnectionTypeVSCodeRemote, url, nil
-}
-
-// generateWebUIURL generates a Web UI connection URL
-// Returns (connectionType, connectionURL, error)
-func (s *ExtensionServer) generateWebUIURL(r *http.Request, workspaceName, namespace string) (string, string, error) {
-	// TODO: Implement Web UI URL generation with JWT tokens
-	return connectionv1alpha1.ConnectionTypeWebUI, "https://placeholder-webui-url.com", nil
 }

--- a/internal/extensionapi/constants.go
+++ b/internal/extensionapi/constants.go
@@ -3,4 +3,7 @@ package extensionapi
 const (
 	// VSCodeScheme is the URL scheme for VSCode remote connections
 	VSCodeScheme = "vscode://amazonwebservices.aws-toolkit-vscode/connect/sagemaker"
+
+	// WebUIURLFormat is the URL format for WebUI bearer token authentication
+	WebUIURLFormat = "%s/workspaces/%s/%s/bearer-auth?token=%s"
 )

--- a/internal/extensionapi/server_test.go
+++ b/internal/extensionapi/server_test.go
@@ -25,9 +25,6 @@ import (
 
 const testResourceName = "test-resource"
 
-// No need to override the function at init since we can't modify package functions
-// Instead we'll use variables that our test will check
-
 // MockHTTPServer is a wrapper around http.Server for testing
 type MockHTTPServer struct {
 	Server             *http.Server
@@ -184,8 +181,11 @@ var _ = Describe("Server", func() {
 		clientSet := &kubernetes.Clientset{}
 		sarClient = clientSet.AuthorizationV1().SubjectAccessReviews()
 
+		// Create mock JWT manager
+		mockJWT := &mockJWTManager{token: "test-token"}
+
 		// Create the server
-		server = newExtensionServer(config, &logger, k8sClient, sarClient)
+		server = newExtensionServer(config, &logger, k8sClient, sarClient, mockJWT)
 		server.registerAllRoutes()
 
 		// Create a minimal fake routes server without automatic route registration

--- a/internal/extensionapi/utils.go
+++ b/internal/extensionapi/utils.go
@@ -39,3 +39,18 @@ func GetNamespaceFromPath(path string) (string, error) {
 	}
 	return "", fmt.Errorf("cannot find the namespace in URL")
 }
+
+// GetUserFromHeaders extracts user information from request headers
+func GetUserFromHeaders(r *http.Request) string {
+	// Try common user headers in order of preference
+	if user := r.Header.Get("X-Remote-User"); user != "" {
+		return user
+	}
+	if user := r.Header.Get("X-Forwarded-User"); user != "" {
+		return user
+	}
+	if user := r.Header.Get("Remote-User"); user != "" {
+		return user
+	}
+	return ""
+}


### PR DESCRIPTION
## **Description:**
This PR adds support for generating WebUI connection URLs with KMS-encrypted JWT tokens for workspace authentication.

### Changes:
- **WebUI URL Generation**: Added `generateWebUIBearerTokenURL()` function that creates bearer token URLs
- **Configuration**: Added `Domain` and `KMSKeyID` configuration options
- **URL Format**: Follows agreed format: `$DOMAIN/workspaces/{namespace}/{workspace}/bearer-auth?token={jwt}`
- **Error Handling**: Improved validation with clear error messages for invalid connection types


### Testing:
- Unit Tests
- Tested manually - 
 workspaceConnectionUrl: "https://jupyter.test.com/workspaces/default/workspace-sample/bearer-auth?token=eyJ..."




