### PR TITLE
refactor: Changing service account pattern annotation name

### DIFF
--- a/config/samples/serviceaccount_with_allowlisting.yaml
+++ b/config/samples/serviceaccount_with_allowlisting.yaml
@@ -8,5 +8,5 @@ metadata:
       - sample-username
     workspace.jupyter.org/service-account-groups: |
       - default-data-scientist
-    workspace.jupyter.org/service-account-users-pattern: |
+    workspace.jupyter.org/service-account-user-patterns: |
       - arn:aws:sts::561569208013:assumed-role/DSRole/*

--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -37,7 +37,7 @@ const (
 	AnnotationCreatedBy                  = "workspace.jupyter.org/created-by"
 	AnnotationLastUpdatedBy              = "workspace.jupyter.org/last-updated-by"
 	AnnotationServiceAccountUsers        = "workspace.jupyter.org/service-account-users"
-	AnnotationServiceAccountUsersPattern = "workspace.jupyter.org/service-account-users-pattern"
+	AnnotationServiceAccountUserPatterns = "workspace.jupyter.org/service-account-user-patterns"
 	AnnotationServiceAccountGroups       = "workspace.jupyter.org/service-account-groups"
 
 	// Status phases

--- a/internal/webhook/v1alpha1/service_account_validator.go
+++ b/internal/webhook/v1alpha1/service_account_validator.go
@@ -79,9 +79,9 @@ func (sav *ServiceAccountValidator) checkUsernameAccess(username string, sa *cor
 	return false
 }
 
-// checkUsernamePatternAccess checks if username matches wildcard patterns in service-account-users-pattern annotation
+// checkUsernamePatternAccess checks if username matches wildcard patterns in service-account-user-patterns annotation
 func (sav *ServiceAccountValidator) checkUsernamePatternAccess(username string, sa *corev1.ServiceAccount) bool {
-	patternsYaml, exists := sa.Annotations[controller.AnnotationServiceAccountUsersPattern]
+	patternsYaml, exists := sa.Annotations[controller.AnnotationServiceAccountUserPatterns]
 	if !exists {
 		return false
 	}

--- a/internal/webhook/v1alpha1/service_account_validator_test.go
+++ b/internal/webhook/v1alpha1/service_account_validator_test.go
@@ -94,21 +94,21 @@ var _ = Describe("ServiceAccount Validator", func() {
 
 		It("should match username with asterisk wildcard", func() {
 			sa.Annotations = map[string]string{
-				controller.AnnotationServiceAccountUsersPattern: "- arn:aws:iam::123456789012:role/MyRole/*",
+				controller.AnnotationServiceAccountUserPatterns: "- arn:aws:iam::123456789012:role/MyRole/*",
 			}
 			Expect(sav.checkUsernamePatternAccess("arn:aws:iam::123456789012:role/MyRole/user123", sa)).To(BeTrue())
 		})
 
 		It("should match username with question mark wildcard", func() {
 			sa.Annotations = map[string]string{
-				controller.AnnotationServiceAccountUsersPattern: "- user?",
+				controller.AnnotationServiceAccountUserPatterns: "- user?",
 			}
 			Expect(sav.checkUsernamePatternAccess("user1", sa)).To(BeTrue())
 		})
 
 		It("should not match when pattern does not match", func() {
 			sa.Annotations = map[string]string{
-				controller.AnnotationServiceAccountUsersPattern: "- arn:aws:iam::123456789012:role/MyRole/*",
+				controller.AnnotationServiceAccountUserPatterns: "- arn:aws:iam::123456789012:role/MyRole/*",
 			}
 			Expect(sav.checkUsernamePatternAccess("arn:aws:iam::123456789012:role/OtherRole/user123", sa)).To(BeFalse())
 		})


### PR DESCRIPTION
- Using plural for service account user patterns annotation