### PR TITLE
fix: change the vscode url to /connect/workspace

### DIFF
--- a/internal/aws/constants.go
+++ b/internal/aws/constants.go
@@ -22,5 +22,5 @@ const (
 	SSMInstanceNamePrefix = "workspace"
 
 	// VSCodeScheme is the URL scheme for VSCode remote connections
-	VSCodeScheme = "vscode://amazonwebservices.aws-toolkit-vscode/connect/sagemaker"
+	VSCodeScheme = "vscode://amazonwebservices.aws-toolkit-vscode/connect/workspace"
 )

--- a/internal/aws/ssm_remote_access_strategy_test.go
+++ b/internal/aws/ssm_remote_access_strategy_test.go
@@ -538,7 +538,7 @@ func TestGenerateVSCodeConnectionURL_Success(t *testing.T) {
 	url, err := strategy.GenerateVSCodeConnectionURL(context.Background(), "test-workspace", "default", "test-pod-uid", "arn:aws:eks:us-east-1:123456789012:cluster/test")
 
 	assert.NoError(t, err)
-	assert.Contains(t, url, "vscode://amazonwebservices.aws-toolkit-vscode/connect/sagemaker")
+	assert.Contains(t, url, "vscode://amazonwebservices.aws-toolkit-vscode/connect/workspace")
 	assert.Contains(t, url, "sessionId=sess-123")
 	assert.Contains(t, url, "sessionToken=token-456")
 	assert.Contains(t, url, "streamUrl=wss://stream-url")


### PR DESCRIPTION
Quick fix changing from  /connect/sagemaker to  /connect/workspace.

Apologize for the messed PR, even I fetched the latest commit, github still captures previous commits(already merge on the source repo). 