### PR TITLE
Using restricted mode for workspace container

### DIFF
--- a/internal/controller/deployment_builder.go
+++ b/internal/controller/deployment_builder.go
@@ -215,6 +215,16 @@ func (db *DeploymentBuilder) buildPrimaryContainer(workspace *workspacev1alpha1.
 			},
 		},
 		Resources: resources,
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: &[]bool{false}[0],
+			RunAsNonRoot:             &[]bool{true}[0],
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{"ALL"},
+			},
+			SeccompProfile: &corev1.SeccompProfile{
+				Type: corev1.SeccompProfileTypeRuntimeDefault,
+			},
+		},
 		// Default environment variables
 		Env: []corev1.EnvVar{},
 		// TODO: Add probes


### PR DESCRIPTION
Validated using `pod-security.kubernetes.io/audit=restricted` label on namespace