### PR TITLE
fix: specify workspace container for idle-shutdown check

### DIFF
--- a/internal/controller/idle_detectors.go
+++ b/internal/controller/idle_detectors.go
@@ -85,7 +85,9 @@ func (h *HTTPGetDetector) CheckIdle(ctx context.Context, workspaceName string, p
 
 	logger.V(1).Info("Calling idle endpoint", "port", port, "path", httpGetConfig.Path)
 
-	output, err := h.execUtil.ExecInPod(ctx, pod, "", cmd, "")
+	// Always execute in the workspace container
+	const workspaceContainerName = "workspace"
+	output, err := h.execUtil.ExecInPod(ctx, pod, workspaceContainerName, cmd, "")
 	if err != nil {
 		// Handle curl exit codes - connection refused (temporary failure)
 		if strings.Contains(err.Error(), "exit code 7") {

--- a/internal/controller/idle_detectors_test.go
+++ b/internal/controller/idle_detectors_test.go
@@ -129,7 +129,7 @@ func TestHTTPGetDetector_CheckIdle_Success_NotIdle(t *testing.T) {
 HTTP Status: 200`, recentTime)
 
 	mockExecUtil.On("ExecInPod",
-		ctx, pod, "",
+		ctx, pod, "workspace",
 		mock.AnythingOfType("[]string"), // Don't match exact command, just verify it's called
 		"").Return(curlOutput, nil)
 
@@ -160,7 +160,7 @@ func TestHTTPGetDetector_CheckIdle_Success_IsIdle(t *testing.T) {
 HTTP Status: 200`, oldTime)
 
 	mockExecUtil.On("ExecInPod",
-		ctx, pod, "",
+		ctx, pod, "workspace",
 		mock.AnythingOfType("[]string"),
 		"").Return(curlOutput, nil)
 
@@ -189,7 +189,7 @@ func TestHTTPGetDetector_CheckIdle_HTTP404_PermanentFailure(t *testing.T) {
 	curlOutput := `HTTP Status: 404`
 
 	mockExecUtil.On("ExecInPod",
-		ctx, pod, "",
+		ctx, pod, "workspace",
 		mock.AnythingOfType("[]string"),
 		"").Return(curlOutput, nil)
 
@@ -217,7 +217,7 @@ func TestHTTPGetDetector_CheckIdle_ConnectionRefused_TemporaryFailure(t *testing
 
 	// Mock connection refused error (curl exit code 7)
 	mockExecUtil.On("ExecInPod",
-		ctx, pod, "",
+		ctx, pod, "workspace",
 		mock.AnythingOfType("[]string"),
 		"").Return("", errors.New("command terminated with exit code 7"))
 
@@ -261,7 +261,7 @@ func TestHTTPGetDetector_CheckIdle_HTTP500_TemporaryFailure(t *testing.T) {
 			curlOutput := fmt.Sprintf(`HTTP Status: %s`, tc.statusCode)
 
 			mockExecUtil.On("ExecInPod",
-				ctx, pod, "",
+				ctx, pod, "workspace",
 				mock.AnythingOfType("[]string"),
 				"").Return(curlOutput, nil)
 


### PR DESCRIPTION
Tested on EKS , verified idle checks worked and workspace was stopped
```
2025-11-20T02:47:36Z	DEBUG	Successfully checked idle status	{"controller": "workspace", "controllerGroup": "workspace.jupyter.org", "controllerKind": "Workspace", "Workspace": {"name":"prayags-jl302","namespace":"default"}, "namespace": "default", "name": "prayags-jl302", "reconcileID": "9644fda9-fcbd-4a6c-93bb-253aa38dd125", "workspace": "prayags-jl302", "resourceVersion": "44417196", "isIdle": false}
2025-11-20T02:47:36Z	DEBUG	Scheduling next idle check	{"controller": "workspace", "controllerGroup": "workspace.jupyter.org", "controllerKind": "Workspace", "Workspace": {"name":"prayags-jl302","namespace":"default"}, "namespace": "default", "name": "prayags-jl302", "reconcileID": "9644fda9-fcbd-4a6c-93bb-253aa38dd125", "workspace": "prayags-jl302", "resourceVersion": "44417196", "interval": "5m0s"}

2025-11-20T02:52:37Z	DEBUG	Successfully checked idle status	{"controller": "workspace", "controllerGroup": "workspace.jupyter.org", "controllerKind": "Workspace", "Workspace": {"name":"prayags-jl302","namespace":"default"}, "namespace": "default", "name": "prayags-jl302", "reconcileID": "c0f7b9e0-47be-4442-befd-162f533d8b0d", "workspace": "prayags-jl302", "resourceVersion": "44417196", "isIdle": true}

2025-11-20T02:52:37Z	INFO	Workspace idle timeout reached, stopping workspace	{"controller": "workspace", "controllerGroup": "workspace.jupyter.org", "controllerKind": "Workspace", "Workspace": {"name":"prayags-jl302","namespace":"default"}, "namespace": "default", "name": "prayags-jl302", "reconcileID": "c0f7b9e0-47be-4442-befd-162f533d8b0d", "workspace": "prayags-jl302", "resourceVersion": "44417196", "timeout": 2}
```