### PR TITLE
feat: k8s native bearer tokens

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -354,6 +354,15 @@ setup-kind: ## Set up a Kind cluster for development if it does not exist
 	else \
 		echo "cert-manager is already installed, skipping installation"; \
 	fi
+	@if ! kubectl get crds ingressroutes.traefik.io > /dev/null 2>&1; then \
+		echo "Installing Traefik CRDs"; \
+		helm repo add traefik https://traefik.github.io/charts; \
+		helm install traefik-crd traefik/traefik-crds \
+			--namespace traefik \
+			--create-namespace; \
+	else \
+		echo "Traefik CRDs are already installed, skipping installation"; \
+	fi
 
 .PHONY: test-e2e-focus
 test-e2e-focus: setup-test-e2e manifests generate fmt vet load-images-e2e ## Run specific e2e tests using FOCUS parameter. Usage: make test-e2e-focus FOCUS="Primary Storage"
@@ -383,12 +392,16 @@ teardown-kind: ## Tear down the Kind cluster, registry, and clean up images
 	$(MAKE) -C images clean CONTAINER_TOOL=$(CONTAINER_TOOL)
 
 .PHONY: load-images
-load-images: docker-build ## Build and load images into the Kind cluster
+load-images: docker-build build-rotator ## Build and load images into the Kind cluster
 	@echo "Loading controller image ${IMG} into kind cluster ${DEV_KIND_CLUSTER}..."
 	@mkdir -p /tmp/kind-images
 	$(CONTAINER_TOOL) save ${IMG} -o /tmp/kind-images/controller.tar
 	$(KIND) load image-archive /tmp/kind-images/controller.tar --name $(DEV_KIND_CLUSTER)
 	rm -f /tmp/kind-images/controller.tar
+	@echo "Loading rotator image into kind cluster ${DEV_KIND_CLUSTER}..."
+	$(CONTAINER_TOOL) save docker.io/library/rotator:local -o /tmp/kind-images/rotator.tar
+	$(KIND) load image-archive /tmp/kind-images/rotator.tar --name $(DEV_KIND_CLUSTER)
+	rm -f /tmp/kind-images/rotator.tar
 	$(MAKE) -C images push-all-kind CLUSTER_NAME=$(DEV_KIND_CLUSTER) CONTAINER_TOOL=$(CONTAINER_TOOL)
 
 .PHONY: load-images-e2e

--- a/Makefile
+++ b/Makefile
@@ -313,6 +313,8 @@ deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in
 	@echo "Using kubectl context: $$(kubectl config current-context)"
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/default | $(KUBECTL) apply -f -
+	@echo "Applying extension API auth RoleBinding in kube-system (not managed by kustomize)..."
+	$(KUBECTL) apply -f config/rbac/extension_api_auth_binding.yaml
 	@if [ "$(USE_KIND)" = "true" ]; then \
 		echo "Using Kind cluster mode, patching deployment for local images..."; \
 		$(MAKE) load-images; \
@@ -433,12 +435,25 @@ kubectl-kind: ## Configure kubectl to use kind cluster
 	}
 
 .PHONY: deploy-kind
-deploy-kind: docker-build kubectl-kind ## Build, load, and deploy controller to a kind cluster.
-	$(MAKE) deploy USE_KIND=true EXTRA_HELM_ARGS="--set application.imagesPullPolicy=Never --set application.imagesRegistry='docker.io/library' --set extensionApi.enable=true"
+deploy-kind: docker-build build-rotator helm-generate kubectl-kind ## Build, load, and deploy controller to a kind cluster.
+	$(MAKE) load-images
+	helm upgrade --install jk8s dist/chart \
+		--namespace jupyter-k8s-system --create-namespace \
+		--set controllerManager.container.imagePullPolicy=Never \
+		--set application.imagesPullPolicy=Never \
+		--set application.imagesRegistry='docker.io/library' \
+		--set extensionApi.enable=true \
+		--set extensionApi.jwtSecret.enable=true \
+		--set extensionApi.jwtSecret.rotator.repository=docker.io/library \
+		--set extensionApi.jwtSecret.rotator.imageName=rotator \
+		--set extensionApi.jwtSecret.rotator.imageTag=local \
+		--set extensionApi.jwtSecret.rotator.imagePullPolicy=Never \
+		--set workspacePodWatching.enable=true \
+		--set accessResources.traefik.enable=true
 
 .PHONY: redeploy-kind
-redeploy-kind: kubectl-kind
-	$(KUBECTL) delete deployment jupyter-k8s-controller-manager -n jupyter-k8s-system
+redeploy-kind: kubectl-kind ## Rebuild and redeploy controller to the kind cluster.
+	$(KUBECTL) delete deployment jupyter-k8s-controller-manager -n jupyter-k8s-system --ignore-not-found
 	$(MAKE) deploy-kind
 
 ##@ Local Auth Middleware & Rotator
@@ -774,6 +789,7 @@ port-forward:
 .PHONY: undeploy
 undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	$(KUSTOMIZE) build config/default | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
+	$(KUBECTL) delete -f config/rbac/extension_api_auth_binding.yaml --ignore-not-found
 
 ##@ Dependencies
 

--- a/Makefile
+++ b/Makefile
@@ -405,9 +405,14 @@ load-images: docker-build build-rotator ## Build and load images into the Kind c
 	$(MAKE) -C images push-all-kind CLUSTER_NAME=$(DEV_KIND_CLUSTER) CONTAINER_TOOL=$(CONTAINER_TOOL)
 
 .PHONY: load-images-e2e
-load-images-e2e: ## Build and load application images into the e2e test Kind cluster
+load-images-e2e: build-rotator ## Build and load application images into the e2e test Kind cluster
 	@echo "Loading application images into e2e test cluster ${KIND_CLUSTER}..."
 	@echo "Note: Controller image is built and loaded by the e2e test suite itself"
