### PR TITLE
fix: discovery handler not properly registering connection resources

### DIFF
--- a/internal/extensionapi/server.go
+++ b/internal/extensionapi/server.go
@@ -211,6 +211,9 @@ func createRecommendedOptions(config *ExtensionConfig) *genericoptions.Recommend
 	recommendedOptions.SecureServing.ServerCert.CertKey.KeyFile = config.KeyPath
 	recommendedOptions.SecureServing.ServerCert.PairName = "tls"
 
+	// turn off advanced priority and fairness features that require extra permissions
+	recommendedOptions.Features.EnablePriorityAndFairness = false
+
 	return recommendedOptions
 }
 
@@ -218,6 +221,7 @@ func createRecommendedOptions(config *ExtensionConfig) *genericoptions.Recommend
 func createGenericAPIServer(recommendedOptions *genericoptions.RecommendedOptions) (*genericapiserver.GenericAPIServer, error) {
 	// Create server config
 	serverConfig := genericapiserver.NewRecommendedConfig(codecs)
+	serverConfig.EnableDiscovery = false
 	serverConfig.EffectiveVersion = compatibility.DefaultBuildEffectiveVersion()
 
 	// Apply options to configure authentication automatically


### PR DESCRIPTION
Fixes the discovery handling issues for workspace connections by turning of the built-in discovery handler of generic API, which causes a conflict. Also turns off the fairness controller, which required extra permissions to call flowschema & pollutes startup logs. we can consider re-adding in future.

this allows for the original CLI UX:
```
kubectl create -f - -o yaml <<EOF                                                                                                          
apiVersion: connection.workspace.jupyter.org/v1alpha1                                                                                                                                    kind: WorkspaceConnection
metadata:
 namespace: default     
spec:
 workspaceName: workspace-sample
 workspaceConnectionType: vscode-remote                                                                                                                                                  EOF
```