### PR TITLE
feat: zero trust in auth route of middleware

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/coreos/go-oidc/v3 v3.16.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.12.2 // indirect
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
@@ -47,6 +48,7 @@ require (
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
+	github.com/go-jose/go-jose/v4 v4.1.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
@@ -103,7 +105,7 @@ require (
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	golang.org/x/mod v0.27.0 // indirect
 	golang.org/x/net v0.43.0 // indirect
-	golang.org/x/oauth2 v0.27.0 // indirect
+	golang.org/x/oauth2 v0.28.0 // indirect
 	golang.org/x/sync v0.16.0 // indirect
 	golang.org/x/sys v0.35.0 // indirect
 	golang.org/x/term v0.34.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK3
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/coreos/go-oidc/v3 v3.16.0 h1:qRQUCFstKpXwmEjDQTIbyY/5jF00+asXzSkmkoa/mow=
+github.com/coreos/go-oidc/v3 v3.16.0/go.mod h1:wqPbKFrVnE90vty060SB40FCJ8fTHTxSwyXJqZH+sI8=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -63,6 +65,8 @@ github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
+github.com/go-jose/go-jose/v4 v4.1.3 h1:CVLmWDhDVRa6Mi/IgCgaopNosCaHz7zrMeF9MlZRkrs=
+github.com/go-jose/go-jose/v4 v4.1.3/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
@@ -245,6 +249,8 @@ golang.org/x/net v0.43.0 h1:lat02VYK2j4aLzMzecihNvTlJNQUq316m2Mr9rnM6YE=
 golang.org/x/net v0.43.0/go.mod h1:vhO1fvI4dGsIjh73sWfUVjj3N7CA9WkKJNQm2svM6Jg=
 golang.org/x/oauth2 v0.27.0 h1:da9Vo7/tDv5RH/7nZDz1eMGS/q1Vv1N/7FCrBhI9I3M=
 golang.org/x/oauth2 v0.27.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT8=
+golang.org/x/oauth2 v0.28.0 h1:CrgCKl8PPAVtLnU3c+EDw6x11699EWlsDeWNWKdIOkc=
+golang.org/x/oauth2 v0.28.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT8=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/guided-charts/aws-traefik-dex/templates/authmiddleware/deployment.yaml
+++ b/guided-charts/aws-traefik-dex/templates/authmiddleware/deployment.yaml
@@ -129,12 +129,7 @@ spec:
           - name: OIDC_ISSUER_URL
             value: "https://{{ .Values.domain }}/dex"
           - name: OIDC_CLIENT_ID
-            value: "{{ .Values.dex.authmiddlewareClientId }}"
-          - name: OIDC_CLIENT_SECRET
-            valueFrom:
-              secretKeyRef:
-                name: authmiddleware-secrets
-                key: oidc-client-secret
+            value: "{{ .Values.dex.oauth2ProxyClientId }}"
           - name: OIDC_INIT_TIMEOUT_SECONDS
             value: "{{ .Values.authmiddleware.oidcInitTimeoutSecs }}"
         volumeMounts:

--- a/guided-charts/aws-traefik-dex/templates/authmiddleware/deployment.yaml
+++ b/guided-charts/aws-traefik-dex/templates/authmiddleware/deployment.yaml
@@ -118,10 +118,25 @@ spec:
             value: "{{ .Values.authmiddleware.csrfCookieMaxAge }}"
           - name: CSRF_COOKIE_SECURE
             value: "{{ .Values.authmiddleware.csrfCookieSecure }}"
+          - name: ENABLE_OAUTH
+            value: "{{ .Values.authmiddleware.enableOauth}}"
+          - name: ENABLE_BEARER_URL_AUTH
+            value: "{{ .Values.authmiddleware.enableBearerAuth}}"
           - name: OIDC_USERNAME_PREFIX
             value: "{{ .Values.dex.oidcUsernamePrefix }}"
           - name: OIDC_GROUPS_PREFIX
             value: "{{ .Values.dex.oidcGroupPrefix }}"
+          - name: OIDC_ISSUER_URL
+            value: "https://{{ .Values.domain }}/dex"
+          - name: OIDC_CLIENT_ID
+            value: "{{ .Values.dex.authmiddlewareClientId }}"
+          - name: OIDC_CLIENT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: authmiddleware-secrets
+                key: oidc-client-secret
+          - name: OIDC_INIT_TIMEOUT_SECONDS
+            value: "{{ .Values.authmiddleware.oidcInitTimeoutSecs }}"
         volumeMounts:
           - name: tmp
             mountPath: /tmp

--- a/guided-charts/aws-traefik-dex/templates/authmiddleware/secrets.yaml
+++ b/guided-charts/aws-traefik-dex/templates/authmiddleware/secrets.yaml
@@ -12,4 +12,5 @@ data:
   # These values must be provided in .Values.authmiddleware.jwtSigningKey and .Values.authmiddleware.csrfAuthKey
   jwt-signing-key: {{ .Values.authmiddleware.jwtSigningKey | quote }}
   csrf-auth-key: {{ .Values.authmiddleware.csrfAuthKey | quote }}
+  oidc-client-secret: {{ .Values.dex.authmiddlewareClientSecret | quote }}
 {{- end }}

--- a/guided-charts/aws-traefik-dex/templates/authmiddleware/secrets.yaml
+++ b/guided-charts/aws-traefik-dex/templates/authmiddleware/secrets.yaml
@@ -12,5 +12,4 @@ data:
   # These values must be provided in .Values.authmiddleware.jwtSigningKey and .Values.authmiddleware.csrfAuthKey
   jwt-signing-key: {{ .Values.authmiddleware.jwtSigningKey | quote }}
   csrf-auth-key: {{ .Values.authmiddleware.csrfAuthKey | quote }}
-  oidc-client-secret: {{ .Values.dex.authmiddlewareClientSecret | quote }}
 {{- end }}

--- a/guided-charts/aws-traefik-dex/templates/dex/configmap.yaml
+++ b/guided-charts/aws-traefik-dex/templates/dex/configmap.yaml
@@ -29,6 +29,9 @@ data:
       {{- else }}
       public: true
       {{- end }}
+    - id: {{ .Values.dex.authmiddlewareClientId }}
+      name: 'Auth Middleware'
+      secret: {{ .Values.dex.authmiddlewareClientSecret }}
     connectors:
     - type: github
       id: github

--- a/guided-charts/aws-traefik-dex/templates/dex/configmap.yaml
+++ b/guided-charts/aws-traefik-dex/templates/dex/configmap.yaml
@@ -29,9 +29,6 @@ data:
       {{- else }}
       public: true
       {{- end }}
-    - id: {{ .Values.dex.authmiddlewareClientId }}
-      name: 'Auth Middleware'
-      secret: {{ .Values.dex.authmiddlewareClientSecret }}
     connectors:
     - type: github
       id: github

--- a/guided-charts/aws-traefik-dex/templates/oauth2-proxy/deployment.yaml
+++ b/guided-charts/aws-traefik-dex/templates/oauth2-proxy/deployment.yaml
@@ -66,6 +66,7 @@ spec:
         - --session-store-type=cookie
         - --skip-provider-button=true
         - --set-xauthrequest=true
+        - --set-authorization-header=true
         - --pass-authorization-header=true
         - --pass-user-headers=true
         - --pass-access-token=true

--- a/guided-charts/aws-traefik-dex/templates/traefik/auth-middlewares.yaml
+++ b/guided-charts/aws-traefik-dex/templates/traefik/auth-middlewares.yaml
@@ -64,6 +64,7 @@ spec:
       - "X-Auth-Request-Email"
       - "X-Auth-Request-Groups"
       - "X-Auth-Request-Preferred-Username"
+      - "Authorization"
 ---
 apiVersion: traefik.io/v1alpha1
 kind: Middleware

--- a/guided-charts/aws-traefik-dex/values.yaml
+++ b/guided-charts/aws-traefik-dex/values.yaml
@@ -92,12 +92,6 @@ dex:
     - 18000
     - 9800
 
-  # Client ID for authmiddleware to authenticate with Dex
-  authmiddlewareClientId: "authmiddleware"
-  # Client secret for authmiddleware to authenticate with Dex (auto-generated if empty)
-  # Generate with 'openssl rand -hex 16'
-  authmiddlewareClientSecret: "852c547d73dfaa51ef3bb290ed29ea5e"
-
 # Github OAuth configuration
 github:
   # GitHub OAuth client ID (required)

--- a/guided-charts/aws-traefik-dex/values.yaml
+++ b/guided-charts/aws-traefik-dex/values.yaml
@@ -91,7 +91,13 @@ dex:
     - 8000
     - 18000
     - 9800
-    
+
+  # Client ID for authmiddleware to authenticate with Dex
+  authmiddlewareClientId: "authmiddleware"
+  # Client secret for authmiddleware to authenticate with Dex (auto-generated if empty)
+  # Generate with 'openssl rand -hex 16'
+  authmiddlewareClientSecret: "852c547d73dfaa51ef3bb290ed29ea5e"
+
 # Github OAuth configuration
 github:
   # GitHub OAuth client ID (required)
@@ -183,3 +189,8 @@ authmiddleware:
   readTimeout: "10s"
   writeTimeout: "10s"
   shutdownTimeout: "30s"
+  # Bearer auth configuration
+  enableOauth: true
+  enableBearerAuth: false
+  # Timeout in seconds for OIDC provider initialization
+  oidcInitTimeoutSecs: 30

--- a/internal/authmiddleware/config.go
+++ b/internal/authmiddleware/config.go
@@ -65,7 +65,6 @@ const (
 	EnvOidcGroupsPrefix    = "OIDC_GROUPS_PREFIX"
 	EnvOIDCIssuerURL       = "OIDC_ISSUER_URL"
 	EnvOIDCClientID        = "OIDC_CLIENT_ID"
-	EnvOIDCClientSecret    = "OIDC_CLIENT_SECRET"
 	EnvOIDCInitTimeoutSecs = "OIDC_INIT_TIMEOUT_SECONDS"
 )
 
@@ -184,7 +183,6 @@ type Config struct {
 	OidcGroupsPrefix    string
 	OIDCIssuerURL       string
 	OIDCClientID        string
-	OIDCClientSecret    string
 	OIDCInitTimeoutSecs int
 }
 
@@ -524,10 +522,6 @@ func applyOidcConfig(config *Config) error {
 
 	if oidcClientID := os.Getenv(EnvOIDCClientID); oidcClientID != "" {
 		config.OIDCClientID = oidcClientID
-	}
-
-	if oidcClientSecret := os.Getenv(EnvOIDCClientSecret); oidcClientSecret != "" {
-		config.OIDCClientSecret = oidcClientSecret
 	}
 
 	if oidcInitTimeoutSecs := os.Getenv(EnvOIDCInitTimeoutSecs); oidcInitTimeoutSecs != "" {

--- a/internal/authmiddleware/config.go
+++ b/internal/authmiddleware/config.go
@@ -61,8 +61,12 @@ const (
 	EnvCsrfTrustedOrigins = "CSRF_TRUSTED_ORIGINS"
 
 	// OIDC configuration
-	EnvOidcUsernamePrefix = "OIDC_USERNAME_PREFIX"
-	EnvOidcGroupsPrefix   = "OIDC_GROUPS_PREFIX"
+	EnvOidcUsernamePrefix  = "OIDC_USERNAME_PREFIX"
+	EnvOidcGroupsPrefix    = "OIDC_GROUPS_PREFIX"
+	EnvOIDCIssuerURL       = "OIDC_ISSUER_URL"
+	EnvOIDCClientID        = "OIDC_CLIENT_ID"
+	EnvOIDCClientSecret    = "OIDC_CLIENT_SECRET"
+	EnvOIDCInitTimeoutSecs = "OIDC_INIT_TIMEOUT_SECONDS"
 )
 
 // JWT signing types
@@ -119,8 +123,9 @@ const (
 	// DefaultCsrfTrustedOrigins is a slice, defined in createDefaultConfig
 
 	// OIDC configuration
-	DefaultOidcUsernamePrefix = "github:"
-	DefaultOidcGroupsPrefix   = "github:"
+	DefaultOidcUsernamePrefix  = "github:"
+	DefaultOidcGroupsPrefix    = "github:"
+	DefaultOIDCInitTimeoutSecs = 30
 )
 
 // Config holds all configuration for the workspaces-auth service
@@ -175,8 +180,12 @@ type Config struct {
 	CSRFTrustedOrigins []string
 
 	// OIDC configuration
-	OidcUsernamePrefix string
-	OidcGroupsPrefix   string
+	OidcUsernamePrefix  string
+	OidcGroupsPrefix    string
+	OIDCIssuerURL       string
+	OIDCClientID        string
+	OIDCClientSecret    string
+	OIDCInitTimeoutSecs int
 }
 
 // NewConfig creates a Config with values from environment variables
@@ -205,7 +214,9 @@ func NewConfig() (*Config, error) {
 		return nil, err
 	}
 
-	applyOidcConfig(config)
+	if err := applyOidcConfig(config); err != nil {
+		return nil, err
+	}
 
 	return config, nil
 }
@@ -260,8 +271,9 @@ func createDefaultConfig() *Config {
 		CSRFHeaderName:   DefaultCsrfHeaderName,
 
 		// OIDC defaults
-		OidcUsernamePrefix: DefaultOidcUsernamePrefix,
-		OidcGroupsPrefix:   DefaultOidcGroupsPrefix,
+		OidcUsernamePrefix:  DefaultOidcUsernamePrefix,
+		OidcGroupsPrefix:    DefaultOidcGroupsPrefix,
+		OIDCInitTimeoutSecs: DefaultOIDCInitTimeoutSecs,
 	}
 }
 
@@ -497,7 +509,7 @@ func applyCSRFConfig(config *Config) error {
 }
 
 // applyOidcConfig applies OIDC-related environment variable overrides
-func applyOidcConfig(config *Config) {
+func applyOidcConfig(config *Config) error {
 	if oidcUsernamePrefix := os.Getenv(EnvOidcUsernamePrefix); oidcUsernamePrefix != "" {
 		config.OidcUsernamePrefix = oidcUsernamePrefix
 	}
@@ -505,4 +517,34 @@ func applyOidcConfig(config *Config) {
 	if oidcGroupsPrefix := os.Getenv(EnvOidcGroupsPrefix); oidcGroupsPrefix != "" {
 		config.OidcGroupsPrefix = oidcGroupsPrefix
 	}
+
+	if oidcIssuerURL := os.Getenv(EnvOIDCIssuerURL); oidcIssuerURL != "" {
+		config.OIDCIssuerURL = oidcIssuerURL
+	}
+
+	if oidcClientID := os.Getenv(EnvOIDCClientID); oidcClientID != "" {
+		config.OIDCClientID = oidcClientID
+	}
+
+	if oidcClientSecret := os.Getenv(EnvOIDCClientSecret); oidcClientSecret != "" {
+		config.OIDCClientSecret = oidcClientSecret
+	}
+
+	if oidcInitTimeoutSecs := os.Getenv(EnvOIDCInitTimeoutSecs); oidcInitTimeoutSecs != "" {
+		timeoutSecs, err := strconv.Atoi(oidcInitTimeoutSecs)
+		if err != nil {
+			return fmt.Errorf("invalid %s: %w", EnvOIDCInitTimeoutSecs, err)
+		}
+		if timeoutSecs <= 0 {
+			return fmt.Errorf("%s must be a positive integer, got %d", EnvOIDCInitTimeoutSecs, timeoutSecs)
+		}
+		config.OIDCInitTimeoutSecs = timeoutSecs
+	}
+
+	// Ensure OIDCInitTimeoutSecs is always positive, even if using the default
+	if config.OIDCInitTimeoutSecs <= 0 {
+		config.OIDCInitTimeoutSecs = 30 // Fallback to a reasonable default
+	}
+
+	return nil
 }

--- a/internal/authmiddleware/config_test.go
+++ b/internal/authmiddleware/config_test.go
@@ -153,9 +153,6 @@ func checkOIDCDefaults(t *testing.T, config *Config) {
 	if config.OIDCClientID != "" {
 		t.Errorf("Expected default OIDCClientID to be empty, got %s", config.OIDCClientID)
 	}
-	if config.OIDCClientSecret != "" {
-		t.Errorf("Expected default OIDCClientSecret to be empty, got %s", config.OIDCClientSecret)
-	}
 	if config.OIDCInitTimeoutSecs != DefaultOIDCInitTimeoutSecs {
 		t.Errorf("Expected OIDCInitTimeoutSecs to be %d, got %d", DefaultOIDCInitTimeoutSecs, config.OIDCInitTimeoutSecs)
 	}
@@ -223,7 +220,6 @@ func TestNewConfigEnvOverrides(t *testing.T) {
 	setEnv(t, EnvOidcGroupsPrefix, "oidc-group:")
 	setEnv(t, EnvOIDCIssuerURL, "https://test-dex.example.com")
 	setEnv(t, EnvOIDCClientID, "test-client-id")
-	setEnv(t, EnvOIDCClientSecret, "test-client-secret")
 	setEnv(t, EnvOIDCInitTimeoutSecs, "45")
 
 	// Clean up environment variables after the test
@@ -238,7 +234,7 @@ func TestNewConfigEnvOverrides(t *testing.T) {
 		EnvCsrfCookieMaxAge, EnvCsrfCookieSecure, EnvCsrfFieldName, EnvCsrfHeaderName,
 		EnvCsrfTrustedOrigins,
 		EnvOidcUsernamePrefix, EnvOidcGroupsPrefix,
-		EnvOIDCIssuerURL, EnvOIDCClientID, EnvOIDCClientSecret, EnvOIDCInitTimeoutSecs,
+		EnvOIDCIssuerURL, EnvOIDCClientID, EnvOIDCInitTimeoutSecs,
 	}
 	defer unsetEnv(t, vars)
 
@@ -388,9 +384,6 @@ func checkOIDCConfig(t *testing.T, config *Config) {
 	}
 	if config.OIDCClientID != "test-client-id" {
 		t.Errorf("Expected OIDCClientID to be test-client-id, got %s", config.OIDCClientID)
-	}
-	if config.OIDCClientSecret != "test-client-secret" {
-		t.Errorf("Expected OIDCClientSecret to be test-client-secret, got %s", config.OIDCClientSecret)
 	}
 	if config.OIDCInitTimeoutSecs != 45 {
 		t.Errorf("Expected OIDCInitTimeoutSecs to be 45, got %d", config.OIDCInitTimeoutSecs)
@@ -626,7 +619,6 @@ func TestOIDCVerifierInitConfig(t *testing.T) {
 			config := &Config{
 				OIDCIssuerURL:       tc.issuerURL,
 				OIDCClientID:        tc.clientID,
-				OIDCClientSecret:    tc.clientSecret,
 				OIDCInitTimeoutSecs: 1, // Short timeout for tests
 			}
 

--- a/internal/authmiddleware/config_test.go
+++ b/internal/authmiddleware/config_test.go
@@ -1,7 +1,9 @@
 package authmiddleware
 
 import (
+	"log/slog"
 	"os"
+	"strings"
 	"testing"
 	"time"
 )
@@ -145,6 +147,18 @@ func checkOIDCDefaults(t *testing.T, config *Config) {
 	if config.OidcGroupsPrefix != DefaultOidcGroupsPrefix {
 		t.Errorf("Expected OidcGroupsPrefix to be %s, got %s", DefaultOidcGroupsPrefix, config.OidcGroupsPrefix)
 	}
+	if config.OIDCIssuerURL != "" {
+		t.Errorf("Expected default OIDCIssuerURL to be empty, got %s", config.OIDCIssuerURL)
+	}
+	if config.OIDCClientID != "" {
+		t.Errorf("Expected default OIDCClientID to be empty, got %s", config.OIDCClientID)
+	}
+	if config.OIDCClientSecret != "" {
+		t.Errorf("Expected default OIDCClientSecret to be empty, got %s", config.OIDCClientSecret)
+	}
+	if config.OIDCInitTimeoutSecs != DefaultOIDCInitTimeoutSecs {
+		t.Errorf("Expected OIDCInitTimeoutSecs to be %d, got %d", DefaultOIDCInitTimeoutSecs, config.OIDCInitTimeoutSecs)
+	}
 }
 
 // setEnv is a helper function to set environment variables for tests
@@ -207,6 +221,10 @@ func TestNewConfigEnvOverrides(t *testing.T) {
 	// OIDC configuration
 	setEnv(t, EnvOidcUsernamePrefix, "oidc:")
 	setEnv(t, EnvOidcGroupsPrefix, "oidc-group:")
+	setEnv(t, EnvOIDCIssuerURL, "https://test-dex.example.com")
+	setEnv(t, EnvOIDCClientID, "test-client-id")
+	setEnv(t, EnvOIDCClientSecret, "test-client-secret")
+	setEnv(t, EnvOIDCInitTimeoutSecs, "45")
 
 	// Clean up environment variables after the test
 	vars := []string{
@@ -220,6 +238,7 @@ func TestNewConfigEnvOverrides(t *testing.T) {
 		EnvCsrfCookieMaxAge, EnvCsrfCookieSecure, EnvCsrfFieldName, EnvCsrfHeaderName,
 		EnvCsrfTrustedOrigins,
 		EnvOidcUsernamePrefix, EnvOidcGroupsPrefix,
+		EnvOIDCIssuerURL, EnvOIDCClientID, EnvOIDCClientSecret, EnvOIDCInitTimeoutSecs,
 	}
 	defer unsetEnv(t, vars)
 
@@ -364,6 +383,110 @@ func checkOIDCConfig(t *testing.T, config *Config) {
 	if config.OidcGroupsPrefix != "oidc-group:" {
 		t.Errorf("Expected OidcGroupsPrefix to be oidc-group:, got %s", config.OidcGroupsPrefix)
 	}
+	if config.OIDCIssuerURL != "https://test-dex.example.com" {
+		t.Errorf("Expected OIDCIssuerURL to be https://test-dex.example.com, got %s", config.OIDCIssuerURL)
+	}
+	if config.OIDCClientID != "test-client-id" {
+		t.Errorf("Expected OIDCClientID to be test-client-id, got %s", config.OIDCClientID)
+	}
+	if config.OIDCClientSecret != "test-client-secret" {
+		t.Errorf("Expected OIDCClientSecret to be test-client-secret, got %s", config.OIDCClientSecret)
+	}
+	if config.OIDCInitTimeoutSecs != 45 {
+		t.Errorf("Expected OIDCInitTimeoutSecs to be 45, got %d", config.OIDCInitTimeoutSecs)
+	}
+}
+
+// TestOIDCInitTimeoutConfig tests that the OIDCInitTimeoutSecs configuration
+// correctly handles various environment variable scenarios
+func TestOIDCInitTimeoutConfig(t *testing.T) {
+	testCases := []struct {
+		name          string
+		envValue      string
+		expectedValue int
+		expectError   bool
+	}{
+		{
+			name:          "Default value when env var not set",
+			envValue:      "",
+			expectedValue: DefaultOIDCInitTimeoutSecs,
+			expectError:   false,
+		},
+		{
+			name:          "Valid timeout value",
+			envValue:      "60",
+			expectedValue: 60,
+			expectError:   false,
+		},
+		{
+			name:          "Zero timeout value",
+			envValue:      "0",
+			expectedValue: 0,
+			expectError:   true, // Now we expect an error for zero timeout
+		},
+		{
+			name:          "Negative timeout value",
+			envValue:      "-5",
+			expectedValue: 0,
+			expectError:   true, // Should error on negative timeout
+		},
+		{
+			name:        "Invalid non-numeric timeout",
+			envValue:    "invalid",
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Set environment variable for JWT signing key (required)
+			if err := os.Setenv(EnvJwtSigningKey, "test-signing-key"); err != nil {
+				t.Fatalf("Failed to set environment variable %s: %v", EnvJwtSigningKey, err)
+			}
+			if err := os.Setenv(EnvCsrfAuthKey, "test-csrf-key"); err != nil {
+				t.Fatalf("Failed to set environment variable %s: %v", EnvCsrfAuthKey, err)
+			}
+			defer func() {
+				if err := os.Unsetenv(EnvJwtSigningKey); err != nil {
+					t.Logf("Failed to unset environment variable %s: %v", EnvJwtSigningKey, err)
+				}
+				if err := os.Unsetenv(EnvCsrfAuthKey); err != nil {
+					t.Logf("Failed to unset environment variable %s: %v", EnvCsrfAuthKey, err)
+				}
+			}()
+
+			// Set test environment variable if value is provided
+			if tc.envValue != "" {
+				if err := os.Setenv(EnvOIDCInitTimeoutSecs, tc.envValue); err != nil {
+					t.Fatalf("Failed to set environment variable %s: %v", EnvOIDCInitTimeoutSecs, err)
+				}
+				defer func() {
+					if err := os.Unsetenv(EnvOIDCInitTimeoutSecs); err != nil {
+						t.Logf("Failed to unset environment variable %s: %v", EnvOIDCInitTimeoutSecs, err)
+					}
+				}()
+			}
+
+			// Create config
+			config, err := NewConfig()
+
+			if tc.expectError {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("NewConfig() error = %v", err)
+			}
+
+			// Check timeout value
+			if config.OIDCInitTimeoutSecs != tc.expectedValue {
+				t.Errorf("Expected OIDCInitTimeoutSecs to be %d, got %d", tc.expectedValue, config.OIDCInitTimeoutSecs)
+			}
+		})
+	}
 }
 
 // TestApplyOidcConfig tests that the applyOidcConfig function
@@ -428,7 +551,9 @@ func TestApplyOidcConfig(t *testing.T) {
 			config.OidcGroupsPrefix = DefaultOidcGroupsPrefix
 
 			// Apply OIDC configuration
-			applyOidcConfig(config)
+			if err := applyOidcConfig(config); err != nil {
+				t.Fatalf("Failed to apply OIDC configuration: %v", err)
+			}
 
 			// Check values
 			if config.OidcUsernamePrefix != tc.expectedUsername {
@@ -447,6 +572,76 @@ func TestApplyOidcConfig(t *testing.T) {
 			if tc.envOidcGroups != "" {
 				if err := os.Unsetenv(EnvOidcGroupsPrefix); err != nil {
 					t.Logf("Failed to unset environment variable %s: %v", EnvOidcGroupsPrefix, err)
+				}
+			}
+		})
+	}
+}
+
+// TestOIDCVerifierInitConfig tests that the NewOIDCVerifier function properly validates config
+func TestOIDCVerifierInitConfig(t *testing.T) {
+	testCases := []struct {
+		name         string
+		issuerURL    string
+		clientID     string
+		clientSecret string
+		expectError  bool
+	}{
+		{
+			name:         "Missing issuer URL",
+			issuerURL:    "",
+			clientID:     "test-client",
+			clientSecret: "test-secret",
+			expectError:  true,
+		},
+		{
+			name:         "Missing client ID",
+			issuerURL:    "https://dex.example.com",
+			clientID:     "",
+			clientSecret: "test-secret",
+			expectError:  true,
+		},
+		{
+			name:         "Empty client secret",
+			issuerURL:    "https://dex.example.com",
+			clientID:     "test-client",
+			clientSecret: "",
+			expectError:  false, // Client secret is allowed to be empty
+		},
+		{
+			name:         "Valid config",
+			issuerURL:    "https://dex.example.com",
+			clientID:     "test-client",
+			clientSecret: "test-secret",
+			expectError:  false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create a dummy logger for testing
+			logger := slog.Default()
+
+			// Create a config with test values
+			config := &Config{
+				OIDCIssuerURL:       tc.issuerURL,
+				OIDCClientID:        tc.clientID,
+				OIDCClientSecret:    tc.clientSecret,
+				OIDCInitTimeoutSecs: 1, // Short timeout for tests
+			}
+
+			// Note: We no longer need to skip initialization since our refactoring
+			// moved the actual provider initialization to the Start() method
+
+			_, err := NewOIDCVerifier(config, logger)
+
+			// Check if error matches expectation
+			if tc.expectError && err == nil {
+				t.Errorf("Expected error but got none")
+			} else if !tc.expectError && err != nil {
+				// Only report error if it's not related to context cancellation
+				if !strings.Contains(err.Error(), "context canceled") {
+					t.Errorf("Did not expect error but got: %v", err)
 				}
 			}
 		})

--- a/internal/authmiddleware/constants.go
+++ b/internal/authmiddleware/constants.go
@@ -20,4 +20,7 @@ const (
 	// Routing modes
 	RoutingModeSubdomain = "subdomain"
 	RoutingModePath      = "path"
+
+	// OIDC constants
+	OIDCAuthHeaderPrefix = "Bearer "
 )

--- a/internal/authmiddleware/constants.go
+++ b/internal/authmiddleware/constants.go
@@ -6,6 +6,7 @@ const (
 	HeaderAuthRequestUser              = "X-Auth-Request-User"
 	HeaderAuthRequestGroups            = "X-Auth-Request-Groups"
 	HeaderAuthRequestPreferredUsername = "X-Auth-Request-Preferred-Username"
+	HeaderAuthorization                = "Authorization"
 
 	// Headers from reverse proxy
 	HeaderForwardedURI   = "X-Forwarded-Uri"

--- a/internal/authmiddleware/headers.go
+++ b/internal/authmiddleware/headers.go
@@ -1,6 +1,7 @@
 package authmiddleware
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -31,4 +32,22 @@ func ExtractSubdomain(host string) string {
 		return parts[0]
 	}
 	return host
+}
+
+// ExtractBearerToken extracts a bearer token from an Authorization header
+func ExtractBearerToken(authHeader string) (string, error) {
+	if authHeader == "" {
+		return "", errors.New("authorization header is empty")
+	}
+
+	if !strings.HasPrefix(authHeader, OIDCAuthHeaderPrefix) {
+		return "", errors.New("authorization header is not a bearer token")
+	}
+
+	token := strings.TrimPrefix(authHeader, OIDCAuthHeaderPrefix)
+	if token == "" {
+		return "", errors.New("bearer token is empty")
+	}
+
+	return token, nil
 }

--- a/internal/authmiddleware/headers_test.go
+++ b/internal/authmiddleware/headers_test.go
@@ -1,0 +1,62 @@
+package authmiddleware
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestExtractBearerToken tests the ExtractBearerToken function with various inputs
+func TestExtractBearerToken(t *testing.T) {
+	tests := []struct {
+		name        string
+		authHeader  string
+		expected    string
+		expectError bool
+	}{
+		{
+			name:        "Valid bearer token",
+			authHeader:  "Bearer abc123.def456.ghi789",
+			expected:    "abc123.def456.ghi789",
+			expectError: false,
+		},
+		{
+			name:        "Empty auth header",
+			authHeader:  "",
+			expected:    "",
+			expectError: true,
+		},
+		{
+			name:        "Not a bearer token",
+			authHeader:  "Basic dXNlcm5hbWU6cGFzc3dvcmQ=",
+			expected:    "",
+			expectError: true,
+		},
+		{
+			name:        "Bearer prefix without token",
+			authHeader:  "Bearer ",
+			expected:    "",
+			expectError: true,
+		},
+		{
+			name:        "Wrong case in bearer prefix",
+			authHeader:  "bearer abc123.def456.ghi789",
+			expected:    "",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			token, err := ExtractBearerToken(tt.authHeader)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Empty(t, token)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, token)
+			}
+		})
+	}
+}

--- a/internal/authmiddleware/oidc_verifier.go
+++ b/internal/authmiddleware/oidc_verifier.go
@@ -129,24 +129,6 @@ func (v *OIDCVerifier) Start(ctx context.Context) error {
 	return nil
 }
 
-// ExtractBearerToken extracts a bearer token from an Authorization header
-func ExtractBearerToken(authHeader string) (string, error) {
-	if authHeader == "" {
-		return "", errors.New("authorization header is empty")
-	}
-
-	if !strings.HasPrefix(authHeader, OIDCAuthHeaderPrefix) {
-		return "", errors.New("authorization header is not a bearer token")
-	}
-
-	token := strings.TrimPrefix(authHeader, OIDCAuthHeaderPrefix)
-	if token == "" {
-		return "", errors.New("bearer token is empty")
-	}
-
-	return token, nil
-}
-
 // VerifyToken verifies an OIDC token and returns Claims, isFault, error.
 // It may call the provider to refresh the public keySet if not cached
 func (v *OIDCVerifier) VerifyToken(ctx context.Context, tokenString string, logger *slog.Logger) (*OIDCClaims, bool, error) {

--- a/internal/authmiddleware/oidc_verifier.go
+++ b/internal/authmiddleware/oidc_verifier.go
@@ -1,0 +1,238 @@
+package authmiddleware
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+)
+
+// No constants needed here
+
+// OIDCVerifierInterface defines the interface for OIDC token verification
+type OIDCVerifierInterface interface {
+	// VerifyToken verifies an OIDC token and returns Claims, isFault, error.
+	// It may call the provider to refresh the public keySet if not cached
+	VerifyToken(ctx context.Context, tokenString string, logger *slog.Logger) (*OIDCClaims, bool, error)
+
+	// Start initializes the OIDC provider and verifier
+	// This allows deferring HTTP calls until the application is ready
+	Start(ctx context.Context) error
+}
+
+// OIDCVerifier handles verification of OIDC tokens
+type OIDCVerifier struct {
+	provider       *oidc.Provider
+	verifier       *oidc.IDTokenVerifier
+	clientID       string
+	clientSecret   string
+	issuerURL      string
+	logger         *slog.Logger
+	timeoutSeconds int // Timeout for OIDC provider initialization
+	oidcConfig     *oidc.Config
+}
+
+// OIDCClaims represents the claims we extract from an OIDC ID token
+type OIDCClaims struct {
+	Username         string   `json:"preferred_username"`
+	Email            string   `json:"email"`
+	Groups           []string `json:"groups"`
+	Subject          string   `json:"sub"`
+	ExtraClaimsField map[string]any
+}
+
+// NewOIDCVerifier creates a new OIDC verifier without initializing connections
+// The actual initialization is deferred to the Start method
+func NewOIDCVerifier(config *Config, logger *slog.Logger) (*OIDCVerifier, error) {
+	if config.OIDCIssuerURL == "" {
+		return nil, fmt.Errorf("OIDC issuer URL is required")
+	}
+
+	if config.OIDCClientID == "" {
+		return nil, fmt.Errorf("OIDC client ID is required")
+	}
+
+	logger.Info("Creating OIDC verifier (not initialized)",
+		"issuer", config.OIDCIssuerURL,
+		"client_id", config.OIDCClientID,
+		"timeout_secs", config.OIDCInitTimeoutSecs,
+	)
+
+	// Create the token verifier
+	// authmiddleware should be registered with OIDC provider (e.g. dex) as its own client
+	// so that it can access the public keys.
+	// However, in authmiddleware flow, the OIDC provider will issue token to a different component (e.g. oauth2-proxy)
+	// and such component will pass the token as Authentication token to authmiddleware,
+	// thus, authmiddleware will not necessarily be in the audience of the token.
+	// In order to prevent the token verification to fail on target audience, set SkipClientIDCheck to true.
+	// This is okay: authmiddleware's only purpose is to verify that the token was issued by the OIDC provider.
+	oidcConfig := &oidc.Config{
+		ClientID:          config.OIDCClientID,
+		SkipClientIDCheck: true,
+	}
+
+	return &OIDCVerifier{
+		provider:       nil, // Will be initialized in Start()
+		verifier:       nil, // Will be initialized in Start()
+		clientID:       config.OIDCClientID,
+		clientSecret:   config.OIDCClientSecret,
+		issuerURL:      config.OIDCIssuerURL,
+		logger:         logger,
+		timeoutSeconds: config.OIDCInitTimeoutSecs,
+		oidcConfig:     oidcConfig,
+	}, nil
+}
+
+// Start initializes the OIDC provider and verifier
+// This allows deferring HTTP calls until the application is ready
+func (v *OIDCVerifier) Start(ctx context.Context) error {
+	if v.provider != nil {
+		// Already initialized
+		return nil
+	}
+
+	v.logger.Info("Starting OIDC verifier - initializing provider connection",
+		"issuer", v.issuerURL,
+		"client_id", v.clientID,
+	)
+
+	// Create a context with timeout for OIDC provider initialization
+	initCtx, cancel := context.WithTimeout(ctx, time.Duration(v.timeoutSeconds)*time.Second)
+	defer cancel()
+
+	// Initialize OIDC provider and verifier - this makes HTTP calls
+	if v.logger != nil {
+		v.logger.Info("Configuring new OIDC provider", "issuerURL", v.issuerURL)
+	}
+	provider, err := oidc.NewProvider(initCtx, v.issuerURL)
+	if err != nil {
+		return fmt.Errorf("failed to initialize OIDC provider: %w", err)
+	}
+	v.provider = provider
+	if v.logger != nil {
+		v.logger.Info("OIDC provider is ready")
+	}
+
+	if v.logger != nil {
+		v.logger.Info("Configuring token verifier",
+			"issuer URL", v.issuerURL,
+			"client ID", v.clientID)
+	}
+	v.verifier = provider.Verifier(v.oidcConfig)
+	if v.logger != nil {
+		v.logger.Info("Token verifier is ready")
+	}
+	return nil
+}
+
+// ExtractBearerToken extracts a bearer token from an Authorization header
+func ExtractBearerToken(authHeader string) (string, error) {
+	if authHeader == "" {
+		return "", errors.New("authorization header is empty")
+	}
+
+	if !strings.HasPrefix(authHeader, OIDCAuthHeaderPrefix) {
+		return "", errors.New("authorization header is not a bearer token")
+	}
+
+	token := strings.TrimPrefix(authHeader, OIDCAuthHeaderPrefix)
+	if token == "" {
+		return "", errors.New("bearer token is empty")
+	}
+
+	return token, nil
+}
+
+// VerifyToken verifies an OIDC token and returns Claims, isFault, error.
+// It may call the provider to refresh the public keySet if not cached
+func (v *OIDCVerifier) VerifyToken(ctx context.Context, tokenString string, logger *slog.Logger) (*OIDCClaims, bool, error) {
+	if v.verifier == nil {
+		return nil, true, fmt.Errorf("OIDC verifier is not initialized - call Start() first")
+	}
+
+	// Verify the token
+	idToken, err := v.verifier.Verify(ctx, tokenString)
+	if err != nil {
+		// Check if this is a discovery document error
+		errMsg := err.Error()
+		if strings.Contains(errMsg, "failed to get discovery document") ||
+			errors.Is(err, context.DeadlineExceeded) ||
+			errors.Is(err, context.Canceled) {
+			return nil, true, fmt.Errorf("failed to connect to OIDC provider: %w", err)
+		}
+
+		// All other errors are likely token validation errors
+		return nil, false, fmt.Errorf("invalid ID token: %w", err)
+	}
+
+	// Extract claims from the token
+	var claims OIDCClaims
+
+	// Log the response from Dex for debugging
+	logger.Info("Received verified token from Dex",
+		"issuer", idToken.Issuer,
+		"subject", idToken.Subject,
+		"audience", idToken.Audience,
+		"expiration", idToken.Expiry,
+		"issued_at", idToken.IssuedAt)
+
+	if err := idToken.Claims(&claims); err != nil {
+		return nil, false, fmt.Errorf("failed to parse claims: %w", err)
+	}
+
+	// Log detailed claims information to help verify correct parsing in production
+	// This is especially useful when integrating with Dex using GitHub connector
+	if logger.Enabled(context.Background(), slog.LevelDebug) {
+		logger.Debug("Successfully parsed OIDC claims",
+			"username_claim", claims.Username,
+			"email_claim", claims.Email,
+			"subject_format", claims.Subject,
+			"groups_count", len(claims.Groups),
+			"has_groups", len(claims.Groups) > 0,
+		)
+
+		// Log group format examples to help diagnose GitHub org/team format issues
+		if len(claims.Groups) > 0 {
+			groupSamples := claims.Groups
+			if len(groupSamples) > 3 {
+				groupSamples = groupSamples[:3] // Limit to first 3 groups to avoid log spam
+			}
+			logger.Debug("Group format examples",
+				"group_samples", strings.Join(groupSamples, ", "),
+			)
+		}
+
+		// Log any extra fields that might be useful for debugging
+		if len(claims.ExtraClaimsField) > 0 {
+			extraClaimKeys := make([]string, 0, len(claims.ExtraClaimsField))
+			for k := range claims.ExtraClaimsField {
+				extraClaimKeys = append(extraClaimKeys, k)
+			}
+			logger.Debug("Extra claims present",
+				"extra_claim_keys", strings.Join(extraClaimKeys, ", "),
+			)
+		}
+	}
+
+	return &claims, false, nil
+}
+
+// GetOIDCGroupsFromToken extracts and formats group names from OIDC claims
+func GetOIDCGroupsFromToken(config *Config, claims *OIDCClaims) []string {
+	if claims == nil || len(claims.Groups) == 0 {
+		return []string{}
+	}
+	return GetOidcGroups(config, claims.Groups)
+}
+
+// GetOIDCUsernameFromToken extracts and formats the username from OIDC claims
+func GetOIDCUsernameFromToken(config *Config, claims *OIDCClaims) string {
+	if claims == nil || claims.Username == "" {
+		return ""
+	}
+	return GetOidcUsername(config, claims.Username)
+}

--- a/internal/authmiddleware/oidc_verifier_test.go
+++ b/internal/authmiddleware/oidc_verifier_test.go
@@ -1,0 +1,326 @@
+package authmiddleware
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOIDCClaimsParsingFromGitHub tests that the OIDCClaims struct
+// correctly parses tokens from Dex with GitHub connector
+func TestOIDCClaimsParsingFromGitHub(t *testing.T) {
+	t.Run("Default GitHub ID format", func(t *testing.T) {
+		testOIDCClaimsParsingFromGitHub(t, "CgcyMzQ1Njc4EgZnaXRodWI") // Dex's default format with GitHub ID
+	})
+
+	t.Run("Using login as ID", func(t *testing.T) {
+		testOIDCClaimsParsingFromGitHub(t, "github|github-user") // Format when useLoginAsID is true
+	})
+}
+
+// testOIDCClaimsParsingFromGitHub is a helper function to test parsing tokens
+// with different subject formats
+func testOIDCClaimsParsingFromGitHub(t *testing.T, subject string) {
+	// Create a sample raw token claims as they would come from Dex with GitHub connector
+	// This simulates the JSON payload inside a JWT token from Dex
+	rawClaims := map[string]interface{}{
+		"iss":                "https://example.com/dex",
+		"sub":                subject, // Subject format passed from the test case
+		"aud":                "authmiddleware-client",
+		"exp":                time.Now().Add(1 * time.Hour).Unix(),
+		"iat":                time.Now().Unix(),
+		"nonce":              "abcdefghijklmnop",
+		"preferred_username": "github-user", // GitHub username
+		"email":              "user@github.com",
+		"groups": []string{
+			"org1:team1",
+			"org1:team2",
+			"org2:admins",
+		},
+		"name": "GitHub User", // Additional claim not explicitly in our struct
+	}
+
+	// Create a mock token with these claims
+	rawClaimsJSON, err := json.Marshal(rawClaims)
+	require.NoError(t, err)
+
+	// Test parsing these claims into our OIDCClaims struct
+	var claims OIDCClaims
+	err = json.Unmarshal(rawClaimsJSON, &claims)
+	require.NoError(t, err)
+
+	// Verify that each field was parsed correctly
+	assert.Equal(t, "github-user", claims.Username)
+	assert.Equal(t, "user@github.com", claims.Email)
+	assert.Equal(t, subject, claims.Subject)
+
+	// Verify groups are parsed correctly
+	assert.Len(t, claims.Groups, 3)
+	assert.Contains(t, claims.Groups, "org1:team1")
+	assert.Contains(t, claims.Groups, "org1:team2")
+	assert.Contains(t, claims.Groups, "org2:admins")
+
+	// Test that GetOIDCGroupsFromToken correctly processes GitHub groups
+	config := &Config{
+		OidcGroupsPrefix: "oidc-github:", // Sample prefix for testing
+	}
+
+	groups := GetOIDCGroupsFromToken(config, &claims)
+
+	// Verify that the prefix is correctly applied
+	assert.Len(t, groups, 3)
+	assert.Contains(t, groups, "oidc-github:org1:team1")
+	assert.Contains(t, groups, "oidc-github:org1:team2")
+	assert.Contains(t, groups, "oidc-github:org2:admins")
+
+	// Test username extraction
+	username := GetOIDCUsernameFromToken(config, &claims)
+	assert.Equal(t, "github-user", username)
+}
+
+// TestOIDCVerifierWithGitHubToken tests the full token verification flow
+// with a simulated GitHub token from Dex
+func TestOIDCVerifierWithGitHubToken(t *testing.T) {
+	// Test both ID formats
+	testSubjects := []string{
+		"CgcyMzQ1Njc4EgZnaXRodWI", // Default GitHub ID format
+		"github|github-user",      // When useLoginAsID is true
+	}
+
+	for _, subject := range testSubjects {
+		t.Run("Subject format: "+subject, func(t *testing.T) {
+			testOIDCVerifierWithSubject(t, subject)
+		})
+	}
+}
+
+// testOIDCVerifierWithSubject is a helper function to test verification with different subjects
+func testOIDCVerifierWithSubject(t *testing.T, subject string) {
+	// This test requires mocking the OIDC provider and verifier
+	// which is complex due to the nature of token verification
+	// Instead, let's test the claims parsing part which is the critical part
+
+	// Create a mock OIDCVerifier with a mock verifier that returns our test claims
+	mockVerifier := &MockOIDCVerifier{
+		VerifyTokenFunc: func(ctx context.Context, tokenString string, logger *slog.Logger) (*OIDCClaims, bool, error) {
+			return &OIDCClaims{
+				Username: "github-user",
+				Email:    "user@github.com",
+				Subject:  subject,
+				Groups: []string{
+					"org1:team1",
+					"org1:team2",
+					"org2:admins",
+				},
+				ExtraClaimsField: map[string]any{
+					"name": "GitHub User",
+				},
+			}, false, nil
+		},
+	}
+
+	// Test the verification
+	claims, isFault, err := mockVerifier.VerifyToken(context.Background(), "fake.jwt.token", slog.Default())
+
+	// Verify results
+	assert.NoError(t, err)
+	assert.False(t, isFault)
+	assert.NotNil(t, claims)
+	assert.Equal(t, "github-user", claims.Username)
+	assert.Equal(t, "user@github.com", claims.Email)
+	assert.Len(t, claims.Groups, 3)
+}
+
+// TestOIDCVerifierConfig tests the configuration of the OIDCVerifier
+func TestOIDCVerifierConfig(t *testing.T) {
+	// Create a comprehensive config to test all values
+	config := &Config{
+		OIDCIssuerURL:       "https://example.com/dex",
+		OIDCClientID:        "authmiddleware",
+		OIDCClientSecret:    "test-secret",
+		OIDCInitTimeoutSecs: 30,
+	}
+
+	// Create the verifier
+	verifier, err := NewOIDCVerifier(config, slog.Default())
+	require.NoError(t, err)
+	require.NotNil(t, verifier)
+
+	// 1. Test that all config values are correctly passed
+	assert.Equal(t, config.OIDCIssuerURL, verifier.issuerURL)
+	assert.Equal(t, config.OIDCClientID, verifier.clientID)
+	assert.Equal(t, config.OIDCClientSecret, verifier.clientSecret)
+	assert.Equal(t, config.OIDCInitTimeoutSecs, verifier.timeoutSeconds)
+
+	// 2. Test that provider and verifier are nil after NewOIDCVerifier
+	assert.Nil(t, verifier.provider, "Provider should be nil after initialization")
+	assert.Nil(t, verifier.verifier, "Verifier should be nil after initialization")
+
+	// 3. Assert that oidcConfig is properly set
+	require.NotNil(t, verifier.oidcConfig)
+	assert.Equal(t, config.OIDCClientID, verifier.oidcConfig.ClientID)
+	assert.True(t, verifier.oidcConfig.SkipClientIDCheck,
+		"OIDCVerifier should have SkipClientIDCheck set to true to allow audience mismatches")
+}
+
+// TestExtractBearerToken tests the ExtractBearerToken function with various inputs
+func TestExtractBearerToken(t *testing.T) {
+	tests := []struct {
+		name        string
+		authHeader  string
+		expected    string
+		expectError bool
+	}{
+		{
+			name:        "Valid bearer token",
+			authHeader:  "Bearer abc123.def456.ghi789",
+			expected:    "abc123.def456.ghi789",
+			expectError: false,
+		},
+		{
+			name:        "Empty auth header",
+			authHeader:  "",
+			expected:    "",
+			expectError: true,
+		},
+		{
+			name:        "Not a bearer token",
+			authHeader:  "Basic dXNlcm5hbWU6cGFzc3dvcmQ=",
+			expected:    "",
+			expectError: true,
+		},
+		{
+			name:        "Bearer prefix without token",
+			authHeader:  "Bearer ",
+			expected:    "",
+			expectError: true,
+		},
+		{
+			name:        "Wrong case in bearer prefix",
+			authHeader:  "bearer abc123.def456.ghi789",
+			expected:    "",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			token, err := ExtractBearerToken(tt.authHeader)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Empty(t, token)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, token)
+			}
+		})
+	}
+}
+
+// TestGetOIDCGroupsFromToken tests the GetOIDCGroupsFromToken function
+func TestGetOIDCGroupsFromToken(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   *Config
+		claims   *OIDCClaims
+		expected []string
+	}{
+		{
+			name: "Normal groups",
+			config: &Config{
+				OidcGroupsPrefix: "oidc:",
+			},
+			claims: &OIDCClaims{
+				Groups: []string{"admin", "dev", "user"},
+			},
+			expected: []string{"oidc:admin", "oidc:dev", "oidc:user"},
+		},
+		{
+			name: "Empty groups",
+			config: &Config{
+				OidcGroupsPrefix: "oidc:",
+			},
+			claims: &OIDCClaims{
+				Groups: []string{},
+			},
+			expected: []string{},
+		},
+		{
+			name: "Nil claims",
+			config: &Config{
+				OidcGroupsPrefix: "oidc:",
+			},
+			claims:   nil,
+			expected: []string{},
+		},
+		{
+			name: "System groups",
+			config: &Config{
+				OidcGroupsPrefix: "github:",
+			},
+			claims: &OIDCClaims{
+				Groups: []string{"system:authenticated", "org:team"},
+			},
+			expected: []string{"system:authenticated", "github:org:team"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetOIDCGroupsFromToken(tt.config, tt.claims)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// TestGetOIDCUsernameFromToken tests the GetOIDCUsernameFromToken function
+func TestGetOIDCUsernameFromToken(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   *Config
+		claims   *OIDCClaims
+		expected string
+	}{
+		{
+			name: "Normal username",
+			config: &Config{
+				OidcUsernamePrefix: "oidc:",
+			},
+			claims: &OIDCClaims{
+				Username: "johndoe",
+			},
+			expected: "oidc:johndoe",
+		},
+		{
+			name: "Empty username",
+			config: &Config{
+				OidcUsernamePrefix: "oidc:",
+			},
+			claims: &OIDCClaims{
+				Username: "",
+			},
+			expected: "",
+		},
+		{
+			name: "Nil claims",
+			config: &Config{
+				OidcUsernamePrefix: "oidc:",
+			},
+			claims:   nil,
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetOIDCUsernameFromToken(tt.config, tt.claims)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/internal/authmiddleware/oidc_verifier_test.go
+++ b/internal/authmiddleware/oidc_verifier_test.go
@@ -141,8 +141,7 @@ func TestOIDCVerifierConfig(t *testing.T) {
 	// Create a comprehensive config to test all values
 	config := &Config{
 		OIDCIssuerURL:       "https://example.com/dex",
-		OIDCClientID:        "authmiddleware",
-		OIDCClientSecret:    "test-secret",
+		OIDCClientID:        "oauth2-proxy",
 		OIDCInitTimeoutSecs: 30,
 	}
 
@@ -154,7 +153,6 @@ func TestOIDCVerifierConfig(t *testing.T) {
 	// 1. Test that all config values are correctly passed
 	assert.Equal(t, config.OIDCIssuerURL, verifier.issuerURL)
 	assert.Equal(t, config.OIDCClientID, verifier.clientID)
-	assert.Equal(t, config.OIDCClientSecret, verifier.clientSecret)
 	assert.Equal(t, config.OIDCInitTimeoutSecs, verifier.timeoutSeconds)
 
 	// 2. Test that provider and verifier are nil after NewOIDCVerifier
@@ -164,8 +162,8 @@ func TestOIDCVerifierConfig(t *testing.T) {
 	// 3. Assert that oidcConfig is properly set
 	require.NotNil(t, verifier.oidcConfig)
 	assert.Equal(t, config.OIDCClientID, verifier.oidcConfig.ClientID)
-	assert.True(t, verifier.oidcConfig.SkipClientIDCheck,
-		"OIDCVerifier should have SkipClientIDCheck set to true to allow audience mismatches")
+	assert.False(t, verifier.oidcConfig.SkipClientIDCheck,
+		"OIDCVerifier should enforce audience validation")
 }
 
 // TestGetOIDCGroupsFromToken tests the GetOIDCGroupsFromToken function

--- a/internal/authmiddleware/oidc_verifier_test.go
+++ b/internal/authmiddleware/oidc_verifier_test.go
@@ -168,61 +168,6 @@ func TestOIDCVerifierConfig(t *testing.T) {
 		"OIDCVerifier should have SkipClientIDCheck set to true to allow audience mismatches")
 }
 
-// TestExtractBearerToken tests the ExtractBearerToken function with various inputs
-func TestExtractBearerToken(t *testing.T) {
-	tests := []struct {
-		name        string
-		authHeader  string
-		expected    string
-		expectError bool
-	}{
-		{
-			name:        "Valid bearer token",
-			authHeader:  "Bearer abc123.def456.ghi789",
-			expected:    "abc123.def456.ghi789",
-			expectError: false,
-		},
-		{
-			name:        "Empty auth header",
-			authHeader:  "",
-			expected:    "",
-			expectError: true,
-		},
-		{
-			name:        "Not a bearer token",
-			authHeader:  "Basic dXNlcm5hbWU6cGFzc3dvcmQ=",
-			expected:    "",
-			expectError: true,
-		},
-		{
-			name:        "Bearer prefix without token",
-			authHeader:  "Bearer ",
-			expected:    "",
-			expectError: true,
-		},
-		{
-			name:        "Wrong case in bearer prefix",
-			authHeader:  "bearer abc123.def456.ghi789",
-			expected:    "",
-			expectError: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			token, err := ExtractBearerToken(tt.authHeader)
-
-			if tt.expectError {
-				assert.Error(t, err)
-				assert.Empty(t, token)
-			} else {
-				assert.NoError(t, err)
-				assert.Equal(t, tt.expected, token)
-			}
-		})
-	}
-}
-
 // TestGetOIDCGroupsFromToken tests the GetOIDCGroupsFromToken function
 func TestGetOIDCGroupsFromToken(t *testing.T) {
 	tests := []struct {

--- a/internal/authmiddleware/server_test.go
+++ b/internal/authmiddleware/server_test.go
@@ -1,6 +1,7 @@
 package authmiddleware
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"log/slog"
@@ -231,6 +232,216 @@ func TestServerTerminatesOnSIGINT(t *testing.T) {
 	}
 }
 
+func TestServerStarts_RetrievesKeySetFromOIDCProvider_WhenOauthIsEnabled(t *testing.T) {
+	t.Run("successful OIDC initialization", func(t *testing.T) {
+		// Create a test logger that captures logs
+		var logBuffer strings.Builder
+		logger := slog.New(slog.NewTextHandler(&logBuffer, nil))
+
+		// Create config with OAuth enabled
+		config := &Config{
+			Port:             0, // Use random port to avoid conflicts
+			ReadTimeout:      1 * time.Second,
+			WriteTimeout:     1 * time.Second,
+			ShutdownTimeout:  1 * time.Second,
+			PathRegexPattern: DefaultPathRegexPattern,
+			JWTSigningKey:    "test-key",
+			EnableOAuth:      true,
+			OIDCIssuerURL:    "https://test-issuer.example.com",
+			OIDCClientID:     "test-client-id",
+			OidcGroupsPrefix: "test-prefix:",
+		}
+
+		// Track if Start() was called on the OIDC verifier
+		startCalled := false
+
+		// Create a mock OIDC verifier that tracks if Start was called
+		mockOIDCVerifier := &MockOIDCVerifier{
+			StartFunc: func(ctx context.Context) error {
+				startCalled = true
+				return nil // Success case
+			},
+		}
+
+		// Create mocks for other components
+		jwtHandler := &MockJWTHandler{}
+		cookieHandler := &MockCookieHandler{}
+
+		// Create server with the mock OIDC verifier
+		server := NewServer(config, jwtHandler, cookieHandler, logger)
+
+		// Replace the server's OIDC verifier with our mock
+		// We need to do this because NewServer initializes its own OIDC verifier
+		server.oidcVerifier = mockOIDCVerifier
+
+		// Start server in a goroutine
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- server.Start()
+		}()
+
+		// Give the server a moment to start and initialize
+		time.Sleep(200 * time.Millisecond)
+
+		// Define cleanup to ensure server is always stopped
+		defer func() {
+			// Trigger shutdown by sending signal
+			p, err := os.FindProcess(os.Getpid())
+			if err == nil {
+				_ = p.Signal(syscall.SIGINT)
+			}
+
+			// Wait for server to shut down (with timeout)
+			select {
+			case err := <-errCh:
+				// If we're still getting the error here, it means the server started
+				// successfully (otherwise it would have returned immediately)
+				if err != nil && !strings.Contains(err.Error(), "server closed") {
+					t.Errorf("Server did not shut down gracefully: %v", err)
+				}
+			case <-time.After(2 * time.Second):
+				t.Log("Warning: Server did not shut down within expected time")
+			}
+		}()
+
+		// Verify that Start() was called on the OIDC verifier
+		if !startCalled {
+			t.Error("OIDC verifier Start() method was not called when OAuth is enabled")
+		}
+
+		// Check that no error was sent to the error channel immediately
+		select {
+		case err := <-errCh:
+			t.Errorf("Server failed to start: %v", err)
+		default:
+			// No error means server started successfully
+		}
+	})
+
+	t.Run("OIDC initialization failure", func(t *testing.T) {
+		// Create a test logger that captures logs
+		var logBuffer strings.Builder
+		logger := slog.New(slog.NewTextHandler(&logBuffer, nil))
+
+		// Create config with OAuth enabled
+		config := &Config{
+			Port:             0, // Use random port to avoid conflicts
+			ReadTimeout:      1 * time.Second,
+			WriteTimeout:     1 * time.Second,
+			ShutdownTimeout:  1 * time.Second,
+			PathRegexPattern: DefaultPathRegexPattern,
+			JWTSigningKey:    "test-key",
+			EnableOAuth:      true,
+			OIDCIssuerURL:    "https://test-issuer.example.com",
+			OIDCClientID:     "test-client-id",
+			OidcGroupsPrefix: "test-prefix:",
+		}
+
+		// Create a mock OIDC verifier that returns an error from Start()
+		mockOIDCVerifier := &MockOIDCVerifier{
+			StartFunc: func(ctx context.Context) error {
+				return fmt.Errorf("simulated OIDC provider connection failure")
+			},
+		}
+
+		// Create mocks for other components
+		jwtHandler := &MockJWTHandler{}
+		cookieHandler := &MockCookieHandler{}
+
+		// Create server with the mock OIDC verifier
+		server := NewServer(config, jwtHandler, cookieHandler, logger)
+
+		// Replace the server's OIDC verifier with our mock
+		server.oidcVerifier = mockOIDCVerifier
+
+		// Start server directly (not in goroutine) since we expect an immediate error
+		err := server.Start()
+
+		// Verify that the server failed to start due to OIDC error
+		if err == nil {
+			t.Error("Server started successfully despite OIDC verification failure")
+		} else if !strings.Contains(err.Error(), "failed to start OIDC verifier") {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	})
+}
+
+func TestServerStarts_DoesNotCallOIDCProvier_WhenOauthIsDisabled(t *testing.T) {
+	// Create a test logger that captures logs
+	var logBuffer strings.Builder
+	logger := slog.New(slog.NewTextHandler(&logBuffer, nil))
+
+	// Create config with OAuth disabled but with OIDC config present
+	config := &Config{
+		Port:             0, // Use random port to avoid conflicts
+		ReadTimeout:      1 * time.Second,
+		WriteTimeout:     1 * time.Second,
+		ShutdownTimeout:  1 * time.Second,
+		PathRegexPattern: DefaultPathRegexPattern,
+		JWTSigningKey:    "test-key",
+		EnableOAuth:      false,                             // This is the important part - OAuth is disabled
+		OIDCIssuerURL:    "https://test-issuer.example.com", // Still has OIDC config
+		OIDCClientID:     "test-client-id",
+		OidcGroupsPrefix: "test-prefix:",
+	}
+
+	// Track if Start() was incorrectly called on the OIDC verifier
+	startCalled := false
+
+	// Create a mock OIDC verifier that tracks if Start was called
+	mockOIDCVerifier := &MockOIDCVerifier{
+		StartFunc: func(ctx context.Context) error {
+			startCalled = true // This should not happen in this test
+			return nil
+		},
+	}
+
+	// Create mocks for other components
+	jwtHandler := &MockJWTHandler{}
+	cookieHandler := &MockCookieHandler{}
+
+	// Create server
+	server := NewServer(config, jwtHandler, cookieHandler, logger)
+
+	// In this test case, the server should not initialize the OIDC verifier at all
+	// since OAuth is disabled. So we'll check that server.oidcVerifier is nil after
+	// creating the server.
+
+	// We'll also manually set it just to ensure no calls happen to it during Start()
+	server.oidcVerifier = mockOIDCVerifier
+
+	// Start server in a goroutine
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- server.Start()
+	}()
+
+	// Give the server a moment to start and initialize
+	time.Sleep(200 * time.Millisecond)
+
+	// Define cleanup to ensure server is always stopped
+	defer func() {
+		// Trigger shutdown by sending signal
+		p, err := os.FindProcess(os.Getpid())
+		if err == nil {
+			_ = p.Signal(syscall.SIGINT)
+		}
+
+		// Wait for server to shut down (with timeout)
+		select {
+		case <-errCh:
+			// Server shut down successfully
+		case <-time.After(2 * time.Second):
+			t.Log("Warning: Server did not shut down within expected time")
+		}
+	}()
+
+	// Verify that Start() was not called on the OIDC verifier
+	if startCalled {
+		t.Error("OIDC verifier Start() method was incorrectly called when OAuth is disabled")
+	}
+}
+
 // TestServerTerminatesOnSIGTERM tests that the server terminates when receiving SIGTERM
 func TestServerTerminatesOnSIGTERM(t *testing.T) {
 	// Skip in short mode as it involves timing and signals
@@ -383,7 +594,20 @@ func TestServerLogsAnErrorIfClientInstantiationFails(t *testing.T) {
 	req.Header.Set("X-Auth-Request-Groups", "group1")
 	req.Header.Set("X-Forwarded-Uri", testAppPath)
 	req.Header.Set("X-Forwarded-Host", "example.com")
+	req.Header.Set("Authorization", "Bearer mock-token") // Add Authorization header for OIDC
 	w := httptest.NewRecorder()
+
+	// Set up OIDC verifier with matching username
+	server.oidcVerifier = &MockOIDCVerifier{
+		VerifyTokenFunc: func(ctx context.Context, tokenString string, logger *slog.Logger) (*OIDCClaims, bool, error) {
+			claims := &OIDCClaims{
+				Subject:  "test-user",
+				Username: "test-user",
+				Groups:   []string{"group1"},
+			}
+			return claims, false, nil
+		},
+	}
 
 	// Explicitly set restClient to nil for this test
 	server.restClient = nil

--- a/internal/authmiddleware/serverroute_auth.go
+++ b/internal/authmiddleware/serverroute_auth.go
@@ -15,24 +15,20 @@ func (s *Server) handleAuth(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get headers from request
-	user := r.Header.Get(HeaderAuthRequestUser)
-	preferredUsername := r.Header.Get(HeaderAuthRequestPreferredUsername)
-	groups := r.Header.Get(HeaderAuthRequestGroups)
 	fullPath := r.Header.Get(HeaderForwardedURI)
 	host := r.Header.Get(HeaderForwardedHost)
+	authHeader := r.Header.Get("Authorization")
+
+	// Get headers for verification with OIDC claims
+	headerUID := r.Header.Get(HeaderAuthRequestUser)
+	headerPreferredUsername := GetOidcUsername(s.config, r.Header.Get(HeaderAuthRequestPreferredUsername))
+	headerGroups := GetOidcGroups(s.config, splitGroups(r.Header.Get(HeaderAuthRequestGroups)))
 
 	// Extract base app path for JWT authorization
 	appPath := ExtractAppPath(fullPath, s.config.PathRegexPattern)
 	s.logger.Debug("Extracted app path for authorization", "full_path", fullPath, "app_path", appPath)
 
 	// Validate required headers
-	if user == "" {
-		http.Error(w, "Missing "+HeaderAuthRequestUser+" header", http.StatusBadRequest)
-		return
-	}
-
-	// Allow Groups header to be empty (user may not belong to any group)
-
 	if fullPath == "" {
 		http.Error(w, "Missing "+HeaderForwardedURI+" header", http.StatusBadRequest)
 		return
@@ -43,10 +39,76 @@ func (s *Server) handleAuth(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Determine k8s username
-	k8sUID := user
-	k8sUsername := GetOidcUsername(s.config, preferredUsername)
-	k8sGroups := GetOidcGroups(s.config, splitGroups(groups))
+	// Authorization is required
+	if authHeader == "" {
+		s.logger.Error("Missing Authorization header")
+		http.Error(w, "Missing Authorization header", http.StatusUnauthorized)
+		return
+	}
+
+	// OIDCVerifier should always be initialized when /auth is enabled
+	if s.oidcVerifier == nil {
+		s.logger.Error("OIDC verifier is not initialized")
+		http.Error(w, "Internal server error: OIDC verifier not initialized", http.StatusInternalServerError)
+		return
+	}
+
+	// Extract token from Authorization header
+	token, err := ExtractBearerToken(authHeader)
+	if err != nil {
+		s.logger.Error("Failed to extract bearer token", "error", err)
+		http.Error(w, "Invalid Authorization header", http.StatusBadRequest)
+		return
+	}
+
+	// Verify the token with the OIDC provider
+	oidcClaims, isVerifyTokenFault, err := s.oidcVerifier.VerifyToken(r.Context(), token, s.logger)
+	if err != nil {
+		if isVerifyTokenFault {
+			// Server-side error (e.g., OIDC provider unavailable)
+			s.logger.Error("OIDC provider connection error", "error", err)
+			http.Error(w, "Internal server error: OIDC provider not available", http.StatusInternalServerError)
+			return
+		}
+
+		// Otherwise the token is invalid, reject with 400
+		s.logger.Error("OIDC token validation error", "error", err)
+		http.Error(w, "Invalid or expired OIDC token", http.StatusForbidden)
+		return
+	}
+
+	// Set the user identity variables from the OIDC token
+	k8sUID := oidcClaims.Subject
+	k8sUsername := GetOIDCUsernameFromToken(s.config, oidcClaims)
+	k8sGroups := GetOIDCGroupsFromToken(s.config, oidcClaims)
+
+	// Verify preferred username in header if available
+	if headerPreferredUsername != "" && k8sUsername != headerPreferredUsername {
+		s.logger.Error("Preferred username mismatch between token and headers",
+			"token preferred username", k8sUsername,
+			"header preferred username", headerPreferredUsername)
+		http.Error(w, "Username mismatch between token and headers", http.StatusUnauthorized)
+		return
+	}
+
+	// Verify UID in header if available
+	if headerUID != "" && k8sUID != headerUID {
+		s.logger.Error("UID mismatch between token and headers",
+			"token UID", k8sUID,
+			"header UID", headerUID)
+		http.Error(w, "UID verification failed", http.StatusUnauthorized)
+		return
+	}
+
+	// Verify groups in header if available
+	if len(headerGroups) > 0 {
+		ok, missingGroups := EnsureSubsetOf(headerGroups, k8sGroups)
+		if !ok {
+			s.logger.Error("Groups mismatch between token and headers", "missing groups in token", missingGroups)
+			http.Error(w, "Groups verification failed", http.StatusUnauthorized)
+			return
+		}
+	}
 
 	// Check workspace access permission
 	// and the Kubernetes REST client is available
@@ -56,58 +118,56 @@ func (s *Server) handleAuth(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if s.restClient != nil {
-		// Verify workspace access using the new extracted function
-		connectionAccessReviewResult, workspaceInfo, err := s.VerifyWorkspaceAccess(
-			r.Context(),
-			r,
-			k8sUsername,
-			k8sGroups,
-			k8sUID,
-			nil, // we cannot retrieve user.Info.GetExtra() in oauth flow
-		)
+	// Verify workspace access using the new extracted function
+	connectionAccessReviewResult, workspaceInfo, err := s.VerifyWorkspaceAccess(
+		r.Context(),
+		r,
+		k8sUsername,
+		k8sGroups,
+		k8sUID,
+		nil, // we cannot retrieve user.Info.GetExtra() in oauth flow
+	)
 
-		if err != nil {
-			s.logger.Error("Failed to verify workspace access", "error", err, "path", appPath)
-			http.Error(w, "Failed to verify workspace access", http.StatusInternalServerError)
-			return
-		}
+	if err != nil {
+		s.logger.Error("Failed to verify workspace access", "error", err, "path", appPath)
+		http.Error(w, "Failed to verify workspace access", http.StatusInternalServerError)
+		return
+	}
 
-		allowed := connectionAccessReviewResult.Allowed
-		notFound := connectionAccessReviewResult.NotFound
+	allowed := connectionAccessReviewResult.Allowed
+	notFound := connectionAccessReviewResult.NotFound
 
-		if !allowed || notFound {
-			s.logger.Info("Workspace connection refused",
-				"username", k8sUsername,
-				"workspace", workspaceInfo.Name,
-				"namespace", workspaceInfo.Namespace,
-				"workspaceNotFound", connectionAccessReviewResult.NotFound,
-				"reason", connectionAccessReviewResult.Reason,
-			)
-
-			// Workspace was not found maps to Access denied error.
-			// If the workspace does not exist, we cannot know whether the user would have access
-			// given such decision depends on a/ the Workspace.Spec.AccessType, b/ whether the user
-			// is the owner of the Workspace, c/ when we support peer-to-peer sharing, whether the
-			// owner shared their workspace to the user or one of the group they belong to.
-
-			// Note: if the Workspace is in Stopped state, we could trigger an automatic restart
-			// when a user makes an authorized connection request. However, we should use a different
-			// route of the authmiddleware and use a redirect (possibly '/restart')
-			http.Error(w, "Access denied: you are not authorized to connect to this workspace", http.StatusForbidden)
-			return
-		}
-
-		s.logger.Info("Connection to the workspace granted",
+	if !allowed || notFound {
+		s.logger.Info("Workspace connection refused",
 			"username", k8sUsername,
 			"workspace", workspaceInfo.Name,
 			"namespace", workspaceInfo.Namespace,
+			"workspaceNotFound", connectionAccessReviewResult.NotFound,
 			"reason", connectionAccessReviewResult.Reason,
 		)
+
+		// Workspace was not found maps to Access denied error.
+		// If the workspace does not exist, we cannot know whether the user would have access
+		// given such decision depends on a/ the Workspace.Spec.AccessType, b/ whether the user
+		// is the owner of the Workspace, c/ when we support peer-to-peer sharing, whether the
+		// owner shared their workspace to the user or one of the group they belong to.
+
+		// Note: if the Workspace is in Stopped state, we could trigger an automatic restart
+		// when a user makes an authorized connection request. However, we should use a different
+		// route of the authmiddleware and use a redirect (possibly '/restart')
+		http.Error(w, "Access denied: you are not authorized to connect to this workspace", http.StatusForbidden)
+		return
 	}
 
+	s.logger.Info("Connection to the workspace granted",
+		"username", k8sUsername,
+		"workspace", workspaceInfo.Name,
+		"namespace", workspaceInfo.Namespace,
+		"reason", connectionAccessReviewResult.Reason,
+	)
+
 	// Generate JWT token with app path and domain for authorization scope
-	token, err := s.jwtManager.GenerateToken(k8sUsername, k8sGroups, k8sUID, nil, appPath, host, jwt.TokenTypeSession)
+	jwtToken, err := s.jwtManager.GenerateToken(k8sUsername, k8sGroups, k8sUID, nil, appPath, host, jwt.TokenTypeSession)
 	if err != nil {
 		s.logger.Error("Failed to generate token", "error", err)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
@@ -115,14 +175,14 @@ func (s *Server) handleAuth(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Set cookie using appPath and same domain as JWT token
-	s.cookieManager.SetCookie(w, token, appPath, host)
+	s.cookieManager.SetCookie(w, jwtToken, appPath, host)
 
 	// Create empty response
 	response := map[string]string{}
 
 	// Log successful connection
 	s.logger.Info("Connection successful",
-		"user", user,
+		"user", k8sUID,
 		"username", k8sUsername,
 		"path", appPath,
 		"groups", k8sGroups)

--- a/internal/authmiddleware/serverroute_auth.go
+++ b/internal/authmiddleware/serverroute_auth.go
@@ -17,7 +17,7 @@ func (s *Server) handleAuth(w http.ResponseWriter, r *http.Request) {
 	// Get headers from request
 	fullPath := r.Header.Get(HeaderForwardedURI)
 	host := r.Header.Get(HeaderForwardedHost)
-	authHeader := r.Header.Get("Authorization")
+	authHeader := r.Header.Get(HeaderAuthorization)
 
 	// Get headers for verification with OIDC claims
 	headerUID := r.Header.Get(HeaderAuthRequestUser)

--- a/internal/authmiddleware/utils.go
+++ b/internal/authmiddleware/utils.go
@@ -111,3 +111,27 @@ func splitString(s, sep string) []string {
 	result = append(result, string(parts[last:]))
 	return result
 }
+
+// EnsureSubsetOf returns (true, []) if smallArray is subset of largeArray
+// (false, missingEntriesInLargeArray) otherwise.
+func EnsureSubsetOf(smallArray []string, largeArray []string) (bool, []string) {
+	if len(largeArray) == 0 && len(smallArray) > 0 {
+		return false, smallArray
+	} else if len(smallArray) == 0 {
+		return true, []string{}
+	}
+
+	set := make(map[string]bool)
+	for _, v := range largeArray {
+		set[v] = true
+	}
+
+	var missingEntries []string
+	for _, v := range smallArray {
+		if !set[v] {
+			missingEntries = append(missingEntries, v)
+		}
+	}
+
+	return len(missingEntries) == 0, missingEntries
+}

--- a/test/helm/guided-aws-traefik-dex/oidc_consistency_test.go
+++ b/test/helm/guided-aws-traefik-dex/oidc_consistency_test.go
@@ -1,0 +1,232 @@
+package aws_traefik_dex_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("OIDC Configuration Consistency", func() {
+	var (
+		rootDir            string
+		testOutputDir      string
+		dexConfigmapData   []byte
+		authMiddlewareData []byte
+		oauth2ProxyData    []byte
+		secretsData        []byte
+
+		// Dex configmap values
+		dexIssuerURL      string
+		dexRedirectURI    string
+		dexOAuth2ClientID string
+		dexOAuth2Secret   string
+		dexAuthMwClientID string
+		dexAuthMwSecret   string
+
+		// Authmiddleware values
+		authMwIssuerURL    string
+		authMwClientID     string
+		authMwClientSecret string
+
+		// OAuth2-proxy values
+		oauth2IssuerURL    string
+		oauth2RedirectURL  string
+		oauth2ClientID     string
+		oauth2ClientSecret string
+	)
+
+	BeforeEach(func() {
+		var err error
+		rootDir, err = filepath.Abs("../../..")
+		Expect(err).NotTo(HaveOccurred())
+
+		// Path to rendered test output
+		testOutputDir = filepath.Join(rootDir, "dist/test-output-guided/jupyter-k8s-aws-traefik-dex/templates")
+
+		// Read the necessary files
+		dexConfigmapPath := filepath.Join(testOutputDir, "dex/configmap.yaml")
+		dexConfigmapData, err = os.ReadFile(dexConfigmapPath)
+		Expect(err).NotTo(HaveOccurred(), "Failed to read dex configmap file")
+
+		authMiddlewarePath := filepath.Join(testOutputDir, "authmiddleware/deployment.yaml")
+		authMiddlewareData, err = os.ReadFile(authMiddlewarePath)
+		Expect(err).NotTo(HaveOccurred(), "Failed to read authmiddleware deployment file")
+
+		authMwSecretsPath := filepath.Join(testOutputDir, "authmiddleware/secrets.yaml")
+		secretsData, err = os.ReadFile(authMwSecretsPath)
+		Expect(err).NotTo(HaveOccurred(), "Failed to read authmiddleware secrets file")
+
+		oauth2ProxyPath := filepath.Join(testOutputDir, "oauth2-proxy/deployment.yaml")
+		oauth2ProxyData, err = os.ReadFile(oauth2ProxyPath)
+		Expect(err).NotTo(HaveOccurred(), "Failed to read oauth2-proxy deployment file")
+
+		// Extract values from dex configmap
+		dexConfigmapContent := string(dexConfigmapData)
+
+		// Extract issuer URL
+		matches := regexp.MustCompile(`(?m)^\s*issuer:\s*(.+)$`).FindStringSubmatch(dexConfigmapContent)
+		Expect(matches).To(HaveLen(2), "Could not find issuer URL in dex configmap")
+		dexIssuerURL = matches[1]
+		Expect(dexIssuerURL).NotTo(BeEmpty(), "Issuer URL in dex config is empty")
+		By(fmt.Sprintf("Extracted dex issuer URL: %s", dexIssuerURL))
+
+		// Extract redirectURI
+		matches = regexp.MustCompile(`(?m)redirectURIs:\s*\n\s*-\s*(.+)`).FindStringSubmatch(dexConfigmapContent)
+		Expect(matches).To(HaveLen(2), "Could not find redirectURI in dex configmap")
+		dexRedirectURI = matches[1]
+		Expect(dexRedirectURI).NotTo(BeEmpty(), "RedirectURI in dex configmap is empty")
+		By(fmt.Sprintf("Extracted dex redirectURI: %s", dexRedirectURI))
+
+		// Extract oauth2-proxy client ID
+		matches = regexp.MustCompile(`(?m)^\s*-\s*id:\s*(\S+)\s*\n\s*redirectURIs:`).FindStringSubmatch(dexConfigmapContent)
+		Expect(matches).To(HaveLen(2), "Could not find oauth2-proxy client ID in dex configmap")
+		dexOAuth2ClientID = matches[1]
+		Expect(dexOAuth2ClientID).NotTo(BeEmpty(), "oauth2-proxy client ID in dex configmap is empty")
+		By(fmt.Sprintf("Extracted oauth2-proxy client ID from dex: %s", dexOAuth2ClientID))
+
+		// Extract oauth2-proxy client secret
+		oauth2ProxySecretRegex := `(?m)^\s*name:\s*'OAuth2 Proxy'\s*\n\s*secret:\s*(\S+)`
+		matches = regexp.MustCompile(oauth2ProxySecretRegex).FindStringSubmatch(dexConfigmapContent)
+		Expect(matches).To(HaveLen(2), "Could not find oauth2-proxy secret in dex configmap")
+		dexOAuth2Secret = matches[1]
+		Expect(dexOAuth2Secret).NotTo(BeEmpty(), "oauth2-proxy secret in dex configmap is empty")
+		By(fmt.Sprintf("Extracted oauth2-proxy secret from dex: %s", dexOAuth2Secret))
+
+		// Extract authmiddleware client ID
+		authMwClientIDRegex := `(?m)^\s*-\s*id:\s*(\S+)\s*\n\s*name:\s*'Auth Middleware'`
+		matches = regexp.MustCompile(authMwClientIDRegex).FindStringSubmatch(dexConfigmapContent)
+		Expect(matches).To(HaveLen(2), "Could not find authmiddleware client ID in dex configmap")
+		dexAuthMwClientID = matches[1]
+		Expect(dexAuthMwClientID).NotTo(BeEmpty(), "authmiddleware client ID in dex configmap is empty")
+		By(fmt.Sprintf("Extracted authmiddleware client ID from dex: %s", dexAuthMwClientID))
+
+		// Extract authmiddleware client secret
+		authMwSecretRegex := `(?m)^\s*name:\s*'Auth Middleware'\s*\n\s*secret:\s*(\S+)`
+		matches = regexp.MustCompile(authMwSecretRegex).FindStringSubmatch(dexConfigmapContent)
+		Expect(matches).To(HaveLen(2), "Could not find authmiddleware secret in dex configmap")
+		dexAuthMwSecret = matches[1]
+		Expect(dexAuthMwSecret).NotTo(BeEmpty(), "authmiddleware secret in dex configmap is empty")
+		By(fmt.Sprintf("Extracted authmiddleware secret from dex: %s", dexAuthMwSecret))
+
+		// Extract values from oauth2-proxy deployment
+		oauth2ProxyContent := string(oauth2ProxyData)
+
+		// Extract oidc-issuer-url
+		matches = regexp.MustCompile(`(?m)^\s*-\s*--oidc-issuer-url=(.+)$`).FindStringSubmatch(oauth2ProxyContent)
+		Expect(matches).To(HaveLen(2), "Could not find --oidc-issuer-url in oauth2-proxy deployment")
+		oauth2IssuerURL = matches[1]
+		Expect(oauth2IssuerURL).NotTo(BeEmpty(), "--oidc-issuer-url in oauth2-proxy deployment is empty")
+		By(fmt.Sprintf("Extracted oauth2-proxy issuer URL: %s", oauth2IssuerURL))
+
+		// Extract redirect-url
+		matches = regexp.MustCompile(`(?m)^\s*-\s*--redirect-url=(.+)$`).FindStringSubmatch(oauth2ProxyContent)
+		Expect(matches).To(HaveLen(2), "Could not find --redirect-url in oauth2-proxy deployment")
+		oauth2RedirectURL = matches[1]
+		Expect(oauth2RedirectURL).NotTo(BeEmpty(), "--redirect-url in oauth2-proxy deployment is empty")
+		By(fmt.Sprintf("Extracted oauth2-proxy redirect URL: %s", oauth2RedirectURL))
+
+		// Extract oauth2-proxy client ID
+		matches = regexp.MustCompile(`(?m)^\s*-\s*--client-id=(.+)$`).FindStringSubmatch(oauth2ProxyContent)
+		Expect(matches).To(HaveLen(2), "Could not find --client-id in oauth2-proxy deployment")
+		oauth2ClientID = matches[1]
+		Expect(oauth2ClientID).NotTo(BeEmpty(), "--client-id in oauth2-proxy deployment is empty")
+		By(fmt.Sprintf("Extracted oauth2-proxy client ID: %s", oauth2ClientID))
+
+		// Extract oauth2-proxy client secret
+		matches = regexp.MustCompile(`(?m)^\s*-\s*--client-secret=(.+)$`).FindStringSubmatch(oauth2ProxyContent)
+		Expect(matches).To(HaveLen(2), "Could not find --client-secret in oauth2-proxy deployment")
+		oauth2ClientSecret = matches[1]
+		Expect(oauth2ClientSecret).NotTo(BeEmpty(), "--client-secret in oauth2-proxy deployment is empty")
+		By(fmt.Sprintf("Extracted oauth2-proxy client secret: %s", oauth2ClientSecret))
+
+		// Extract values from authmiddleware deployment
+		authMiddlewareContent := string(authMiddlewareData)
+
+		// Extract OIDC_ISSUER_URL
+		oidcIssuerURLRegex := `(?m)^\s*-\s*name:\s*OIDC_ISSUER_URL\s*\n\s*value:\s*"(.+?)"`
+		matches = regexp.MustCompile(oidcIssuerURLRegex).FindStringSubmatch(authMiddlewareContent)
+		Expect(matches).To(HaveLen(2), "Could not find OIDC_ISSUER_URL in authmiddleware deployment")
+		authMwIssuerURL = matches[1]
+		Expect(authMwIssuerURL).NotTo(BeEmpty(), "OIDC_ISSUER_URL in authmiddleware deployment is empty")
+		By(fmt.Sprintf("Extracted authmiddleware OIDC_ISSUER_URL: %s", authMwIssuerURL))
+
+		// Extract OIDC_CLIENT_ID
+		oidcClientIDRegex := `(?m)^\s*-\s*name:\s*OIDC_CLIENT_ID\s*\n\s*value:\s*"(.+?)"`
+		matches = regexp.MustCompile(oidcClientIDRegex).FindStringSubmatch(authMiddlewareContent)
+		Expect(matches).To(HaveLen(2), "Could not find OIDC_CLIENT_ID in authmiddleware deployment")
+		authMwClientID = matches[1]
+		Expect(authMwClientID).NotTo(BeEmpty(), "OIDC_CLIENT_ID in authmiddleware deployment is empty")
+		By(fmt.Sprintf("Extracted authmiddleware client ID: %s", authMwClientID))
+
+		// Extract client secret from authmiddleware secrets
+		authMwSecretsContent := string(secretsData)
+		matches = regexp.MustCompile(`(?m)^\s*oidc-client-secret:\s*(.+)$`).FindStringSubmatch(authMwSecretsContent)
+		Expect(matches).To(HaveLen(2), "Could not find oidc-client-secret in authmiddleware secrets")
+		authMwClientSecret = matches[1]
+
+		// Remove quotes if present
+		authMwClientSecret = regexp.MustCompile(`^"(.*)"$`).ReplaceAllString(authMwClientSecret, "$1")
+		Expect(authMwClientSecret).NotTo(BeEmpty(), "oidc-client-secret in authmiddleware secrets is empty")
+		By(fmt.Sprintf("Extracted authmiddleware client secret: %s", authMwClientSecret))
+	})
+
+	It("should have consistent OIDC issuer URL between dex configmap and authmiddleware deployment", func() {
+		By(fmt.Sprintf("Comparing dex issuer URL '%s' with authmiddleware URL '%s'",
+			dexIssuerURL, authMwIssuerURL))
+
+		const errMsg = "OIDC_ISSUER_URL in authmiddleware deployment does not match issuer URL in dex configmap"
+		Expect(authMwIssuerURL).To(Equal(dexIssuerURL), errMsg)
+	})
+
+	It("should have consistent OIDC issuer URL between dex configmap and oauth2-proxy deployment", func() {
+		By(fmt.Sprintf("Comparing dex issuer URL '%s' with oauth2-proxy URL '%s'",
+			dexIssuerURL, oauth2IssuerURL))
+
+		const errMsg = "--oidc-issuer-url in oauth2-proxy deployment does not match issuer URL in dex configmap"
+		Expect(oauth2IssuerURL).To(Equal(dexIssuerURL), errMsg)
+	})
+
+	It("should have consistent redirect URL between dex configmap and oauth2-proxy deployment", func() {
+		By(fmt.Sprintf("Comparing dex redirectURI '%s' with oauth2-proxy URL '%s'",
+			dexRedirectURI, oauth2RedirectURL))
+
+		const errMsg = "--redirect-url in oauth2-proxy deployment does not match redirectURI in dex configmap"
+		Expect(oauth2RedirectURL).To(Equal(dexRedirectURI), errMsg)
+	})
+
+	It("should have consistent client ID between dex configmap and authmiddleware deployment", func() {
+		By(fmt.Sprintf("Comparing authmiddleware client ID in dex configmap '%s' with "+
+			"OIDC_CLIENT_ID in authmiddleware deployment '%s'", dexAuthMwClientID, authMwClientID))
+
+		const errMsg = "OIDC_CLIENT_ID in authmiddleware deployment does not match client ID in dex configmap"
+		Expect(authMwClientID).To(Equal(dexAuthMwClientID), errMsg)
+	})
+
+	It("should have consistent client ID between dex configmap and oauth2-proxy deployment", func() {
+		By(fmt.Sprintf("Comparing oauth2-proxy client ID in dex configmap '%s' with "+
+			"--client-id in oauth2-proxy deployment '%s'", dexOAuth2ClientID, oauth2ClientID))
+
+		const errMsg = "--client-id in oauth2-proxy deployment does not match client ID in dex configmap"
+		Expect(oauth2ClientID).To(Equal(dexOAuth2ClientID), errMsg)
+	})
+
+	It("should have consistent client secret between dex configmap and oauth2-proxy deployment", func() {
+		By(fmt.Sprintf("Comparing oauth2-proxy client secret in dex configmap '%s' with "+
+			"--client-secret in oauth2-proxy deployment '%s'", dexOAuth2Secret, oauth2ClientSecret))
+
+		const errMsg = "--client-secret in oauth2-proxy deployment does not match client secret in dex configmap"
+		Expect(oauth2ClientSecret).To(Equal(dexOAuth2Secret), errMsg)
+	})
+
+	It("should have consistent client secret between dex configmap and authmiddleware secrets", func() {
+		By(fmt.Sprintf("Comparing authmiddleware client secret in dex configmap '%s' with "+
+			"oidc-client-secret in authmiddleware secrets '%s'", dexAuthMwSecret, authMwClientSecret))
+
+		const errMsg = "oidc-client-secret in authmiddleware secrets does not match client secret in dex configmap"
+		Expect(authMwClientSecret).To(Equal(dexAuthMwSecret), errMsg)
+	})
+})


### PR DESCRIPTION
This PR implements the zero-trust paradigm for the authmiddleware `/auth` route. Addresses #227 

Previously, the `authmiddleware` would trust the `X-Auth-Request-Preferred-Username` and `X-Auth-Request-Groups` headers it received from `oauth2-proxy`, and make authorization decisions based on this.

Now, `authmiddleware` requires the `Authorization` header to be set, and expects the token issued from `dex` as its value.

### Implementation
- register `authmiddleware` as client to `dex` (with static client ID and secret)
- pass the `Authorization` header in `oauth2-proxy`
- add `Authorization` header to `authmiddleware` traefik middleware
- pass `dex` configuration to `authmiddleware` via env vars and `config`
- when oauth is enabled, instantiates an `OIDCVerifier` in `authmiddleware`, which on `Start()`
    - queries the OIDC provider public keys (`updateKeySet()`)
    - setup the verifier
- update `/auth` route to:
    - read `Authorization` header, reject if missing
    - use `OIDCVerifier.VerifyToken()` to validate the token (tolerate other audiences), which in most cases _will not_ require to make an HTTPS call (if key is found in keySet)
    - if pass, use the information from the token, not from the headers
    - compares the username, uid and groups headers with what's in the token

### Testing
- tested end to end with the guided deployment `aws-traefik-dex`