+	@echo "Loading rotator image into e2e test cluster ${KIND_CLUSTER}..."
+	@mkdir -p /tmp/kind-images
+	$(CONTAINER_TOOL) save docker.io/library/rotator:local -o /tmp/kind-images/rotator.tar
+	$(KIND) load image-archive /tmp/kind-images/rotator.tar --name $(KIND_CLUSTER)
+	rm -f /tmp/kind-images/rotator.tar
 	$(MAKE) -C images push-all-kind CLUSTER_NAME=$(KIND_CLUSTER) CONTAINER_TOOL=$(CONTAINER_TOOL)
 
 .PHONY: kubectl-kind

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -40,6 +41,8 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
@@ -116,6 +119,11 @@ func main() {
 	var watchResourcesGVK string
 	var enableWorkspacePodWatching bool
 	var defaultTemplateNamespace string
+	var jwtIssuer string
+	var jwtAudience string
+	var jwtSecretName string
+	var jwtTTL time.Duration
+	var newKeyUseDelay time.Duration
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -147,6 +155,16 @@ func main() {
 		"Enable workspace pod event watching for workspace lifecycle management")
 	flag.StringVar(&defaultTemplateNamespace, "default-template-namespace", "",
 		"Default namespace for WorkspaceTemplate resolution when templateRef.namespace is not specified")
+	flag.StringVar(&jwtIssuer, "jwt-issuer", "",
+		"JWT issuer claim. Uses server default if not set.")
+	flag.StringVar(&jwtAudience, "jwt-audience", "",
+		"JWT audience claim. Uses server default if not set.")
+	flag.StringVar(&jwtSecretName, "jwt-secret-name", "",
+		"K8s Secret name for JWT signing keys (enables k8s-native signing)")
+	flag.DurationVar(&jwtTTL, "jwt-ttl", 0,
+		"JWT expiration duration (e.g. 5m). Uses server default if not set.")
+	flag.DurationVar(&newKeyUseDelay, "new-key-use-delay", 0,
+		"Delay before using a newly rotated signing key (e.g. 5s). Uses server default if not set.")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -222,7 +240,7 @@ func main() {
 		metricsServerOptions.KeyName = metricsCertKey
 	}
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	mgrOptions := ctrl.Options{
 		Scheme:                 scheme,
 		Metrics:                metricsServerOptions,
 		WebhookServer:          webhookServer,
@@ -240,7 +258,23 @@ func main() {
 		// if you are doing or is intended to do any operation such as perform cleanups
 		// after the manager stops then its usage might be unsafe.
 		// LeaderElectionReleaseOnCancel: true,
-	})
+	}
+
+	// Scope Secret watching to the controller's namespace to avoid requiring
+	// cluster-wide secret list/watch permissions (needed for JWT secret informer).
+	if podNamespace := os.Getenv("CONTROLLER_POD_NAMESPACE"); podNamespace != "" {
+		mgrOptions.Cache = cache.Options{
+			ByObject: map[client.Object]cache.ByObject{
+				&corev1.Secret{}: {
+					Namespaces: map[string]cache.Config{
+						podNamespace: {},
+					},
+				},
+			},
+		}
+	}
+
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), mgrOptions)
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)
@@ -315,12 +349,31 @@ func main() {
 	if enableExtensionAPI {
 		setupLog.Info("Setting up extension API server")
 		// Create config with a different port to avoid conflict with metrics
-		config := extensionapi.NewConfig(
+		configOpts := []extensionapi.ConfigOption{
 			extensionapi.WithServerPort(7443),
+			extensionapi.WithControllerNamespace(os.Getenv("CONTROLLER_POD_NAMESPACE")),
 			extensionapi.WithClusterId(os.Getenv("CLUSTER_ID")),
 			extensionapi.WithKMSKeyID(os.Getenv("KMS_KEY_ID")),
 			extensionapi.WithDomain(os.Getenv("DOMAIN")),
-		)
+		}
+
+		if jwtIssuer != "" {
+			configOpts = append(configOpts, extensionapi.WithJwtIssuer(jwtIssuer))
+		}
+		if jwtAudience != "" {
+			configOpts = append(configOpts, extensionapi.WithJwtAudience(jwtAudience))
+		}
+		if jwtSecretName != "" {
+			configOpts = append(configOpts, extensionapi.WithJwtSecretName(jwtSecretName))
+		}
+		if jwtTTL > 0 {
+			configOpts = append(configOpts, extensionapi.WithJwtTTL(jwtTTL))
+		}
+		if newKeyUseDelay > 0 {
+			configOpts = append(configOpts, extensionapi.WithNewKeyUseDelay(newKeyUseDelay))
+		}
+
+		config := extensionapi.NewConfig(configOpts...)
 		if err := extensionapi.SetupExtensionAPIServerWithManager(mgr, config); err != nil {
 			setupLog.Error(err, "unable to create extension API server", "extensionapi", "Server")
 			os.Exit(1)

--- a/cmd/rotator/main.go
+++ b/cmd/rotator/main.go
@@ -9,6 +9,7 @@ package main
 import (
 	"context"
 	"log"
+	"math"
 	"os"
 	"strconv"
 	"time"
@@ -22,10 +23,12 @@ import (
 
 // Environment variable names
 const (
-	EnvSecretName      = "SECRET_NAME"
-	EnvSecretNamespace = "SECRET_NAMESPACE"
-	EnvNumberOfKeys    = "NUMBER_OF_KEYS"
-	EnvDryRun          = "DRY_RUN"
+	EnvSecretName       = "SECRET_NAME"
+	EnvSecretNamespace  = "SECRET_NAMESPACE"
+	EnvNumberOfKeys     = "NUMBER_OF_KEYS"
+	EnvDryRun           = "DRY_RUN"
+	EnvTokenTTL         = "TOKEN_TTL"
+	EnvRotationInterval = "ROTATION_INTERVAL"
 )
 
 // Default values
@@ -40,8 +43,10 @@ func main() {
 	// Parse configuration from environment
 	secretName := getEnv(EnvSecretName, DefaultSecretName)
 	secretNamespace := os.Getenv(EnvSecretNamespace)
-	numberOfKeys := getEnvInt(EnvNumberOfKeys, DefaultNumberOfKeys)
 	dryRun := getEnvBool(EnvDryRun, false)
+
+	// Determine numberOfKeys: derived from TOKEN_TTL + ROTATION_INTERVAL, or explicit NUMBER_OF_KEYS
+	numberOfKeys := resolveNumberOfKeys()
 
 	log.Printf("Starting JWT key rotation...")
 	log.Printf("  Secret: %s", secretName)
@@ -102,6 +107,44 @@ func main() {
 	}
 
 	log.Printf("Key rotation completed successfully")
+}
+
+// resolveNumberOfKeys determines the number of keys to retain.
+// Explicit NUMBER_OF_KEYS takes precedence. Otherwise derives from TOKEN_TTL + ROTATION_INTERVAL.
+func resolveNumberOfKeys() int {
+	// Explicit NUMBER_OF_KEYS takes precedence
+	if v := os.Getenv(EnvNumberOfKeys); v != "" {
+		return getEnvInt(EnvNumberOfKeys, DefaultNumberOfKeys)
+	}
+
+	// Derive from TOKEN_TTL + ROTATION_INTERVAL
+	tokenTTLStr := os.Getenv(EnvTokenTTL)
+	rotationIntervalStr := os.Getenv(EnvRotationInterval)
+
+	if tokenTTLStr != "" && rotationIntervalStr != "" {
+		tokenTTL, err := time.ParseDuration(tokenTTLStr)
+		if err != nil {
+			log.Fatalf("Invalid %s value %q: %v", EnvTokenTTL, tokenTTLStr, err)
+		}
+		rotationInterval, err := time.ParseDuration(rotationIntervalStr)
+		if err != nil {
+			log.Fatalf("Invalid %s value %q: %v", EnvRotationInterval, rotationIntervalStr, err)
+		}
+		n := deriveNumberOfKeys(tokenTTL, rotationInterval)
+		log.Printf("Derived numberOfKeys=%d from TOKEN_TTL=%s, ROTATION_INTERVAL=%s", n, tokenTTL, rotationInterval)
+		return n
+	}
+
+	return DefaultNumberOfKeys
+}
+
+// deriveNumberOfKeys computes ceil(ttl / interval) + 1.
+// The +1 ensures the previous signing key is always available during rotation.
+func deriveNumberOfKeys(ttl, interval time.Duration) int {
+	if interval <= 0 {
+		log.Fatalf("ROTATION_INTERVAL must be > 0")
+	}
+	return int(math.Ceil(float64(ttl)/float64(interval))) + 1
 }
 
 // getEnv retrieves an environment variable or returns a default value

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -19,6 +19,7 @@ resources:
 - ../rbac
 - ../manager
 - ../apiservice
+- ../jwt-rotator
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 - ../webhook

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -77,6 +77,7 @@ patches:
   target:
     kind: Deployment
 
+
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
 # Uncomment the following replacements to add the cert-manager CA injection annotations
 replacements:

--- a/config/jwt-rotator/cronjob.yaml
+++ b/config/jwt-rotator/cronjob.yaml
@@ -1,0 +1,59 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: jwt-rotator
+  labels:
+    app: extensionapi-jwt-rotator
+    component: security
+spec:
+  # Run every 15 minutes (matches default rotationInterval)
+  schedule: "*/15 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 3
+      template:
+        metadata:
+          labels:
+            app: extensionapi-jwt-rotator
+            component: security
+        spec:
+          serviceAccountName: jwt-rotator
+          restartPolicy: OnFailure
+          securityContext:
+            runAsUser: 65532
+            runAsGroup: 65532
+            runAsNonRoot: true
+            fsGroup: 65532
+          containers:
+          - name: rotator
+            image: docker.io/library/rotator:local
+            imagePullPolicy: Never
+            resources:
+              requests:
+                cpu: 50m
+                memory: 64Mi
+              limits:
+                cpu: 100m
+                memory: 128Mi
+            securityContext:
+              capabilities:
+                drop:
+                - ALL
+              readOnlyRootFilesystem: true
+              allowPrivilegeEscalation: false
+            env:
+            - name: SECRET_NAME
+              value: "jupyter-k8s-extensionapi-secrets"
+            - name: SECRET_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: TOKEN_TTL
+              value: "5m"
+            - name: ROTATION_INTERVAL
+              value: "15m"
+            - name: DRY_RUN
+              value: "false"

--- a/config/jwt-rotator/cronjob.yaml
+++ b/config/jwt-rotator/cronjob.yaml
@@ -27,6 +27,8 @@ spec:
             runAsGroup: 65532
             runAsNonRoot: true
             fsGroup: 65532
+            seccompProfile:
+              type: RuntimeDefault
           containers:
           - name: rotator
             image: docker.io/library/rotator:local

--- a/config/jwt-rotator/kustomization.yaml
+++ b/config/jwt-rotator/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+- secret.yaml
+- serviceaccount.yaml
+- rbac.yaml
+- cronjob.yaml

--- a/config/jwt-rotator/rbac.yaml
+++ b/config/jwt-rotator/rbac.yaml
@@ -1,0 +1,59 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: jwt-rotator-secrets-manager
+  labels:
+    app: extensionapi-jwt-rotator
+    component: security
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  resourceNames: ["jupyter-k8s-extensionapi-secrets"]
+  verbs: ["get", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: jwt-rotator-secrets-manager-binding
+  labels:
+    app: extensionapi-jwt-rotator
+    component: security
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: jwt-rotator-secrets-manager
+subjects:
+- kind: ServiceAccount
+  name: jwt-rotator
+---
+# Controller needs read access to the JWT secret
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: jwt-secrets-reader
+  labels:
+    app: extensionapi-jwt-rotator
+    component: security
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["list", "watch"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  resourceNames: ["jupyter-k8s-extensionapi-secrets"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: jwt-secrets-reader-binding
+  labels:
+    app: extensionapi-jwt-rotator
+    component: security
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: jwt-secrets-reader
+subjects:
+- kind: ServiceAccount
+  name: controller-manager

--- a/config/jwt-rotator/secret.yaml
+++ b/config/jwt-rotator/secret.yaml
@@ -13,6 +13,9 @@ data:
   # 1. Kind clusters are ephemeral and for local development only
   # 2. This key is immediately rotated by the rotator CronJob on first run
   # 3. Production deployments use the Helm chart which generates random keys via:
-  #    jwt-signing-key-{{ now | unixEpoch }}: {{ randBytes 48 | quote }}
+  #    jwt-signing-key-{{ now | unixEpoch }}: {{ randBytes 48 | b64enc | quote }}
   # 4. JWTs signed with this key are only valid within the local Kind cluster
+  #
+  # The timestamp (1) ensures this seed key is always the oldest and gets pruned
+  # first when the rotator adds new keys.
   jwt-signing-key-1: "YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXoxMjM0NTY3ODkwQUJDREVGR0hJSktMTU5PUFFSU1RVVg=="

--- a/config/jwt-rotator/secret.yaml
+++ b/config/jwt-rotator/secret.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: extensionapi-secrets
+  labels:
+    app: extensionapi-jwt-rotator
+    component: security
+type: Opaque
+data:
+  # Initial JWT signing key - 48 bytes base64-encoded (384 bits for HS384)
+  #
+  # NOTE: This hardcoded key is ONLY for local Kind testing and is NOT sensitive because:
+  # 1. Kind clusters are ephemeral and for local development only
+  # 2. This key is immediately rotated by the rotator CronJob on first run
+  # 3. Production deployments use the Helm chart which generates random keys via:
+  #    jwt-signing-key-{{ now | unixEpoch }}: {{ randBytes 48 | quote }}
+  # 4. JWTs signed with this key are only valid within the local Kind cluster
+  jwt-signing-key-1: "YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXoxMjM0NTY3ODkwQUJDREVGR0hJSktMTU5PUFFSU1RVVg=="

--- a/config/jwt-rotator/serviceaccount.yaml
+++ b/config/jwt-rotator/serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: jwt-rotator
+  labels:
+    app: extensionapi-jwt-rotator
+    component: security

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: jupyter.org/jupyter-k8s
-  newTag: v0.0.1
+  newName: controller
+  newTag: latest

--- a/config/rbac/extension_api_auth_binding.yaml
+++ b/config/rbac/extension_api_auth_binding.yaml
@@ -1,3 +1,6 @@
+## This RoleBinding is applied separately from kustomize because it must live
+## in kube-system, and kustomize's global namespace transform would override that.
+## See Makefile deploy/undeploy targets.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -10,4 +13,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: jupyter-k8s-controller-manager
-  namespace: system
+  namespace: jupyter-k8s-system

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -10,7 +10,9 @@ resources:
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
 # Extension API authentication permissions
-- extension_api_auth_binding.yaml
+# NOTE: extension_api_auth_binding.yaml is NOT included here because kustomize's
+# global namespace transform would override its kube-system namespace. It is
+# applied separately in the Makefile deploy/undeploy targets.
 # The following RBAC configurations are used to protect
 # the metrics endpoint with authn/authz. These configurations
 # ensure that only authorized users and service accounts

--- a/dist/chart/templates/jwt-rotator/cronjob.yaml
+++ b/dist/chart/templates/jwt-rotator/cronjob.yaml
@@ -1,0 +1,61 @@
+{{- if and .Values.extensionApi.enable .Values.extensionApi.jwtSecret.enable }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: jwt-rotator
+  labels:
+    app: extensionapi-jwt-rotator
+    component: security
+spec:
+  # Run every 15 minutes (matches default rotationInterval)
+  schedule: "*/15 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 3
+      template:
+        metadata:
+          labels:
+            app: extensionapi-jwt-rotator
+            component: security
+        spec:
+          serviceAccountName: jwt-rotator
+          restartPolicy: OnFailure
+          securityContext:
+            runAsUser: 65532
+            runAsGroup: 65532
+            runAsNonRoot: true
+            fsGroup: 65532
+          containers:
+          - name: rotator
+            image: "{{ .Values.extensionApi.jwtSecret.rotator.repository }}/{{ .Values.extensionApi.jwtSecret.rotator.imageName }}:{{ .Values.extensionApi.jwtSecret.rotator.imageTag }}"
+            imagePullPolicy: IfNotPresent
+            resources:
+              requests:
+                cpu: 50m
+                memory: 64Mi
+              limits:
+                cpu: 100m
+                memory: 128Mi
+            securityContext:
+              capabilities:
+                drop:
+                - ALL
+              readOnlyRootFilesystem: true
+              allowPrivilegeEscalation: false
+            env:
+            - name: SECRET_NAME
+              value: {{ .Values.extensionApi.jwtSecret.secretName | quote }}
+            - name: SECRET_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: TOKEN_TTL
+              value: {{ .Values.extensionApi.jwtSecret.tokenTTL | quote }}
+            - name: ROTATION_INTERVAL
+              value: {{ .Values.extensionApi.jwtSecret.rotationInterval | quote }}
+            - name: DRY_RUN
+              value: "false"
+{{- end }}

--- a/dist/chart/templates/jwt-rotator/cronjob.yaml
+++ b/dist/chart/templates/jwt-rotator/cronjob.yaml
@@ -33,7 +33,7 @@ spec:
           containers:
           - name: rotator
             image: "{{ .Values.extensionApi.jwtSecret.rotator.repository }}/{{ .Values.extensionApi.jwtSecret.rotator.imageName }}:{{ .Values.extensionApi.jwtSecret.rotator.imageTag }}"
-            imagePullPolicy: IfNotPresent
+            imagePullPolicy: {{ .Values.extensionApi.jwtSecret.rotator.imagePullPolicy }}
             resources:
               requests:
                 cpu: 50m

--- a/dist/chart/templates/jwt-rotator/cronjob.yaml
+++ b/dist/chart/templates/jwt-rotator/cronjob.yaml
@@ -28,6 +28,8 @@ spec:
             runAsGroup: 65532
             runAsNonRoot: true
             fsGroup: 65532
+            seccompProfile:
+              type: RuntimeDefault
           containers:
           - name: rotator
             image: "{{ .Values.extensionApi.jwtSecret.rotator.repository }}/{{ .Values.extensionApi.jwtSecret.rotator.imageName }}:{{ .Values.extensionApi.jwtSecret.rotator.imageTag }}"

--- a/dist/chart/templates/jwt-rotator/rbac.yaml
+++ b/dist/chart/templates/jwt-rotator/rbac.yaml
@@ -1,0 +1,61 @@
+{{- if and .Values.extensionApi.enable .Values.extensionApi.jwtSecret.enable }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: jwt-rotator-secrets-manager
+  labels:
+    app: extensionapi-jwt-rotator
+    component: security
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  resourceNames: [{{ .Values.extensionApi.jwtSecret.secretName | quote }}]
+  verbs: ["get", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: jwt-rotator-secrets-manager-binding
+  labels:
+    app: extensionapi-jwt-rotator
+    component: security
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: jwt-rotator-secrets-manager
+subjects:
+- kind: ServiceAccount
+  name: jwt-rotator
+---
+# Controller needs read access to the JWT secret
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: jwt-secrets-reader
+  labels:
+    app: extensionapi-jwt-rotator
+    component: security
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["list", "watch"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  resourceNames: [{{ .Values.extensionApi.jwtSecret.secretName | quote }}]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: jwt-secrets-reader-binding
+  labels:
+    app: extensionapi-jwt-rotator
+    component: security
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: jwt-secrets-reader
+subjects:
+- kind: ServiceAccount
+  name: jupyter-k8s-controller-manager
+{{- end }}

--- a/dist/chart/templates/jwt-rotator/secret.yaml
+++ b/dist/chart/templates/jwt-rotator/secret.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.extensionApi.enable .Values.extensionApi.jwtSecret.enable }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.extensionApi.jwtSecret.secretName }}
+  labels:
+    app: extensionapi-jwt-rotator
+    component: security
+type: Opaque
+data:
+  jwt-signing-key-{{ now | unixEpoch }}: {{ randBytes 48 | b64enc | quote }}
+{{- end }}

--- a/dist/chart/templates/jwt-rotator/serviceaccount.yaml
+++ b/dist/chart/templates/jwt-rotator/serviceaccount.yaml
@@ -1,0 +1,9 @@
+{{- if and .Values.extensionApi.enable .Values.extensionApi.jwtSecret.enable }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: jwt-rotator
+  labels:
+    app: extensionapi-jwt-rotator
+    component: security
+{{- end }}

--- a/dist/chart/templates/manager/manager.yaml
+++ b/dist/chart/templates/manager/manager.yaml
@@ -42,6 +42,21 @@ spec:
             {{- end}}
             {{- if .Values.extensionApi.enable }}
             - "--enable-extension-api"
+            {{- if .Values.extensionApi.jwtIssuer }}
+            - "--jwt-issuer={{ .Values.extensionApi.jwtIssuer }}"
+            {{- end}}
+            {{- if .Values.extensionApi.jwtAudience }}
+            - "--jwt-audience={{ .Values.extensionApi.jwtAudience }}"
+            {{- end}}
+            {{- end}}
+            {{- if and .Values.extensionApi.enable .Values.extensionApi.jwtSecret.enable }}
+            - "--jwt-secret-name={{ .Values.extensionApi.jwtSecret.secretName }}"
+            {{- if .Values.extensionApi.jwtSecret.tokenTTL }}
+            - "--jwt-ttl={{ .Values.extensionApi.jwtSecret.tokenTTL }}"
+            {{- end}}
+            {{- if .Values.extensionApi.jwtSecret.newKeyUseDelay }}
+            - "--new-key-use-delay={{ .Values.extensionApi.jwtSecret.newKeyUseDelay }}"
+            {{- end}}
             {{- end}}
             {{- if .Values.workspacePodWatching.enable }}
             - "--enable-workspace-pod-watching"

--- a/dist/chart/values.yaml
+++ b/dist/chart/values.yaml
@@ -129,7 +129,30 @@ accessResources:
   # Additional Group-Version-Kind to watch
   additionalGvk: []
 
-# [EXTENSION_API]: Extension API server configuration  
+# [EXTENSION_API]: Extension API server configuration
 extensionApi:
   # Enable extension API server for WorkspaceConnection
   enable: true
+  # JWT issuer and audience claims
+  jwtIssuer: "workspaces-controller"
+  jwtAudience: "workspaces-controller"
+  # K8s-native JWT secret configuration
+  # When enabled, JWTs are signed with HMAC keys from a K8s Secret
+  # instead of AWS KMS. The secret is rotated by a CronJob.
+  jwtSecret:
+    enable: false
+    secretName: "extensionapi-secrets"
+    tokenTTL: "5m"
+    newKeyUseDelay: "5s"
+    rotationInterval: "15m"
+    rotator:
+      repository: "docker.io"
+      imageName: "jupyter-k8s-rotator"
+      imageTag: "latest"
+      resources:
+        requests:
+          cpu: 50m
+          memory: 64Mi
+        limits:
+          cpu: 100m
+          memory: 128Mi

--- a/dist/chart/values.yaml
+++ b/dist/chart/values.yaml
@@ -149,6 +149,7 @@ extensionApi:
       repository: "docker.io"
       imageName: "jupyter-k8s-rotator"
       imageTag: "latest"
+      imagePullPolicy: "IfNotPresent"
       resources:
         requests:
           cpu: 50m

--- a/hack/apply-helm-patches.sh
+++ b/hack/apply-helm-patches.sh
@@ -94,7 +94,7 @@ if [ -d "${SCRIPT_DIR}/../config/jwt-rotator" ]; then
             if [[ "$filename" == "cronjob.yaml" ]]; then
                 cat "$file" | \
                     sed 's#image: docker.io/library/rotator:local#image: "{{ .Values.extensionApi.jwtSecret.rotator.repository }}/{{ .Values.extensionApi.jwtSecret.rotator.imageName }}:{{ .Values.extensionApi.jwtSecret.rotator.imageTag }}"#' | \
-                    sed 's#imagePullPolicy: Never#imagePullPolicy: IfNotPresent#' | \
+                    sed 's#imagePullPolicy: Never#imagePullPolicy: {{ .Values.extensionApi.jwtSecret.rotator.imagePullPolicy }}#' | \
                     sed 's#value: "jupyter-k8s-extensionapi-secrets"#value: {{ .Values.extensionApi.jwtSecret.secretName | quote }}#' | \
                     sed '/name: TOKEN_TTL$/{n; s#value: "5m"#value: {{ .Values.extensionApi.jwtSecret.tokenTTL | quote }}#;}' | \
                     sed '/name: ROTATION_INTERVAL$/{n; s#value: "15m"#value: {{ .Values.extensionApi.jwtSecret.rotationInterval | quote }}#;}' >> "$target"
@@ -127,6 +127,32 @@ SECRETEOF
 
     rm -f "${CHART_DIR}/templates/jwt-rotator/kustomization.yaml"
 fi
+
+# Create extension API auth RoleBinding in kube-system
+# This RoleBinding is excluded from the kustomize pipeline because kustomize's global
+# namespace transform would override kube-system. We create it directly in the helm chart.
+echo "Creating extension API auth RoleBinding template..."
+EXTENSION_AUTH_BINDING="${CHART_DIR}/templates/rbac/extension_api_auth_binding.yaml"
+cat > "${EXTENSION_AUTH_BINDING}" << 'AUTHEOF'
+{{- if .Values.rbac.enable }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+  name: jupyter-k8s-extension-api-auth
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: jupyter-k8s-controller-manager
+  namespace: {{ .Release.Namespace }}
+{{- end -}}
+AUTHEOF
+echo "Created extension API auth RoleBinding template"
 
 # Remove connection CRDs as they're meant to be subresources, not standalone CRDs
 echo "Removing connection CRDs from Helm chart..."

--- a/hack/apply-helm-patches.sh
+++ b/hack/apply-helm-patches.sh
@@ -77,6 +77,57 @@ if [ -d "${SCRIPT_DIR}/../config/apiservice" ]; then
     rm -f "${CHART_DIR}/templates/apiservice/kustomization.yaml"
 fi
 
+# Copy jwt-rotator resources (same pattern as apiservice above)
+if [ -d "${SCRIPT_DIR}/../config/jwt-rotator" ]; then
+    echo "Copying jwt-rotator resources..."
+    mkdir -p "${CHART_DIR}/templates/jwt-rotator"
+
+    JWT_COND='{{- if and .Values.extensionApi.enable .Values.extensionApi.jwtSecret.enable }}'
+
+    for file in "${SCRIPT_DIR}/../config/jwt-rotator"/*.yaml; do
+        if [ -f "$file" ]; then
+            filename=$(basename "$file")
+            target="${CHART_DIR}/templates/jwt-rotator/${filename}"
+
+            echo "$JWT_COND" > "$target"
+
+            if [[ "$filename" == "cronjob.yaml" ]]; then
+                cat "$file" | \
+                    sed 's#image: docker.io/library/rotator:local#image: "{{ .Values.extensionApi.jwtSecret.rotator.repository }}/{{ .Values.extensionApi.jwtSecret.rotator.imageName }}:{{ .Values.extensionApi.jwtSecret.rotator.imageTag }}"#' | \
+                    sed 's#imagePullPolicy: Never#imagePullPolicy: IfNotPresent#' | \
+                    sed 's#value: "jupyter-k8s-extensionapi-secrets"#value: {{ .Values.extensionApi.jwtSecret.secretName | quote }}#' | \
+                    sed '/name: TOKEN_TTL$/{n; s#value: "5m"#value: {{ .Values.extensionApi.jwtSecret.tokenTTL | quote }}#;}' | \
+                    sed '/name: ROTATION_INTERVAL$/{n; s#value: "15m"#value: {{ .Values.extensionApi.jwtSecret.rotationInterval | quote }}#;}' >> "$target"
+            elif [[ "$filename" == "rbac.yaml" ]]; then
+                cat "$file" | \
+                    sed 's#\["jupyter-k8s-extensionapi-secrets"\]#[{{ .Values.extensionApi.jwtSecret.secretName | quote }}]#g' | \
+                    sed 's#name: controller-manager$#name: jupyter-k8s-controller-manager#' >> "$target"
+            elif [[ "$filename" == "secret.yaml" ]]; then
+                # Secret needs a full rewrite: generate random key instead of hardcoded
+                cat >> "$target" << 'SECRETEOF'
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.extensionApi.jwtSecret.secretName }}
+  labels:
+    app: extensionapi-jwt-rotator
+    component: security
+type: Opaque
+data:
+  jwt-signing-key-{{ now | unixEpoch }}: {{ randBytes 48 | b64enc | quote }}
+SECRETEOF
+            else
+                cat "$file" >> "$target"
+            fi
+
+            echo '{{- end }}' >> "$target"
+            echo "  Patched ${filename}"
+        fi
+    done
+
+    rm -f "${CHART_DIR}/templates/jwt-rotator/kustomization.yaml"
+fi
+
 # Remove connection CRDs as they're meant to be subresources, not standalone CRDs
 echo "Removing connection CRDs from Helm chart..."
 find "${CHART_DIR}/templates/crd/" -name "connection.workspace.jupyter.org_*.yaml" -delete
@@ -224,6 +275,21 @@ if [ -f "${PATCHES_DIR}/manager.yaml.patch" ]; then
             {{- end}}\
             {{- if .Values.extensionApi.enable }}\
             - "--enable-extension-api"\
+            {{- if .Values.extensionApi.jwtIssuer }}\
+            - "--jwt-issuer={{ .Values.extensionApi.jwtIssuer }}"\
+            {{- end}}\
+            {{- if .Values.extensionApi.jwtAudience }}\
+            - "--jwt-audience={{ .Values.extensionApi.jwtAudience }}"\
+            {{- end}}\
+            {{- end}}\
+            {{- if and .Values.extensionApi.enable .Values.extensionApi.jwtSecret.enable }}\
+            - "--jwt-secret-name={{ .Values.extensionApi.jwtSecret.secretName }}"\
+            {{- if .Values.extensionApi.jwtSecret.tokenTTL }}\
+            - "--jwt-ttl={{ .Values.extensionApi.jwtSecret.tokenTTL }}"\
+            {{- end}}\
+            {{- if .Values.extensionApi.jwtSecret.newKeyUseDelay }}\
+            - "--new-key-use-delay={{ .Values.extensionApi.jwtSecret.newKeyUseDelay }}"\
+            {{- end}}\
             {{- end}}\
             {{- if .Values.workspacePodWatching.enable }}\
             - "--enable-workspace-pod-watching"\
@@ -233,7 +299,7 @@ if [ -f "${PATCHES_DIR}/manager.yaml.patch" ]; then
                     # Linux sed
                     sed -i '/args:/,/command:/ {
                     /command:/!d
-                    i\          args:\n            {{- range .Values.controllerManager.container.args }}\n            - {{ . }}\n            {{- end }}\n            - "--application-images-pull-policy={{ .Values.application.imagesPullPolicy }}"\n            - "--application-images-registry={{ .Values.application.imagesRegistry }}"\n            - "--default-template-namespace={{ .Values.workspaceTemplates.defaultNamespace }}"\n            {{- if .Values.accessResources.traefik.enable }}\n            - "--watch-traefik"\n            {{- end}}\n            {{- if .Values.extensionApi.enable }}\n            - "--enable-extension-api"\n            {{- end}}\n            {{- if .Values.workspacePodWatching.enable }}\n            - "--enable-workspace-pod-watching"\n            {{- end}}
+                    i\          args:\n            {{- range .Values.controllerManager.container.args }}\n            - {{ . }}\n            {{- end }}\n            - "--application-images-pull-policy={{ .Values.application.imagesPullPolicy }}"\n            - "--application-images-registry={{ .Values.application.imagesRegistry }}"\n            - "--default-template-namespace={{ .Values.workspaceTemplates.defaultNamespace }}"\n            {{- if .Values.accessResources.traefik.enable }}\n            - "--watch-traefik"\n            {{- end}}\n            {{- if .Values.extensionApi.enable }}\n            - "--enable-extension-api"\n            {{- if .Values.extensionApi.jwtIssuer }}\n            - "--jwt-issuer={{ .Values.extensionApi.jwtIssuer }}"\n            {{- end}}\n            {{- if .Values.extensionApi.jwtAudience }}\n            - "--jwt-audience={{ .Values.extensionApi.jwtAudience }}"\n            {{- end}}\n            {{- end}}\n            {{- if and .Values.extensionApi.enable .Values.extensionApi.jwtSecret.enable }}\n            - "--jwt-secret-name={{ .Values.extensionApi.jwtSecret.secretName }}"\n            {{- if .Values.extensionApi.jwtSecret.tokenTTL }}\n            - "--jwt-ttl={{ .Values.extensionApi.jwtSecret.tokenTTL }}"\n            {{- end}}\n            {{- if .Values.extensionApi.jwtSecret.newKeyUseDelay }}\n            - "--new-key-use-delay={{ .Values.extensionApi.jwtSecret.newKeyUseDelay }}"\n            {{- end}}\n            {{- end}}\n            {{- if .Values.workspacePodWatching.enable }}\n            - "--enable-workspace-pod-watching"\n            {{- end}}
                 }' "${MANAGER_YAML}"
                 fi
                 # Also add extension API volume mount if not already present
@@ -329,6 +395,9 @@ if [ -f "${PATCHES_DIR}/manager.yaml.patch" ]; then
         else
             echo "CONTROLLER_POD_NAMESPACE already exists, skipping env var injection"
         fi
+
+        # JWT params are now passed as flags (--jwt-secret-name, --jwt-ttl, --new-key-use-delay)
+        # in the args block above, so no env var injection needed here.
     else
         echo "Warning: manager.yaml not found at ${MANAGER_YAML}"
     fi

--- a/hack/helm-patches/values.yaml.patch
+++ b/hack/helm-patches/values.yaml.patch
@@ -47,6 +47,7 @@ extensionApi:
       repository: "docker.io"
       imageName: "jupyter-k8s-rotator"
       imageTag: "latest"
+      imagePullPolicy: "IfNotPresent"
       resources:
         requests:
           cpu: 50m

--- a/hack/helm-patches/values.yaml.patch
+++ b/hack/helm-patches/values.yaml.patch
@@ -27,7 +27,30 @@ accessResources:
   # Additional Group-Version-Kind to watch
   additionalGvk: []
 
-# [EXTENSION_API]: Extension API server configuration  
+# [EXTENSION_API]: Extension API server configuration
 extensionApi:
   # Enable extension API server for WorkspaceConnection
   enable: true
+  # JWT issuer and audience claims
+  jwtIssuer: "workspaces-controller"
+  jwtAudience: "workspaces-controller"
+  # K8s-native JWT secret configuration
+  # When enabled, JWTs are signed with HMAC keys from a K8s Secret
+  # instead of AWS KMS. The secret is rotated by a CronJob.
+  jwtSecret:
+    enable: false
+    secretName: "extensionapi-secrets"
+    tokenTTL: "5m"
+    newKeyUseDelay: "5s"
+    rotationInterval: "15m"
+    rotator:
+      repository: "docker.io"
+      imageName: "jupyter-k8s-rotator"
+      imageTag: "latest"
+      resources:
+        requests:
+          cpu: 50m
+          memory: 64Mi
+        limits:
+          cpu: 100m
+          memory: 128Mi

--- a/images/rotator/Dockerfile
+++ b/images/rotator/Dockerfile
@@ -34,10 +34,5 @@ WORKDIR /
 COPY --from=builder /workspace/rotator /rotator
 USER 65532:65532
 
-# Set default environment variables
-ENV SECRET_NAME=authmiddleware-secrets \
-    SECRET_NAMESPACE=jupyter-k8s-system \
-    NUMBER_OF_KEYS=6 \
-    DRY_RUN=false
 
 ENTRYPOINT ["/rotator"]

--- a/internal/authmiddleware/setup.go
+++ b/internal/authmiddleware/setup.go
@@ -6,17 +6,11 @@ Distributed under the terms of the MIT license
 package authmiddleware
 
 import (
-	"context"
 	"fmt"
 	"log/slog"
 	"os"
 
-	"github.com/go-logr/logr"
-	corev1 "k8s.io/api/core/v1"
-	toolscache "k8s.io/client-go/tools/cache"
 	ctrl "sigs.k8s.io/controller-runtime"
-
-	"github.com/jupyter-infra/jupyter-k8s/internal/jwt"
 )
 
 // SetupAuthMiddlewareWithManager sets up the authentication middleware server
@@ -49,11 +43,10 @@ func SetupAuthMiddlewareWithManager(mgr ctrl.Manager, cfg *Config) error {
 			"secret", cfg.JwtSecretName,
 			"namespace", cfg.Namespace)
 
-		if err := registerSecretWatchHandlers(
+		if err := standardSigner.RegisterSecretWatch(
 			mgr,
 			cfg.JwtSecretName,
 			cfg.Namespace,
-			standardSigner,
 			logrLogger.WithName("secret-watch"),
 		); err != nil {
 			return fmt.Errorf("failed to register secret watch handlers: %w", err)
@@ -86,97 +79,5 @@ func SetupAuthMiddlewareWithManager(mgr ctrl.Manager, cfg *Config) error {
 	}
 
 	logrLogger.Info("Authentication middleware setup complete")
-	return nil
-}
-
-// registerSecretWatchHandlers registers informer event handlers to watch for secret changes
-// and update the StandardSigner when keys are rotated.
-func registerSecretWatchHandlers(
-	mgr ctrl.Manager,
-	secretName string,
-	namespace string,
-	standardSigner *jwt.StandardSigner,
-	logger logr.Logger,
-) error {
-	// Get informer for Secrets from the manager's cache
-	// This provides automatic retry/backoff and reconnection
-	ctx := context.Background()
-	informer, err := mgr.GetCache().GetInformer(ctx, &corev1.Secret{})
-	if err != nil {
-		return fmt.Errorf("failed to get secret informer: %w", err)
-	}
-
-	// Helper function to update signer from secret
-	updateSignerFromSecret := func(secret *corev1.Secret) {
-		// Parse signing keys from secret
-		signingKeys, latestKid, err := jwt.ParseSigningKeysFromSecret(secret)
-		if err != nil {
-			logger.Error(err, "Failed to parse signing keys")
-			return
-		}
-
-		// Update signer with new keys
-		if err := standardSigner.UpdateKeys(signingKeys, latestKid); err != nil {
-			logger.Error(err, "Failed to update signing keys")
-			return
-		}
-
-		logger.Info("Successfully updated signing keys from secret",
-			"keyCount", len(signingKeys),
-			"latestKid", latestKid)
-	}
-
-	// Add event handler with filtering by secret name and namespace
-	_, err = informer.AddEventHandler(toolscache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			secret, ok := obj.(*corev1.Secret)
-			if !ok {
-				logger.Error(fmt.Errorf("unexpected object type: %T", obj),
-					"Failed to cast add event object to Secret")
-				return
-			}
-
-			// Filter: only process our specific secret
-			if secret.Name == secretName && secret.Namespace == namespace {
-				logger.Info("Secret added event received", "secret", secret.Name, "namespace", secret.Namespace)
-				updateSignerFromSecret(secret)
-			}
-		},
-		UpdateFunc: func(oldObj, newObj interface{}) {
-			secret, ok := newObj.(*corev1.Secret)
-			if !ok {
-				logger.Error(fmt.Errorf("unexpected object type: %T", newObj),
-					"Failed to cast update event object to Secret")
-				return
-			}
-
-			// Filter: only process our specific secret
-			if secret.Name == secretName && secret.Namespace == namespace {
-				logger.Info("Secret updated event received", "secret", secret.Name, "namespace", secret.Namespace)
-				updateSignerFromSecret(secret)
-			}
-		},
-		DeleteFunc: func(obj interface{}) {
-			secret, ok := obj.(*corev1.Secret)
-			if !ok {
-				logger.Error(fmt.Errorf("unexpected object type: %T", obj),
-					"Failed to cast delete event object to Secret")
-				return
-			}
-
-			// Filter: only process our specific secret
-			if secret.Name == secretName && secret.Namespace == namespace {
-				logger.Error(fmt.Errorf("secret was deleted"), "Secret deleted",
-					"secret", secretName,
-					"namespace", namespace)
-				// No action needed - secret might be recreated and we'll get an Add event
-			}
-		},
-	})
-	if err != nil {
-		return fmt.Errorf("failed to add event handler to informer: %w", err)
-	}
-
-	logger.Info("Secret watch event handlers registered")
 	return nil
 }

--- a/internal/extensionapi/config.go
+++ b/internal/extensionapi/config.go
@@ -6,6 +6,8 @@ Distributed under the terms of the MIT license
 // Package extensionapi provides extension API server functionality.
 package extensionapi
 
+import "time"
+
 // Default values
 const (
 	// Server defaults
@@ -18,6 +20,12 @@ const (
 	DefaultReadTimeoutSeconds  = 30
 	DefaultWriteTimeoutSeconds = 120
 	DefaultAllowedOrigin       = "*"
+
+	// JWT defaults
+	DefaultJwtIssuer      = "workspaces-controller"
+	DefaultJwtAudience    = "workspaces-controller"
+	DefaultJwtTTL         = 5 * time.Minute
+	DefaultNewKeyUseDelay = 5 * time.Second
 )
 
 // ExtensionConfig contains the configuration for the extension API server
@@ -35,6 +43,16 @@ type ExtensionConfig struct {
 	ClusterId string
 	KMSKeyID  string
 	Domain    string
+
+	// Controller namespace (from Downward API)
+	ControllerNamespace string
+
+	// JWT signing section
+	JwtIssuer      string
+	JwtAudience    string
+	JwtSecretName  string
+	JwtTTL         time.Duration
+	NewKeyUseDelay time.Duration
 }
 
 // ConfigOption is a function that modifies an ExtensionConfig
@@ -121,6 +139,49 @@ func WithDomain(domain string) ConfigOption {
 func WithClusterId(id string) ConfigOption {
 	return func(c *ExtensionConfig) {
 		c.ClusterId = id
+	}
+}
+
+// WithControllerNamespace sets the namespace the controller is running in.
+func WithControllerNamespace(ns string) ConfigOption {
+	return func(c *ExtensionConfig) {
+		c.ControllerNamespace = ns
+	}
+}
+
+// WithJwtIssuer sets the JWT issuer claim.
+func WithJwtIssuer(issuer string) ConfigOption {
+	return func(c *ExtensionConfig) {
+		c.JwtIssuer = issuer
+	}
+}
+
+// WithJwtAudience sets the JWT audience claim.
+func WithJwtAudience(audience string) ConfigOption {
+	return func(c *ExtensionConfig) {
+		c.JwtAudience = audience
+	}
+}
+
+// WithJwtSecretName sets the K8s Secret name for JWT signing keys.
+// When set, the extension API uses StandardSignerFactory instead of AWSSignerFactory.
+func WithJwtSecretName(name string) ConfigOption {
+	return func(c *ExtensionConfig) {
+		c.JwtSecretName = name
+	}
+}
+
+// WithJwtTTL sets the JWT expiration duration.
+func WithJwtTTL(ttl time.Duration) ConfigOption {
+	return func(c *ExtensionConfig) {
+		c.JwtTTL = ttl
+	}
+}
+
+// WithNewKeyUseDelay sets the cooloff delay before using a newly rotated signing key.
+func WithNewKeyUseDelay(delay time.Duration) ConfigOption {
+	return func(c *ExtensionConfig) {
+		c.NewKeyUseDelay = delay
 	}
 }
 

--- a/internal/extensionapi/k8s_secret_jwt_initializer.go
+++ b/internal/extensionapi/k8s_secret_jwt_initializer.go
@@ -1,0 +1,62 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package extensionapi
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"github.com/jupyter-infra/jupyter-k8s/internal/jwt"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// k8sSecretJwtInitializer loads initial JWT signing keys from a K8s Secret on startup.
+// It implements the controller-runtime Runnable interface.
+type k8sSecretJwtInitializer struct {
+	signer     *jwt.StandardSigner
+	secretName string
+	namespace  string
+	logger     logr.Logger
+}
+
+func newK8sSecretJwtInitializer(signer *jwt.StandardSigner, secretName, namespace string, logger logr.Logger) *k8sSecretJwtInitializer {
+	return &k8sSecretJwtInitializer{
+		signer:     signer,
+		secretName: secretName,
+		namespace:  namespace,
+		logger:     logger,
+	}
+}
+
+func (b *k8sSecretJwtInitializer) Start(ctx context.Context) error {
+	b.logger.Info("Loading initial JWT signing keys",
+		"secret", b.secretName,
+		"namespace", b.namespace)
+
+	// Use a direct client (not cached) to ensure we get the latest secret
+	cfg, err := ctrl.GetConfig()
+	if err != nil {
+		return fmt.Errorf("failed to get rest config: %w", err)
+	}
+
+	directClient, err := client.New(cfg, client.Options{})
+	if err != nil {
+		return fmt.Errorf("failed to create direct client: %w", err)
+	}
+
+	if err := b.signer.RetrieveInitialSecret(ctx, directClient, b.secretName, b.namespace); err != nil {
+		return fmt.Errorf("failed to load initial JWT signing keys: %w", err)
+	}
+
+	b.logger.Info("Successfully loaded initial JWT signing keys")
+	return nil
+}
+
+func (b *k8sSecretJwtInitializer) NeedLeaderElection() bool {
+	return false
+}

--- a/internal/extensionapi/server.go
+++ b/internal/extensionapi/server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/jupyter-infra/jupyter-k8s/internal/aws"
 	"github.com/jupyter-infra/jupyter-k8s/internal/jwt"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	genericapiserver "k8s.io/apiserver/pkg/server"
@@ -24,6 +25,7 @@ import (
 	"k8s.io/apiserver/pkg/util/compatibility"
 	"k8s.io/client-go/kubernetes"
 	v1 "k8s.io/client-go/kubernetes/typed/authorization/v1"
+	toolscache "k8s.io/client-go/tools/cache"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -238,17 +240,53 @@ func createGenericAPIServer(recommendedOptions *genericoptions.RecommendedOption
 	return genericServer, nil
 }
 
-func createJWTSignerFactory(config *ExtensionConfig) (jwt.SignerFactory, error) {
-	// Create KMS client and signer factory
-	ctx := context.Background()
-	kmsClient, err := aws.NewKMSClient(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create KMS client: %w", err)
+func createJWTCompositeSignerFactory(config *ExtensionConfig) (jwt.SignerFactory, error) {
+	factories := map[string]jwt.SignerFactory{}
+	var defaultFactory jwt.SignerFactory
+
+	if config.JwtSecretName != "" {
+		ttl := config.JwtTTL
+		if ttl == 0 {
+			ttl = DefaultJwtTTL
+		}
+		newKeyDelay := config.NewKeyUseDelay
+		if newKeyDelay == 0 {
+			newKeyDelay = DefaultNewKeyUseDelay
+		}
+		issuer := config.JwtIssuer
+		if issuer == "" {
+			issuer = DefaultJwtIssuer
+		}
+		audience := config.JwtAudience
+		if audience == "" {
+			audience = DefaultJwtAudience
+		}
+		signer := jwt.NewStandardSigner(issuer, audience, ttl, newKeyDelay)
+		stdFactory := jwt.NewStandardSignerFactory(signer)
+		factories["k8s-native"] = stdFactory
+		defaultFactory = stdFactory
 	}
 
-	signerFactory := aws.NewAWSSignerFactory(kmsClient, config.KMSKeyID, time.Minute*5)
+	if config.KMSKeyID != "" || defaultFactory == nil {
+		ctx := context.Background()
+		kmsClient, err := aws.NewKMSClient(ctx)
+		if err != nil {
+			if defaultFactory != nil {
+				// k8s-native is available; AWS is optional
+				setupLog.Info("AWS KMS not available, using k8s-native signing only", "error", err)
+			} else {
+				return nil, fmt.Errorf("failed to create KMS client: %w", err)
+			}
+		} else {
+			awsFactory := aws.NewAWSSignerFactory(kmsClient, config.KMSKeyID, time.Minute*5)
+			factories["aws"] = awsFactory
+			if defaultFactory == nil {
+				defaultFactory = awsFactory
+			}
+		}
+	}
 
-	return signerFactory, nil
+	return jwt.NewCompositeSignerFactory(factories, defaultFactory), nil
 }
 
 // createExtensionServer creates and configures the extension server
@@ -275,10 +313,45 @@ func SetupExtensionAPIServerWithManager(mgr ctrl.Manager, config *ExtensionConfi
 
 	logger := mgr.GetLogger().WithName("extension-api")
 
-	// Create JWT manager
-	signerFactory, err := createJWTSignerFactory(config)
+	// Create JWT signer factory
+	signerFactory, err := createJWTCompositeSignerFactory(config)
 	if err != nil {
 		return err
+	}
+
+	// When using k8s-native signing, register secret watch and initial key loader
+	if config.JwtSecretName != "" {
+		composite := signerFactory.(*jwt.CompositeSignerFactory)
+		nativeFactory, _ := composite.GetFactory("k8s-native")
+		stdFactory := nativeFactory.(*jwt.StandardSignerFactory)
+
+		namespace := config.ControllerNamespace
+		if namespace == "" {
+			return fmt.Errorf("ControllerNamespace must be set when using JWT secret")
+		}
+
+		logger.Info("Registering JWT secret watch event handlers",
+			"secret", config.JwtSecretName,
+			"namespace", namespace)
+
+		if err := registerSecretWatchHandlers(
+			mgr,
+			config.JwtSecretName,
+			namespace,
+			stdFactory.Signer(),
+			logger.WithName("jwt-secret-watch"),
+		); err != nil {
+			return fmt.Errorf("failed to register JWT secret watch handlers: %w", err)
+		}
+
+		if err := mgr.Add(newK8sSecretJwtInitializer(
+			stdFactory.Signer(),
+			config.JwtSecretName,
+			namespace,
+			logger.WithName("jwt-secret-init"),
+		)); err != nil {
+			return fmt.Errorf("failed to add k8s secret JWT initializer: %w", err)
+		}
 	}
 
 	// Create SAR client
@@ -299,4 +372,77 @@ func SetupExtensionAPIServerWithManager(mgr ctrl.Manager, config *ExtensionConfi
 
 	// Add server to manager
 	return addServerToManager(mgr, server)
+}
+
+// registerSecretWatchHandlers registers informer event handlers to watch for secret changes
+// and update the StandardSigner when keys are rotated.
+func registerSecretWatchHandlers(
+	mgr ctrl.Manager,
+	secretName string,
+	namespace string,
+	standardSigner *jwt.StandardSigner,
+	logger logr.Logger,
+) error {
+	ctx := context.Background()
+	informer, err := mgr.GetCache().GetInformer(ctx, &corev1.Secret{})
+	if err != nil {
+		return fmt.Errorf("failed to get secret informer: %w", err)
+	}
+
+	updateSignerFromSecret := func(secret *corev1.Secret) {
+		signingKeys, latestKid, err := jwt.ParseSigningKeysFromSecret(secret)
+		if err != nil {
+			logger.Error(err, "Failed to parse signing keys")
+			return
+		}
+
+		if err := standardSigner.UpdateKeys(signingKeys, latestKid); err != nil {
+			logger.Error(err, "Failed to update signing keys")
+			return
+		}
+
+		logger.Info("Successfully updated signing keys from secret",
+			"keyCount", len(signingKeys),
+			"latestKid", latestKid)
+	}
+
+	_, err = informer.AddEventHandler(toolscache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			secret, ok := obj.(*corev1.Secret)
+			if !ok {
+				return
+			}
+			if secret.Name == secretName && secret.Namespace == namespace {
+				logger.Info("Secret added event received", "secret", secret.Name, "namespace", secret.Namespace)
+				updateSignerFromSecret(secret)
+			}
+		},
+		UpdateFunc: func(_, newObj interface{}) {
+			secret, ok := newObj.(*corev1.Secret)
+			if !ok {
+				return
+			}
+			if secret.Name == secretName && secret.Namespace == namespace {
+				logger.Info("Secret updated event received", "secret", secret.Name, "namespace", secret.Namespace)
+				updateSignerFromSecret(secret)
+			}
+		},
+		DeleteFunc: func(obj interface{}) {
+			secret, ok := obj.(*corev1.Secret)
+			if !ok {
+				return
+			}
+			if secret.Name == secretName && secret.Namespace == namespace {
+				logger.Error(fmt.Errorf("secret was deleted"), "JWT secret deleted",
+					"secret", secretName,
+					"namespace", namespace)
+			}
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to add event handler to informer: %w", err)
+	}
+
+	logger.Info("JWT secret watch event handlers registered")
+	return nil
 }

--- a/internal/extensionapi/server.go
+++ b/internal/extensionapi/server.go
@@ -16,7 +16,6 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/jupyter-infra/jupyter-k8s/internal/aws"
 	"github.com/jupyter-infra/jupyter-k8s/internal/jwt"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	genericapiserver "k8s.io/apiserver/pkg/server"
@@ -25,7 +24,6 @@ import (
 	"k8s.io/apiserver/pkg/util/compatibility"
 	"k8s.io/client-go/kubernetes"
 	v1 "k8s.io/client-go/kubernetes/typed/authorization/v1"
-	toolscache "k8s.io/client-go/tools/cache"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -334,17 +332,16 @@ func SetupExtensionAPIServerWithManager(mgr ctrl.Manager, config *ExtensionConfi
 			"secret", config.JwtSecretName,
 			"namespace", namespace)
 
-		if err := registerSecretWatchHandlers(
+		if err := stdFactory.Signer().RegisterSecretWatch(
 			mgr,
 			config.JwtSecretName,
 			namespace,
-			stdFactory.Signer(),
 			logger.WithName("jwt-secret-watch"),
 		); err != nil {
 			return fmt.Errorf("failed to register JWT secret watch handlers: %w", err)
 		}
 
-		if err := mgr.Add(newK8sSecretJwtInitializer(
+		if err := mgr.Add(jwt.NewSecretInitializer(
 			stdFactory.Signer(),
 			config.JwtSecretName,
 			namespace,
@@ -372,77 +369,4 @@ func SetupExtensionAPIServerWithManager(mgr ctrl.Manager, config *ExtensionConfi
 
 	// Add server to manager
 	return addServerToManager(mgr, server)
-}
-
-// registerSecretWatchHandlers registers informer event handlers to watch for secret changes
-// and update the StandardSigner when keys are rotated.
-func registerSecretWatchHandlers(
-	mgr ctrl.Manager,
-	secretName string,
-	namespace string,
-	standardSigner *jwt.StandardSigner,
-	logger logr.Logger,
-) error {
-	ctx := context.Background()
-	informer, err := mgr.GetCache().GetInformer(ctx, &corev1.Secret{})
-	if err != nil {
-		return fmt.Errorf("failed to get secret informer: %w", err)
-	}
-
-	updateSignerFromSecret := func(secret *corev1.Secret) {
-		signingKeys, latestKid, err := jwt.ParseSigningKeysFromSecret(secret)
-		if err != nil {
-			logger.Error(err, "Failed to parse signing keys")
-			return
-		}
-
-		if err := standardSigner.UpdateKeys(signingKeys, latestKid); err != nil {
-			logger.Error(err, "Failed to update signing keys")
-			return
-		}
-
-		logger.Info("Successfully updated signing keys from secret",
-			"keyCount", len(signingKeys),
-			"latestKid", latestKid)
-	}
-
-	_, err = informer.AddEventHandler(toolscache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			secret, ok := obj.(*corev1.Secret)
-			if !ok {
-				return
-			}
-			if secret.Name == secretName && secret.Namespace == namespace {
-				logger.Info("Secret added event received", "secret", secret.Name, "namespace", secret.Namespace)
-				updateSignerFromSecret(secret)
-			}
-		},
-		UpdateFunc: func(_, newObj interface{}) {
-			secret, ok := newObj.(*corev1.Secret)
-			if !ok {
-				return
-			}
-			if secret.Name == secretName && secret.Namespace == namespace {
-				logger.Info("Secret updated event received", "secret", secret.Name, "namespace", secret.Namespace)
-				updateSignerFromSecret(secret)
-			}
-		},
-		DeleteFunc: func(obj interface{}) {
-			secret, ok := obj.(*corev1.Secret)
-			if !ok {
-				return
-			}
-			if secret.Name == secretName && secret.Namespace == namespace {
-				logger.Error(fmt.Errorf("secret was deleted"), "JWT secret deleted",
-					"secret", secretName,
-					"namespace", namespace)
-			}
-		},
-	})
-	if err != nil {
-		return fmt.Errorf("failed to add event handler to informer: %w", err)
-	}
-
-	logger.Info("JWT secret watch event handlers registered")
-	return nil
 }

--- a/internal/extensionapi/server_test.go
+++ b/internal/extensionapi/server_test.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
+	"github.com/jupyter-infra/jupyter-k8s/internal/jwt"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	genericapiserver "k8s.io/apiserver/pkg/server"
@@ -542,14 +543,31 @@ var _ = Describe("Server", func() {
 	})
 
 	Context("Helper Functions", func() {
-		Describe("createJWTSignerFactory", func() {
+		Describe("createJWTCompositeSignerFactory", func() {
 			It("Should not fail startup with empty KMS key ID", func() {
 				config := NewConfig(WithKMSKeyID(""))
-				_, err := createJWTSignerFactory(config)
+				_, err := createJWTCompositeSignerFactory(config)
 				// Should not fail startup due to empty KMS key ID
 				if err != nil {
 					Skip("Requires AWS KMS setup")
 				}
+			})
+
+			It("Should create CompositeSignerFactory with k8s-native when JwtSecretName is set", func() {
+				config := NewConfig(WithJwtSecretName("test-secret"))
+				factory, err := createJWTCompositeSignerFactory(config)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(factory).NotTo(BeNil())
+
+				composite, ok := factory.(*jwt.CompositeSignerFactory)
+				Expect(ok).To(BeTrue())
+
+				nativeFactory, found := composite.GetFactory("k8s-native")
+				Expect(found).To(BeTrue())
+
+				stdFactory, ok := nativeFactory.(*jwt.StandardSignerFactory)
+				Expect(ok).To(BeTrue())
+				Expect(stdFactory.Signer()).NotTo(BeNil())
 			})
 
 			It("Should create JWT manager with valid KMS key", func() {
@@ -606,7 +624,7 @@ var _ = Describe("Server", func() {
 				config := NewConfig(WithKMSKeyID("test-key"))
 
 				// This may or may not fail depending on environment
-				_, _ = createJWTSignerFactory(config)
+				_, _ = createJWTCompositeSignerFactory(config)
 
 				// We just want to test the code path is executed
 				Expect(true).To(BeTrue())
@@ -836,9 +854,9 @@ var _ = Describe("ServerWithManager", func() {
 			options := createRecommendedOptions(config)
 			Expect(options.SecureServing.BindPort).To(Equal(9999))
 
-			// Test createJWTSignerFactory with empty KMS key ID - should not fail startup
+			// Test createJWTCompositeSignerFactory with empty KMS key ID - should not fail startup
 			config = NewConfig(WithKMSKeyID(""))
-			_, err := createJWTSignerFactory(config)
+			_, err := createJWTCompositeSignerFactory(config)
 			// Should not fail startup due to empty KMS key ID
 			if err != nil {
 				Skip("Requires AWS KMS setup")

--- a/internal/extensionapi/serverroute_connection.go
+++ b/internal/extensionapi/serverroute_connection.go
@@ -197,10 +197,12 @@ func (s *ExtensionServer) generateWebUIBearerTokenURL(r *http.Request, ws *works
 func (s *ExtensionServer) HandleConnectionCreate(w http.ResponseWriter, r *http.Request) {
 	logger := GetLoggerFromContext(r.Context())
 
-	// Ensure AWS resources are initialized (only happens once)
-	if err := aws.EnsureResourcesInitialized(r.Context()); err != nil {
-		WriteKubernetesError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to initialize resources: %v", err))
-		return
+	// Ensure AWS resources are initialized (only happens once, only when AWS is configured)
+	if s.config.ClusterId != "" {
+		if err := aws.EnsureResourcesInitialized(r.Context()); err != nil {
+			WriteKubernetesError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to initialize resources: %v", err))
+			return
+		}
 	}
 
 	if r.Method != "POST" {

--- a/internal/jwt/composite_signer_factory.go
+++ b/internal/jwt/composite_signer_factory.go
@@ -1,0 +1,53 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package jwt
+
+import (
+	"fmt"
+
+	workspacev1alpha1 "github.com/jupyter-infra/jupyter-k8s/api/v1alpha1"
+)
+
+// CompositeSignerFactory dispatches to the appropriate SignerFactory based on the
+// access strategy's CreateConnectionHandler field.
+type CompositeSignerFactory struct {
+	factories      map[string]SignerFactory
+	defaultFactory SignerFactory
+}
+
+// NewCompositeSignerFactory creates a factory that routes to child factories by handler name.
+// The defaultFactory is used when the access strategy is nil or has an empty handler.
+func NewCompositeSignerFactory(factories map[string]SignerFactory, defaultFactory SignerFactory) *CompositeSignerFactory {
+	return &CompositeSignerFactory{
+		factories:      factories,
+		defaultFactory: defaultFactory,
+	}
+}
+
+// CreateSigner delegates to the child factory matching the access strategy's handler.
+func (c *CompositeSignerFactory) CreateSigner(accessStrategy *workspacev1alpha1.WorkspaceAccessStrategy) (Signer, error) {
+	if accessStrategy == nil || accessStrategy.Spec.CreateConnectionHandler == "" {
+		return c.defaultFactory.CreateSigner(accessStrategy)
+	}
+
+	handler := accessStrategy.Spec.CreateConnectionHandler
+	factory, ok := c.factories[handler]
+	if !ok {
+		supported := make([]string, 0, len(c.factories))
+		for k := range c.factories {
+			supported = append(supported, k)
+		}
+		return nil, fmt.Errorf("unsupported connection handler %q (available: %v)", handler, supported)
+	}
+
+	return factory.CreateSigner(accessStrategy)
+}
+
+// GetFactory returns the child factory registered for the given handler name.
+func (c *CompositeSignerFactory) GetFactory(handler string) (SignerFactory, bool) {
+	f, ok := c.factories[handler]
+	return f, ok
+}

--- a/internal/jwt/composite_signer_factory_test.go
+++ b/internal/jwt/composite_signer_factory_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package jwt
+
+import (
+	"testing"
+	"time"
+
+	workspacev1alpha1 "github.com/jupyter-infra/jupyter-k8s/api/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestFactory(label string) *StandardSignerFactory {
+	signer := NewStandardSigner("issuer-"+label, "audience-"+label, 5*time.Minute, 0)
+	_ = signer.UpdateKeys(map[string][]byte{
+		"kid-" + label: []byte("test-signing-key-at-least-48-bytes-long-for-hs384!"),
+	}, "kid-"+label)
+	return NewStandardSignerFactory(signer)
+}
+
+func TestCompositeSignerFactory_NilAccessStrategy(t *testing.T) {
+	defaultFactory := newTestFactory("default")
+	composite := NewCompositeSignerFactory(map[string]SignerFactory{
+		"k8s-native": defaultFactory,
+	}, defaultFactory)
+
+	signer, err := composite.CreateSigner(nil)
+
+	require.NoError(t, err)
+	assert.NotNil(t, signer)
+}
+
+func TestCompositeSignerFactory_EmptyHandler(t *testing.T) {
+	defaultFactory := newTestFactory("default")
+	composite := NewCompositeSignerFactory(map[string]SignerFactory{
+		"k8s-native": defaultFactory,
+	}, defaultFactory)
+
+	signer, err := composite.CreateSigner(&workspacev1alpha1.WorkspaceAccessStrategy{
+		Spec: workspacev1alpha1.WorkspaceAccessStrategySpec{
+			CreateConnectionHandler: "",
+		},
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, signer)
+}
+
+func TestCompositeSignerFactory_RoutesToRegisteredFactory(t *testing.T) {
+	nativeFactory := newTestFactory("native")
+	composite := NewCompositeSignerFactory(map[string]SignerFactory{
+		"k8s-native": nativeFactory,
+	}, nativeFactory)
+
+	signer, err := composite.CreateSigner(&workspacev1alpha1.WorkspaceAccessStrategy{
+		Spec: workspacev1alpha1.WorkspaceAccessStrategySpec{
+			CreateConnectionHandler: "k8s-native",
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, nativeFactory.Signer(), signer)
+}
+
+func TestCompositeSignerFactory_DefaultFactoryUsedForEmptyHandler(t *testing.T) {
+	defaultFactory := newTestFactory("default")
+	otherFactory := newTestFactory("other")
+	composite := NewCompositeSignerFactory(map[string]SignerFactory{
+		"k8s-native": otherFactory,
+	}, defaultFactory)
+
+	// Empty handler uses defaultFactory, not the map
+	signer, err := composite.CreateSigner(&workspacev1alpha1.WorkspaceAccessStrategy{
+		Spec: workspacev1alpha1.WorkspaceAccessStrategySpec{
+			CreateConnectionHandler: "",
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, defaultFactory.Signer(), signer)
+}
+
+func TestCompositeSignerFactory_UnsupportedHandler(t *testing.T) {
+	composite := NewCompositeSignerFactory(map[string]SignerFactory{
+		"k8s-native": newTestFactory("native"),
+	}, newTestFactory("default"))
+
+	signer, err := composite.CreateSigner(&workspacev1alpha1.WorkspaceAccessStrategy{
+		Spec: workspacev1alpha1.WorkspaceAccessStrategySpec{
+			CreateConnectionHandler: "nonexistent",
+		},
+	})
+
+	assert.Error(t, err)
+	assert.Nil(t, signer)
+	assert.Contains(t, err.Error(), "unsupported connection handler")
+	assert.Contains(t, err.Error(), "nonexistent")
+}
+
+func TestCompositeSignerFactory_GetFactory(t *testing.T) {
+	nativeFactory := newTestFactory("native")
+	composite := NewCompositeSignerFactory(map[string]SignerFactory{
+		"k8s-native": nativeFactory,
+	}, nativeFactory)
+
+	f, ok := composite.GetFactory("k8s-native")
+	assert.True(t, ok)
+	assert.Equal(t, nativeFactory, f)
+
+	_, ok = composite.GetFactory("nonexistent")
+	assert.False(t, ok)
+}

--- a/internal/jwt/secret_initializer.go
+++ b/internal/jwt/secret_initializer.go
@@ -3,29 +3,30 @@ Copyright (c) Amazon Web Services
 Distributed under the terms of the MIT license
 */
 
-package extensionapi
+package jwt
 
 import (
 	"context"
 	"fmt"
 
 	"github.com/go-logr/logr"
-	"github.com/jupyter-infra/jupyter-k8s/internal/jwt"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// k8sSecretJwtInitializer loads initial JWT signing keys from a K8s Secret on startup.
+// SecretInitializer loads initial JWT signing keys from a K8s Secret on startup.
 // It implements the controller-runtime Runnable interface.
-type k8sSecretJwtInitializer struct {
-	signer     *jwt.StandardSigner
+type SecretInitializer struct {
+	signer     *StandardSigner
 	secretName string
 	namespace  string
 	logger     logr.Logger
 }
 
-func newK8sSecretJwtInitializer(signer *jwt.StandardSigner, secretName, namespace string, logger logr.Logger) *k8sSecretJwtInitializer {
-	return &k8sSecretJwtInitializer{
+// NewSecretInitializer creates a new SecretInitializer that loads initial JWT signing keys
+// from the specified K8s Secret when started.
+func NewSecretInitializer(signer *StandardSigner, secretName, namespace string, logger logr.Logger) *SecretInitializer {
+	return &SecretInitializer{
 		signer:     signer,
 		secretName: secretName,
 		namespace:  namespace,
@@ -33,7 +34,8 @@ func newK8sSecretJwtInitializer(signer *jwt.StandardSigner, secretName, namespac
 	}
 }
 
-func (b *k8sSecretJwtInitializer) Start(ctx context.Context) error {
+// Start loads the initial JWT signing keys from the K8s Secret. Implements the controller-runtime Runnable interface.
+func (b *SecretInitializer) Start(ctx context.Context) error {
 	b.logger.Info("Loading initial JWT signing keys",
 		"secret", b.secretName,
 		"namespace", b.namespace)
@@ -57,6 +59,7 @@ func (b *k8sSecretJwtInitializer) Start(ctx context.Context) error {
 	return nil
 }
 
-func (b *k8sSecretJwtInitializer) NeedLeaderElection() bool {
+// NeedLeaderElection returns false because secret initialization should run on all replicas.
+func (b *SecretInitializer) NeedLeaderElection() bool {
 	return false
 }

--- a/internal/jwt/secret_watch.go
+++ b/internal/jwt/secret_watch.go
@@ -1,0 +1,95 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package jwt
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	toolscache "k8s.io/client-go/tools/cache"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+// RegisterSecretWatch registers informer event handlers to watch for secret changes
+// and update the StandardSigner when keys are rotated.
+func (s *StandardSigner) RegisterSecretWatch(
+	mgr ctrl.Manager,
+	secretName string,
+	namespace string,
+	logger logr.Logger,
+) error {
+	// Get informer for Secrets from the manager's cache
+	// This provides automatic retry/backoff and reconnection
+	ctx := context.Background()
+	informer, err := mgr.GetCache().GetInformer(ctx, &corev1.Secret{})
+	if err != nil {
+		return fmt.Errorf("failed to get secret informer: %w", err)
+	}
+
+	// Helper function to update signer from secret
+	updateSignerFromSecret := func(secret *corev1.Secret) {
+		signingKeys, latestKid, err := ParseSigningKeysFromSecret(secret)
+		if err != nil {
+			logger.Error(err, "Failed to parse signing keys")
+			return
+		}
+
+		if err := s.UpdateKeys(signingKeys, latestKid); err != nil {
+			logger.Error(err, "Failed to update signing keys")
+			return
+		}
+
+		logger.Info("Successfully updated signing keys from secret",
+			"keyCount", len(signingKeys),
+			"latestKid", latestKid)
+	}
+
+	// Add event handler with filtering by secret name and namespace
+	_, err = informer.AddEventHandler(toolscache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			secret, ok := obj.(*corev1.Secret)
+			if !ok {
+				return
+			}
+			// Filter: only process our specific secret
+			if secret.Name == secretName && secret.Namespace == namespace {
+				logger.Info("Secret added event received", "secret", secret.Name, "namespace", secret.Namespace)
+				updateSignerFromSecret(secret)
+			}
+		},
+		UpdateFunc: func(_, newObj interface{}) {
+			secret, ok := newObj.(*corev1.Secret)
+			if !ok {
+				return
+			}
+			// Filter: only process our specific secret
+			if secret.Name == secretName && secret.Namespace == namespace {
+				logger.Info("Secret updated event received", "secret", secret.Name, "namespace", secret.Namespace)
+				updateSignerFromSecret(secret)
+			}
+		},
+		DeleteFunc: func(obj interface{}) {
+			secret, ok := obj.(*corev1.Secret)
+			if !ok {
+				return
+			}
+			// Filter: only process our specific secret
+			if secret.Name == secretName && secret.Namespace == namespace {
+				logger.Error(fmt.Errorf("secret was deleted"), "JWT secret deleted",
+					"secret", secretName,
+					"namespace", namespace)
+			}
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to add event handler to informer: %w", err)
+	}
+
+	logger.Info("JWT secret watch event handlers registered")
+	return nil
+}

--- a/internal/jwt/standard_signer_factory.go
+++ b/internal/jwt/standard_signer_factory.go
@@ -1,0 +1,50 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package jwt
+
+import (
+	"fmt"
+
+	workspacev1alpha1 "github.com/jupyter-infra/jupyter-k8s/api/v1alpha1"
+)
+
+// StandardSignerFactory creates JWT signers using a shared StandardSigner backed by K8s Secrets.
+// Unlike AWSSignerFactory which creates per-strategy signers, this factory reuses a single
+// StandardSigner instance since all k8s-native strategies share the same Secret-based keys.
+type StandardSignerFactory struct {
+	signer *StandardSigner
+}
+
+// NewStandardSignerFactory creates a new factory wrapping a shared StandardSigner.
+func NewStandardSignerFactory(signer *StandardSigner) *StandardSignerFactory {
+	return &StandardSignerFactory{
+		signer: signer,
+	}
+}
+
+// Signer returns the underlying StandardSigner for direct access (e.g. key updates).
+func (f *StandardSignerFactory) Signer() *StandardSigner {
+	return f.signer
+}
+
+// CreateSigner returns the shared StandardSigner for compatible access strategies.
+// Accepts "" (auto/default) and "k8s-native" handlers. Rejects "aws" since that
+// requires AWSSignerFactory.
+func (f *StandardSignerFactory) CreateSigner(accessStrategy *workspacev1alpha1.WorkspaceAccessStrategy) (Signer, error) {
+	if accessStrategy == nil {
+		return f.signer, nil
+	}
+
+	handler := accessStrategy.Spec.CreateConnectionHandler
+	switch handler {
+	case "", "k8s-native":
+		return f.signer, nil
+	case "aws":
+		return nil, fmt.Errorf("access strategy requires \"aws\" handler, but only \"k8s-native\" signing is configured")
+	default:
+		return nil, fmt.Errorf("unsupported connection handler: %s", handler)
+	}
+}

--- a/internal/jwt/standard_signer_factory_test.go
+++ b/internal/jwt/standard_signer_factory_test.go
@@ -1,0 +1,126 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package jwt
+
+import (
+	"testing"
+	"time"
+
+	workspacev1alpha1 "github.com/jupyter-infra/jupyter-k8s/api/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestStandardSignerFactory() (*StandardSignerFactory, *StandardSigner) {
+	signer := NewStandardSigner("test-issuer", "test-audience", 5*time.Minute, 0)
+	_ = signer.UpdateKeys(map[string][]byte{
+		"1234567890": []byte("test-signing-key-at-least-48-bytes-long-for-hs384!"),
+	}, "1234567890")
+	factory := NewStandardSignerFactory(signer)
+	return factory, signer
+}
+
+func TestNewStandardSignerFactory(t *testing.T) {
+	factory, signer := newTestStandardSignerFactory()
+
+	assert.NotNil(t, factory)
+	assert.Equal(t, signer, factory.signer)
+}
+
+func TestStandardSignerFactory_CreateSigner_NilAccessStrategy(t *testing.T) {
+	factory, signer := newTestStandardSignerFactory()
+
+	result, err := factory.CreateSigner(nil)
+
+	assert.NoError(t, err)
+	assert.Equal(t, signer, result)
+}
+
+func TestStandardSignerFactory_CreateSigner_EmptyHandler(t *testing.T) {
+	factory, signer := newTestStandardSignerFactory()
+
+	accessStrategy := &workspacev1alpha1.WorkspaceAccessStrategy{
+		Spec: workspacev1alpha1.WorkspaceAccessStrategySpec{
+			CreateConnectionHandler: "",
+		},
+	}
+
+	result, err := factory.CreateSigner(accessStrategy)
+
+	assert.NoError(t, err)
+	assert.Equal(t, signer, result)
+}
+
+func TestStandardSignerFactory_CreateSigner_K8sNativeHandler(t *testing.T) {
+	factory, signer := newTestStandardSignerFactory()
+
+	accessStrategy := &workspacev1alpha1.WorkspaceAccessStrategy{
+		Spec: workspacev1alpha1.WorkspaceAccessStrategySpec{
+			CreateConnectionHandler: "k8s-native",
+		},
+	}
+
+	result, err := factory.CreateSigner(accessStrategy)
+
+	assert.NoError(t, err)
+	assert.Equal(t, signer, result)
+}
+
+func TestStandardSignerFactory_CreateSigner_AWSHandler(t *testing.T) {
+	factory, _ := newTestStandardSignerFactory()
+
+	accessStrategy := &workspacev1alpha1.WorkspaceAccessStrategy{
+		Spec: workspacev1alpha1.WorkspaceAccessStrategySpec{
+			CreateConnectionHandler: "aws",
+		},
+	}
+
+	result, err := factory.CreateSigner(accessStrategy)
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "aws")
+}
+
+func TestStandardSignerFactory_CreateSigner_UnsupportedHandler(t *testing.T) {
+	factory, _ := newTestStandardSignerFactory()
+
+	accessStrategy := &workspacev1alpha1.WorkspaceAccessStrategy{
+		Spec: workspacev1alpha1.WorkspaceAccessStrategySpec{
+			CreateConnectionHandler: "invalid",
+		},
+	}
+
+	result, err := factory.CreateSigner(accessStrategy)
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "unsupported connection handler")
+}
+
+func TestStandardSignerFactory_CreateSigner_GenerateValidateRoundTrip(t *testing.T) {
+	factory, _ := newTestStandardSignerFactory()
+
+	accessStrategy := &workspacev1alpha1.WorkspaceAccessStrategy{
+		Spec: workspacev1alpha1.WorkspaceAccessStrategySpec{
+			CreateConnectionHandler: "k8s-native",
+		},
+	}
+
+	signer, err := factory.CreateSigner(accessStrategy)
+	require.NoError(t, err)
+
+	token, err := signer.GenerateToken("testuser", []string{"group1"}, "uid1", nil, "/path", "example.com", TokenTypeBootstrap)
+	require.NoError(t, err)
+	assert.NotEmpty(t, token)
+
+	claims, err := signer.ValidateToken(token)
+	require.NoError(t, err)
+	assert.Equal(t, "testuser", claims.User)
+	assert.Equal(t, "/path", claims.Path)
+	assert.Equal(t, "example.com", claims.Domain)
+	assert.Equal(t, TokenTypeBootstrap, claims.TokenType)
+}

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -225,13 +225,10 @@ var _ = BeforeSuite(func() {
 	// Clean up any leftover resources before starting tests
 	ensureCleanState()
 
-	By("deploying the controller-manager with webhook enabled")
-	cmd = exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", projectImage))
-	_, err = utils.Run(cmd)
-	Expect(err).NotTo(HaveOccurred(), "Failed to deploy controller-manager")
-
-	By("creating extension API authentication RoleBinding")
-	// Delete first if it exists from a previous run
+	By("creating extension API authentication RoleBinding before deploy")
+	// The controller needs this RoleBinding at startup to read the
+	// extension-apiserver-authentication configmap from kube-system.
+	// Creating it before deploy prevents CrashLoopBackOff on first start.
 	cmd = exec.Command("kubectl", "delete", "rolebinding", "jupyter-k8s-extension-api-auth",
 		"-n", "kube-system", "--ignore-not-found")
 	_, _ = utils.Run(cmd)
@@ -241,6 +238,28 @@ var _ = BeforeSuite(func() {
 		fmt.Sprintf("--serviceaccount=%s:jupyter-k8s-controller-manager", OperatorNamespace))
 	_, err = utils.Run(cmd)
 	Expect(err).NotTo(HaveOccurred(), "Failed to create extension API auth RoleBinding")
+
+	By("deploying the controller-manager with webhook enabled")
+	cmd = exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", projectImage))
+	_, err = utils.Run(cmd)
+	Expect(err).NotTo(HaveOccurred(), "Failed to deploy controller-manager")
+
+	By("patching controller deployment to enable k8s-native JWT signing")
+	// The jwt-rotator Secret is deployed via kustomize (config/jwt-rotator/).
+	// The secret name gets the kustomize namePrefix "jupyter-k8s-".
+	jwtPatch := `[{"op":"add","path":"/spec/template/spec/containers/0/args/-",` +
+		`"value":"--jwt-secret-name=jupyter-k8s-extensionapi-secrets"}]`
+	cmd = exec.Command("kubectl", "patch", "deployment/jupyter-k8s-controller-manager",
+		"-n", OperatorNamespace, "--type=json", "-p="+jwtPatch)
+	_, err = utils.Run(cmd)
+	Expect(err).NotTo(HaveOccurred(), "Failed to patch controller with --jwt-secret-name")
+
+	By("waiting for controller rollout after JWT secret patch")
+	cmd = exec.Command("kubectl", "rollout", "status",
+		"deployment/jupyter-k8s-controller-manager",
+		"-n", OperatorNamespace, "--timeout=5m")
+	_, err = utils.Run(cmd)
+	Expect(err).NotTo(HaveOccurred(), "Controller rollout failed after JWT secret patch")
 
 	By("waiting for controller deployment to be available")
 	cmd = exec.Command("kubectl", "wait", "deployment/jupyter-k8s-controller-manager",

--- a/test/e2e/extension_api_test.go
+++ b/test/e2e/extension_api_test.go
@@ -384,6 +384,51 @@ var _ = Describe("Extension API", Ordered, func() {
 				ContainSubstring("forbidden"),
 			))
 		})
+
+		It("should use a new signing key after JWT secret rotation", func() {
+			By("creating a connection to capture the initial kid")
+			_, connURL1, err := createWorkspaceConnectionAndGetResponse(
+				getFixturePath("connection-request-webui"))
+			Expect(err).NotTo(HaveOccurred())
+
+			kid1, err := extractKidFromConnectionURL(connURL1)
+			Expect(err).NotTo(HaveOccurred())
+			_, _ = fmt.Fprintf(GinkgoWriter, "Initial kid: %s\n", kid1)
+
+			By("triggering JWT key rotation via CronJob")
+			cmd := exec.Command("kubectl", "create", "job",
+				"--from=cronjob/jupyter-k8s-jwt-rotator",
+				"jwt-rotation-e2e", "-n", OperatorNamespace)
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("waiting for rotation job to complete")
+			cmd = exec.Command("kubectl", "wait", "job/jwt-rotation-e2e",
+				"-n", OperatorNamespace,
+				"--for=condition=complete", "--timeout=60s")
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Rotation job did not complete")
+
+			By("waiting for controller to pick up rotated key and start signing with new kid")
+			// The controller's informer detects the secret change, then newKeyUseDelay
+			// (default 5s) must elapse before the new key is used for signing.
+			Eventually(func(g Gomega) {
+				_, connURL2, err := createWorkspaceConnectionAndGetResponse(
+					getFixturePath("connection-request-webui"))
+				g.Expect(err).NotTo(HaveOccurred())
+
+				kid2, err := extractKidFromConnectionURL(connURL2)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				_, _ = fmt.Fprintf(GinkgoWriter, "Polling kid: %s (waiting for != %s)\n", kid2, kid1)
+				g.Expect(kid2).NotTo(Equal(kid1), "Expected new kid after rotation")
+			}).WithTimeout(30 * time.Second).WithPolling(2 * time.Second).Should(Succeed())
+
+			By("cleaning up rotation job")
+			cmd = exec.Command("kubectl", "delete", "job", "jwt-rotation-e2e",
+				"-n", OperatorNamespace, "--ignore-not-found")
+			_, _ = utils.Run(cmd)
+		})
 	})
 })
 

--- a/test/e2e/extension_api_test.go
+++ b/test/e2e/extension_api_test.go
@@ -9,7 +9,10 @@ Distributed under the terms of the MIT license
 package e2e
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"net/url"
 	"os/exec"
 	"strings"
 	"time"
@@ -211,6 +214,177 @@ var _ = Describe("Extension API", Ordered, func() {
 			_, _ = fmt.Fprintf(GinkgoWriter, "Workspace not found test - allowed: %v, notFound: %v, reason: %s\n", allowed, notFound, reason)
 		})
 	})
+
+	Context("Create Connection", func() {
+		BeforeAll(func() {
+			By("creating access strategies for connection tests")
+			cmd := exec.Command("kubectl", "apply", "-f", getFixturePath("connection-access-strategy"))
+			_, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			cmd = exec.Command("kubectl", "apply", "-f", getFixturePath("connection-access-strategy-default-handler"))
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			cmd = exec.Command("kubectl", "apply", "-f", getFixturePath("connection-access-strategy-no-webui"))
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("creating RBAC for connection tests")
+			// Reuse the existing workspace-connection-role (create workspaceconnections permission)
+			cmd = exec.Command("kubectl", "apply", "-f", getFixturePath("workspace-connection-role"))
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Reuse workspace-creator-role and bind connection-owner-user to it
+			cmd = exec.Command("kubectl", "apply", "-f", getFixturePath("workspace-creator-role"))
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			cmd = exec.Command("kubectl", "apply", "-f", getFixturePath("connection-creator-binding"))
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			cmd = exec.Command("kubectl", "apply", "-f", getFixturePath("connection-owner-binding"))
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("creating public workspace for connection tests")
+			createWorkspaceForTest("workspace-connection-public", extensionAPIGroupDir, extensionAPISubgroupDir)
+
+			By("creating workspace with default handler access strategy")
+			createWorkspaceForTest("workspace-connection-default-handler", extensionAPIGroupDir, extensionAPISubgroupDir)
+
+			By("creating workspace with no-webui access strategy")
+			createWorkspaceForTest("workspace-connection-no-webui", extensionAPIGroupDir, extensionAPISubgroupDir)
+
+			By("creating private workspace as connection-owner-user")
+			privatePath := getFixturePath("workspace-connection-private")
+			cmd = exec.Command("kubectl", "create", "-f", privatePath, "--as=connection-owner-user")
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("waiting for workspaces to be available")
+			WaitForWorkspaceToReachCondition("workspace-connection-public", extensionAPITestNamespace, ConditionTypeAvailable, ConditionTrue)
+			WaitForWorkspaceToReachCondition("workspace-connection-default-handler", extensionAPITestNamespace, ConditionTypeAvailable, ConditionTrue)
+			WaitForWorkspaceToReachCondition("workspace-connection-no-webui", extensionAPITestNamespace, ConditionTypeAvailable, ConditionTrue)
+			WaitForWorkspaceToReachCondition("workspace-connection-private", extensionAPITestNamespace, ConditionTypeAvailable, ConditionTrue)
+		})
+
+		AfterAll(func() {
+			deleteResourcesForExtensionAPITest()
+		})
+
+		It("should return bearer token URL for public workspace", func() {
+			By("creating WorkspaceConnection for public workspace")
+			connType, connURL, err := createWorkspaceConnectionAndGetResponse(
+				getFixturePath("connection-request-webui"))
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying response contains web-ui connection type")
+			Expect(connType).To(Equal("web-ui"))
+
+			By("verifying connection URL contains a token")
+			Expect(connURL).To(ContainSubstring("?token="))
+			Expect(connURL).To(ContainSubstring("bearer-auth"))
+			_, _ = fmt.Fprintf(GinkgoWriter, "Connection URL: %s\n", connURL)
+		})
+
+		It("should return a valid JWT in the bearer token URL", func() {
+			By("creating WorkspaceConnection and extracting JWT")
+			_, connURL, err := createWorkspaceConnectionAndGetResponse(
+				getFixturePath("connection-request-webui"))
+			Expect(err).NotTo(HaveOccurred())
+
+			By("parsing token from URL")
+			parsed, err := url.Parse(connURL)
+			Expect(err).NotTo(HaveOccurred())
+			token := parsed.Query().Get("token")
+			Expect(token).NotTo(BeEmpty(), "Token should be present in URL query params")
+
+			By("validating JWT structure (header.payload.signature)")
+			parts := strings.Split(token, ".")
+			Expect(parts).To(HaveLen(3), "JWT should have 3 parts separated by dots")
+
+			By("decoding and validating JWT header")
+			headerJSON, err := base64.RawURLEncoding.DecodeString(parts[0])
+			Expect(err).NotTo(HaveOccurred(), "JWT header should be valid base64url")
+
+			var header map[string]interface{}
+			err = json.Unmarshal(headerJSON, &header)
+			Expect(err).NotTo(HaveOccurred(), "JWT header should be valid JSON")
+
+			Expect(header).To(HaveKey("alg"))
+			Expect(header["alg"]).To(Equal("HS384"), "JWT should use HS384 algorithm")
+			Expect(header).To(HaveKey("kid"))
+			Expect(header["kid"]).NotTo(BeEmpty(), "JWT should have a key ID")
+			_, _ = fmt.Fprintf(GinkgoWriter, "JWT header: alg=%s, kid=%s\n", header["alg"], header["kid"])
+		})
+
+		It("should work with empty createConnectionHandler (default)", func() {
+			By("creating WorkspaceConnection for workspace with default handler")
+			connType, connURL, err := createWorkspaceConnectionAndGetResponse(
+				getFixturePath("connection-request-default-handler"))
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying response is valid")
+			Expect(connType).To(Equal("web-ui"))
+			Expect(connURL).To(ContainSubstring("?token="))
+			_, _ = fmt.Fprintf(GinkgoWriter, "Default handler connection URL: %s\n", connURL)
+		})
+
+		It("should allow owner to create connection for private workspace", func() {
+			By("creating WorkspaceConnection as owner user")
+			output, err := createWorkspaceConnectionAsUser(
+				getFixturePath("connection-request-private"), "connection-owner-user", []string{})
+			Expect(err).NotTo(HaveOccurred(), "Owner should be able to create connection for private workspace")
+			Expect(output).To(ContainSubstring("workspaceConnectionUrl"))
+			Expect(output).To(ContainSubstring("?token="))
+			_, _ = fmt.Fprintf(GinkgoWriter, "Owner connection response:\n%s\n", output)
+		})
+
+		It("should deny non-owner connection to private workspace", func() {
+			By("creating WorkspaceConnection as non-owner user")
+			_, err := createWorkspaceConnectionAsUser(
+				getFixturePath("connection-request-private"), "connection-other-user", []string{})
+			Expect(err).To(HaveOccurred(), "Non-owner should be denied connection to private workspace")
+			Expect(err.Error()).To(SatisfyAny(
+				ContainSubstring("Forbidden"),
+				ContainSubstring("forbidden"),
+				ContainSubstring("not the workspace owner"),
+			))
+		})
+
+		It("should reject connection when WebUI not enabled", func() {
+			By("creating WorkspaceConnection for workspace without bearerAuthURLTemplate")
+			_, err := createWorkspaceConnectionAsUser(
+				getFixturePath("connection-request-no-webui"), "connection-owner-user", []string{})
+			Expect(err).To(HaveOccurred(), "Connection should be rejected when WebUI is not enabled")
+			Expect(err.Error()).To(ContainSubstring("web browser access is not enabled"))
+		})
+
+		It("should reject connection for non-existent workspace", func() {
+			By("creating WorkspaceConnection for non-existent workspace")
+			_, err := createWorkspaceConnectionAsUser(
+				getFixturePath("connection-request-not-found"), "connection-owner-user", []string{})
+			Expect(err).To(HaveOccurred(), "Connection to non-existent workspace should fail")
+			Expect(err.Error()).To(SatisfyAny(
+				ContainSubstring("not found"),
+				ContainSubstring("NotFound"),
+			))
+		})
+
+		It("should deny unauthorized user from creating connection", func() {
+			By("creating WorkspaceConnection as user without RBAC permissions")
+			_, err := createWorkspaceConnectionAsUser(
+				getFixturePath("connection-request-webui"), "unauthorized-user", []string{})
+			Expect(err).To(HaveOccurred(), "Unauthorized user should be denied")
+			Expect(err.Error()).To(SatisfyAny(
+				ContainSubstring("Forbidden"),
+				ContainSubstring("forbidden"),
+			))
+		})
+	})
 })
 
 // deleteResourcesForExtensionAPITest cleans up resources created during extension API tests
@@ -222,6 +396,11 @@ func deleteResourcesForExtensionAPITest() {
 	By("cleaning up workspaces")
 	cmd := exec.Command("kubectl", "delete", "workspace", "--all", "-n", extensionAPITestNamespace,
 		"--ignore-not-found", "--wait=true", "--timeout=120s")
+	_, _ = utils.Run(cmd)
+
+	By("cleaning up access strategies")
+	cmd = exec.Command("kubectl", "delete", "workspaceaccessstrategy", "--all", "-n", SharedNamespace,
+		"--ignore-not-found", "--wait=true", "--timeout=60s")
 	_, _ = utils.Run(cmd)
 
 	By("cleaning up RBAC resources by label")

--- a/test/e2e/helpers_extension_api.go
+++ b/test/e2e/helpers_extension_api.go
@@ -48,6 +48,42 @@ func createConnectionAccessReviewAndGetStatus(filepath string) (allowed bool, no
 	return allowed, notFound, reason, nil
 }
 
+// createWorkspaceConnectionAndGetResponse creates a WorkspaceConnection and parses the response
+// to extract workspaceConnectionType and workspaceConnectionUrl from the status.
+func createWorkspaceConnectionAndGetResponse(filepath string) (connType, connURL string, err error) {
+	ginkgo.GinkgoHelper()
+	cmd := exec.Command("kubectl", "create", "-f", filepath, "-o", "yaml")
+	output, createErr := utils.Run(cmd)
+	if createErr != nil {
+		return "", "", createErr
+	}
+
+	lines := strings.Split(output, "\n")
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "workspaceConnectionType:") {
+			connType = strings.TrimSpace(strings.TrimPrefix(trimmed, "workspaceConnectionType:"))
+		}
+		if strings.HasPrefix(trimmed, "workspaceConnectionUrl:") {
+			connURL = strings.TrimSpace(strings.TrimPrefix(trimmed, "workspaceConnectionUrl:"))
+		}
+	}
+
+	return connType, connURL, nil
+}
+
+// createWorkspaceConnectionAsUser creates a WorkspaceConnection with kubectl impersonation,
+// returning the raw output and error.
+func createWorkspaceConnectionAsUser(filepath, user string, groups []string) (string, error) {
+	ginkgo.GinkgoHelper()
+	args := []string{"create", "-f", filepath, "-o", "yaml", "--as=" + user}
+	for _, group := range groups {
+		args = append(args, "--as-group="+group)
+	}
+	cmd := exec.Command("kubectl", args...)
+	return utils.Run(cmd)
+}
+
 // updateObjectAsUser updates a Kubernetes object with kubectl impersonation
 func updateObjectAsUser(filepath, user string, groups []string) error {
 	ginkgo.GinkgoHelper()

--- a/test/e2e/helpers_extension_api.go
+++ b/test/e2e/helpers_extension_api.go
@@ -9,6 +9,10 @@ Distributed under the terms of the MIT license
 package e2e
 
 import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/url"
 	"os/exec"
 	"strings"
 
@@ -82,6 +86,36 @@ func createWorkspaceConnectionAsUser(filepath, user string, groups []string) (st
 	}
 	cmd := exec.Command("kubectl", args...)
 	return utils.Run(cmd)
+}
+
+// extractKidFromConnectionURL parses a connection URL's ?token= query param
+// and returns the "kid" field from the JWT header.
+func extractKidFromConnectionURL(connURL string) (string, error) {
+	parsed, err := url.Parse(connURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse URL: %w", err)
+	}
+	token := parsed.Query().Get("token")
+	if token == "" {
+		return "", fmt.Errorf("no token query param in URL")
+	}
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return "", fmt.Errorf("JWT has %d parts, expected 3", len(parts))
+	}
+	headerJSON, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return "", fmt.Errorf("failed to decode JWT header: %w", err)
+	}
+	var header map[string]interface{}
+	if err := json.Unmarshal(headerJSON, &header); err != nil {
+		return "", fmt.Errorf("failed to parse JWT header JSON: %w", err)
+	}
+	kid, ok := header["kid"].(string)
+	if !ok || kid == "" {
+		return "", fmt.Errorf("JWT header missing 'kid' field")
+	}
+	return kid, nil
 }
 
 // updateObjectAsUser updates a Kubernetes object with kubectl impersonation

--- a/test/e2e/static/extension-api/connection-access-strategy-default-handler.yaml
+++ b/test/e2e/static/extension-api/connection-access-strategy-default-handler.yaml
@@ -1,0 +1,10 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: WorkspaceAccessStrategy
+metadata:
+  name: connection-test-default-handler
+  namespace: jupyter-k8s-shared
+spec:
+  displayName: Connection Test Default Handler
+  accessResourceTemplates: []
+  accessURLTemplate: "https://example.com/workspaces/{{ .Workspace.Namespace }}/{{ .Workspace.Name }}/"
+  bearerAuthURLTemplate: "https://example.com/workspaces/{{ .Workspace.Namespace }}/{{ .Workspace.Name }}/bearer-auth"

--- a/test/e2e/static/extension-api/connection-access-strategy-no-webui.yaml
+++ b/test/e2e/static/extension-api/connection-access-strategy-no-webui.yaml
@@ -1,0 +1,10 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: WorkspaceAccessStrategy
+metadata:
+  name: connection-test-no-webui
+  namespace: jupyter-k8s-shared
+spec:
+  displayName: Connection Test No WebUI
+  accessResourceTemplates: []
+  accessURLTemplate: "https://example.com/workspaces/{{ .Workspace.Namespace }}/{{ .Workspace.Name }}/"
+  createConnectionHandler: "k8s-native"

--- a/test/e2e/static/extension-api/connection-access-strategy.yaml
+++ b/test/e2e/static/extension-api/connection-access-strategy.yaml
@@ -1,0 +1,11 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: WorkspaceAccessStrategy
+metadata:
+  name: connection-test-access-strategy
+  namespace: jupyter-k8s-shared
+spec:
+  displayName: Connection Test Access Strategy
+  accessResourceTemplates: []
+  accessURLTemplate: "https://example.com/workspaces/{{ .Workspace.Namespace }}/{{ .Workspace.Name }}/"
+  bearerAuthURLTemplate: "https://example.com/workspaces/{{ .Workspace.Namespace }}/{{ .Workspace.Name }}/bearer-auth"
+  createConnectionHandler: "k8s-native"

--- a/test/e2e/static/extension-api/connection-creator-binding.yaml
+++ b/test/e2e/static/extension-api/connection-creator-binding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: connection-creator-binding
+  namespace: default
+  labels:
+    jk8s/e2e: extension-api-test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: workspace-creator-role
+subjects:
+- kind: User
+  name: connection-owner-user
+  apiGroup: rbac.authorization.k8s.io

--- a/test/e2e/static/extension-api/connection-owner-binding.yaml
+++ b/test/e2e/static/extension-api/connection-owner-binding.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: workspace-connection-owner-binding-for-connection
+  namespace: default
+  labels:
+    jk8s/e2e: extension-api-test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: workspace-connection-role
+subjects:
+- kind: User
+  name: connection-owner-user
+  apiGroup: rbac.authorization.k8s.io
+- kind: User
+  name: connection-other-user
+  apiGroup: rbac.authorization.k8s.io

--- a/test/e2e/static/extension-api/connection-request-default-handler.yaml
+++ b/test/e2e/static/extension-api/connection-request-default-handler.yaml
@@ -1,0 +1,8 @@
+apiVersion: connection.workspace.jupyter.org/v1alpha1
+kind: WorkspaceConnection
+metadata:
+  name: test-connection-default-handler
+  namespace: default
+spec:
+  workspaceName: workspace-connection-default-handler
+  workspaceConnectionType: web-ui

--- a/test/e2e/static/extension-api/connection-request-no-webui.yaml
+++ b/test/e2e/static/extension-api/connection-request-no-webui.yaml
@@ -1,0 +1,8 @@
+apiVersion: connection.workspace.jupyter.org/v1alpha1
+kind: WorkspaceConnection
+metadata:
+  name: test-connection-no-webui
+  namespace: default
+spec:
+  workspaceName: workspace-connection-no-webui
+  workspaceConnectionType: web-ui

--- a/test/e2e/static/extension-api/connection-request-not-found.yaml
+++ b/test/e2e/static/extension-api/connection-request-not-found.yaml
@@ -1,0 +1,8 @@
+apiVersion: connection.workspace.jupyter.org/v1alpha1
+kind: WorkspaceConnection
+metadata:
+  name: test-connection-not-found
+  namespace: default
+spec:
+  workspaceName: nonexistent-workspace
+  workspaceConnectionType: web-ui

--- a/test/e2e/static/extension-api/connection-request-private.yaml
+++ b/test/e2e/static/extension-api/connection-request-private.yaml
@@ -1,0 +1,8 @@
+apiVersion: connection.workspace.jupyter.org/v1alpha1
+kind: WorkspaceConnection
+metadata:
+  name: test-connection-private
+  namespace: default
+spec:
+  workspaceName: workspace-connection-private
+  workspaceConnectionType: web-ui

--- a/test/e2e/static/extension-api/connection-request-webui.yaml
+++ b/test/e2e/static/extension-api/connection-request-webui.yaml
@@ -1,0 +1,8 @@
+apiVersion: connection.workspace.jupyter.org/v1alpha1
+kind: WorkspaceConnection
+metadata:
+  name: test-connection
+  namespace: default
+spec:
+  workspaceName: workspace-connection-public
+  workspaceConnectionType: web-ui

--- a/test/e2e/static/extension-api/workspace-connection-default-handler.yaml
+++ b/test/e2e/static/extension-api/workspace-connection-default-handler.yaml
@@ -1,0 +1,20 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: Workspace
+metadata:
+  name: workspace-connection-default-handler
+  namespace: default
+spec:
+  displayName: "Connection Default Handler Workspace"
+  desiredStatus: Running
+  image: jk8s-application-jupyter-uv:latest
+  accessType: Public
+  accessStrategy:
+    name: connection-test-default-handler
+    namespace: jupyter-k8s-shared
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi

--- a/test/e2e/static/extension-api/workspace-connection-no-webui.yaml
+++ b/test/e2e/static/extension-api/workspace-connection-no-webui.yaml
@@ -1,0 +1,20 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: Workspace
+metadata:
+  name: workspace-connection-no-webui
+  namespace: default
+spec:
+  displayName: "Connection No WebUI Workspace"
+  desiredStatus: Running
+  image: jk8s-application-jupyter-uv:latest
+  accessType: Public
+  accessStrategy:
+    name: connection-test-no-webui
+    namespace: jupyter-k8s-shared
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi

--- a/test/e2e/static/extension-api/workspace-connection-private.yaml
+++ b/test/e2e/static/extension-api/workspace-connection-private.yaml
@@ -1,0 +1,20 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: Workspace
+metadata:
+  name: workspace-connection-private
+  namespace: default
+spec:
+  displayName: "Connection Private Workspace"
+  desiredStatus: Running
+  image: jk8s-application-jupyter-uv:latest
+  accessType: OwnerOnly
+  accessStrategy:
+    name: connection-test-access-strategy
+    namespace: jupyter-k8s-shared
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi

--- a/test/e2e/static/extension-api/workspace-connection-public.yaml
+++ b/test/e2e/static/extension-api/workspace-connection-public.yaml
@@ -1,0 +1,20 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: Workspace
+metadata:
+  name: workspace-connection-public
+  namespace: default
+spec:
+  displayName: "Connection Public Workspace"
+  desiredStatus: Running
+  image: jk8s-application-jupyter-uv:latest
+  accessType: Public
+  accessStrategy:
+    name: connection-test-access-strategy
+    namespace: jupyter-k8s-shared
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi

--- a/test/helm/crd-only/resources_test.go
+++ b/test/helm/crd-only/resources_test.go
@@ -25,6 +25,7 @@ var _ = Describe("CRD-Only Helm Resources", func() {
 		"samples":         true,
 		"default":         true,
 		"samples_routing": true,
+		"jwt-rotator":     true, // opt-in via extensionApi.jwtSecret.enable
 	}
 
 	It("should include all CRD-only resources in the Helm chart", func() {


### PR DESCRIPTION
This PR implements the first step toward adopting a plugin architecture, which separates any aws-specific logic from the core operator. The `extensionapi`, which responds to `Create:Connection` API calls, can optionally sign JWT using a secret seed stored in a k8s secret, instead of relying on a KMS key. The JWT secret seed lives in a k8s secret in the controller namespace, and rotates automatically with a cronjob running on that same namespace. It follows the pattern of the authmiddleware JWT seed rotation implemented in #320 , but decouples from authmiddleware stack by adding an independent secret, cronjob and secrets watches.

### Next steps
1. create verification API
2. use verification API in authmiddleware
3. remove kms config from router helm chart
4. configure plugin sidecar for operator
5. migrate operator chart to use plugin sidecar

### User experience
- no change for workspace end-user, the code path to use the k8s-native JWT is controlled by the access strategy
- for admins, if `AccessStrategy.spec.CreateConnectionHandler` is set to `k8s-native`, then whenever a user calls `Create:Connection` for such a workspace, the `extensionapi` uses the k8s secret instead of AWS to sign the token

### Implementation
- add k8s secret `jupyter-k8s-extensionapi-secrets` to operator namespace
- add cronjob to operator namespace, w/ related RBAC
- add RBAC role/role-binding for controller pod
- update helm chart/kustomize
- update `makefile` methods to pass the new parameters
- migrate `deploy-kind` to use `helm` instead of `kustomize` for deployment
- update `extensionapi` logic to support several signing strategy (not just AWS)
- add secrets watch to `extensionapi` to receive updates

### Testing
- add E2E test coverage for `Create:Connection` that leverage the `k8s-native`signing strategy
- ran "FOCUS=Extension API" E2E tests
- deployed to local kind cluster and verified secret rotation
- deployed manually to AWS --> no issue

