### PR TITLE
fix: improve extensionapi test coverage to 91.4%

### DIFF
--- a/internal/extensionapi/config_test.go
+++ b/internal/extensionapi/config_test.go
@@ -103,5 +103,12 @@ var _ = Describe("ExtensionConfig", func() {
 
 			Expect(config.AllowedOrigin).To(Equal(customOrigin))
 		})
+
+		It("Should allow to override ClusterId", func() {
+			customClusterId := "test-cluster-123"
+			config := NewConfig(WithClusterId(customClusterId))
+
+			Expect(config.ClusterId).To(Equal(customClusterId))
+		})
 	})
 })

--- a/internal/extensionapi/server_test.go
+++ b/internal/extensionapi/server_test.go
@@ -507,6 +507,24 @@ var _ = Describe("Server", func() {
 			}
 			Expect(routeCount).To(Equal(2))
 		})
+
+		It("Should return 404 for paths with insufficient parts", func() {
+			server := newExtensionServer(config, &logger, k8sClient, sarClient)
+
+			resourceHandlers := map[string]func(http.ResponseWriter, *http.Request){
+				"test": func(w http.ResponseWriter, _ *http.Request) {
+					w.WriteHeader(http.StatusOK)
+				},
+			}
+			server.registerNamespacedRoutes(resourceHandlers)
+
+			req := httptest.NewRequest("GET", "/apis/namespaces/short", nil)
+			w := httptest.NewRecorder()
+
+			server.mux.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusNotFound))
+		})
 	})
 
 	Context("Start", func() {

--- a/internal/extensionapi/utils_test.go
+++ b/internal/extensionapi/utils_test.go
@@ -129,4 +129,38 @@ var _ = Describe("Utils", func() {
 			}),
 		)
 	})
+
+	Context("GetUserFromHeaders", func() {
+		It("Should return user from X-User header", func() {
+			req := httptest.NewRequest("GET", "/test", nil)
+			req.Header.Set("X-User", "test-user")
+
+			user := GetUserFromHeaders(req)
+			Expect(user).To(Equal("test-user"))
+		})
+
+		It("Should return user from X-Remote-User header when X-User is not present", func() {
+			req := httptest.NewRequest("GET", "/test", nil)
+			req.Header.Set("X-Remote-User", "remote-user")
+
+			user := GetUserFromHeaders(req)
+			Expect(user).To(Equal("remote-user"))
+		})
+
+		It("Should prioritize X-User over X-Remote-User", func() {
+			req := httptest.NewRequest("GET", "/test", nil)
+			req.Header.Set("X-User", "primary-user")
+			req.Header.Set("X-Remote-User", "secondary-user")
+
+			user := GetUserFromHeaders(req)
+			Expect(user).To(Equal("primary-user"))
+		})
+
+		It("Should return empty string when no user headers are present", func() {
+			req := httptest.NewRequest("GET", "/test", nil)
+
+			user := GetUserFromHeaders(req)
+			Expect(user).To(Equal(""))
+		})
+	})
 })

--- a/internal/workspace/utils_test.go
+++ b/internal/workspace/utils_test.go
@@ -6,12 +6,15 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestGetPodUIDFromWorkspaceName_Success(t *testing.T) {
-	// Create fake clientset with a pod
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-pod",
@@ -23,18 +26,20 @@ func TestGetPodUIDFromWorkspaceName_Success(t *testing.T) {
 		},
 	}
 
-	clientset := fake.NewSimpleClientset(pod)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build()
 
-	uid, err := GetPodUIDFromWorkspaceName(clientset, "test-workspace")
+	uid, err := GetPodUIDFromWorkspaceName(fakeClient, "test-workspace")
 
 	assert.NoError(t, err)
 	assert.Equal(t, "test-pod-uid-123", uid)
 }
 
 func TestGetPodUIDFromWorkspaceName_NoPodFound(t *testing.T) {
-	clientset := fake.NewSimpleClientset()
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-	uid, err := GetPodUIDFromWorkspaceName(clientset, "nonexistent-workspace")
+	uid, err := GetPodUIDFromWorkspaceName(fakeClient, "nonexistent-workspace")
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "no pod found for workspace")


### PR DESCRIPTION
Improve extensionapi test coverage from 76.2% to 91.4% by adding comprehensive tests and making functions mockable.

### Changes Made:
- **Made generateVSCodeURL mockable**: Added function variable `newSSMRemoteAccessStrategy` for testing
- **Refactored workspace utilities**: Updated `GetPodUIDFromWorkspaceName` to use controller-runtime client for consistency
- **Added HandleConnectionCreate tests**: Created tests for WebUI connection path and workspace authorization flow
