### PR TITLE
feat: controller plugin interfaces

### DIFF
--- a/api/plugin/v1alpha1/error.go
+++ b/api/plugin/v1alpha1/error.go
@@ -1,0 +1,11 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package v1alpha1
+
+// ErrorResponse is the standard error response body returned by plugin endpoints.
+type ErrorResponse struct {
+	Error string `json:"error"`
+}

--- a/api/plugin/v1alpha1/jwt_types.go
+++ b/api/plugin/v1alpha1/jwt_types.go
@@ -17,6 +17,7 @@ type SignRequest struct {
 	Path              string              `json:"path"`
 	Domain            string              `json:"domain"`
 	TokenType         string              `json:"tokenType"`
+	SigningType       string              `json:"signingType,omitempty"`
 	ConnectionContext map[string]string   `json:"connectionContext,omitempty"`
 }
 

--- a/api/plugin/v1alpha1/jwt_types.go
+++ b/api/plugin/v1alpha1/jwt_types.go
@@ -1,0 +1,48 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+// Package v1alpha1 defines the request/response types for the plugin HTTP interface.
+// These are plain Go structs with JSON tags — not Kubernetes API objects.
+// Zero external dependencies so both core operator and plugin binaries can import them.
+package v1alpha1
+
+// SignRequest is the request body for POST /v1alpha1/jwt/sign.
+type SignRequest struct {
+	User              string              `json:"user"`
+	Groups            []string            `json:"groups"`
+	UID               string              `json:"uid"`
+	Extra             map[string][]string `json:"extra,omitempty"`
+	Path              string              `json:"path"`
+	Domain            string              `json:"domain"`
+	TokenType         string              `json:"tokenType"`
+	ConnectionContext map[string]string   `json:"connectionContext,omitempty"`
+}
+
+// SignResponse is the response body for POST /v1alpha1/jwt/sign.
+type SignResponse struct {
+	Token string `json:"token"`
+}
+
+// VerifyRequest is the request body for POST /v1alpha1/jwt/verify.
+type VerifyRequest struct {
+	Token string `json:"token"`
+}
+
+// VerifyResponse is the response body for POST /v1alpha1/jwt/verify.
+type VerifyResponse struct {
+	Claims *VerifyClaims `json:"claims"`
+}
+
+// VerifyClaims contains the decoded JWT claims returned by verify.
+type VerifyClaims struct {
+	Subject   string              `json:"sub"`
+	Groups    []string            `json:"groups"`
+	UID       string              `json:"uid"`
+	Extra     map[string][]string `json:"extra,omitempty"`
+	Path      string              `json:"path"`
+	Domain    string              `json:"domain"`
+	TokenType string              `json:"tokenType"`
+	ExpiresAt int64               `json:"exp"`
+}

--- a/api/plugin/v1alpha1/remote_access_types.go
+++ b/api/plugin/v1alpha1/remote_access_types.go
@@ -11,27 +11,27 @@ type InitializeRequest struct{}
 // InitializeResponse is the response body for POST /v1alpha1/remote-access/initialize.
 type InitializeResponse struct{}
 
-// RegisterNodeRequest is the request body for POST /v1alpha1/remote-access/register-node.
-type RegisterNodeRequest struct {
+// RegisterNodeAgentRequest is the request body for POST /v1alpha1/remote-access/register-node-agent.
+type RegisterNodeAgentRequest struct {
 	PodUID           string            `json:"podUID"`
 	WorkspaceName    string            `json:"workspaceName"`
 	Namespace        string            `json:"namespace"`
 	PodEventsContext map[string]string `json:"podEventsContext,omitempty"`
 }
 
-// RegisterNodeResponse is the response body for POST /v1alpha1/remote-access/register-node.
-type RegisterNodeResponse struct {
+// RegisterNodeAgentResponse is the response body for POST /v1alpha1/remote-access/register-node-agent.
+type RegisterNodeAgentResponse struct {
 	ActivationID   string `json:"activationId"`
 	ActivationCode string `json:"activationCode"`
 }
 
-// DeregisterNodeRequest is the request body for POST /v1alpha1/remote-access/deregister-node.
-type DeregisterNodeRequest struct {
+// DeregisterNodeAgentRequest is the request body for POST /v1alpha1/remote-access/deregister-node-agent.
+type DeregisterNodeAgentRequest struct {
 	PodUID string `json:"podUID"`
 }
 
-// DeregisterNodeResponse is the response body for POST /v1alpha1/remote-access/deregister-node.
-type DeregisterNodeResponse struct{}
+// DeregisterNodeAgentResponse is the response body for POST /v1alpha1/remote-access/deregister-node-agent.
+type DeregisterNodeAgentResponse struct{}
 
 // CreateSessionRequest is the request body for POST /v1alpha1/remote-access/create-session.
 type CreateSessionRequest struct {

--- a/api/plugin/v1alpha1/remote_access_types.go
+++ b/api/plugin/v1alpha1/remote_access_types.go
@@ -1,0 +1,47 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package v1alpha1
+
+// InitializeRequest is the request body for POST /v1alpha1/remote-access/initialize.
+type InitializeRequest struct{}
+
+// InitializeResponse is the response body for POST /v1alpha1/remote-access/initialize.
+type InitializeResponse struct{}
+
+// RegisterNodeRequest is the request body for POST /v1alpha1/remote-access/register-node.
+type RegisterNodeRequest struct {
+	PodUID           string            `json:"podUID"`
+	WorkspaceName    string            `json:"workspaceName"`
+	Namespace        string            `json:"namespace"`
+	PodEventsContext map[string]string `json:"podEventsContext,omitempty"`
+}
+
+// RegisterNodeResponse is the response body for POST /v1alpha1/remote-access/register-node.
+type RegisterNodeResponse struct {
+	ActivationID   string `json:"activationId"`
+	ActivationCode string `json:"activationCode"`
+}
+
+// DeregisterNodeRequest is the request body for POST /v1alpha1/remote-access/deregister-node.
+type DeregisterNodeRequest struct {
+	PodUID string `json:"podUID"`
+}
+
+// DeregisterNodeResponse is the response body for POST /v1alpha1/remote-access/deregister-node.
+type DeregisterNodeResponse struct{}
+
+// CreateSessionRequest is the request body for POST /v1alpha1/remote-access/create-session.
+type CreateSessionRequest struct {
+	PodUID            string            `json:"podUID"`
+	WorkspaceName     string            `json:"workspaceName"`
+	Namespace         string            `json:"namespace"`
+	ConnectionContext map[string]string `json:"connectionContext,omitempty"`
+}
+
+// CreateSessionResponse is the response body for POST /v1alpha1/remote-access/create-session.
+type CreateSessionResponse struct {
+	ConnectionURL string `json:"connectionURL"`
+}

--- a/api/plugin/v1alpha1/routes.go
+++ b/api/plugin/v1alpha1/routes.go
@@ -10,13 +10,13 @@ const BasePath = "/v1alpha1"
 
 // Plugin HTTP routes. Each route defines its path and HTTP method.
 var (
-	RouteJWTSign          = Route{Method: "POST", Path: BasePath + "/jwt/sign"}
-	RouteJWTVerify        = Route{Method: "POST", Path: BasePath + "/jwt/verify"}
-	RouteRemoteAccessInit = Route{Method: "POST", Path: BasePath + "/remote-access/initialize"}
-	RouteRegisterNode     = Route{Method: "POST", Path: BasePath + "/remote-access/register-node"}
-	RouteDeregisterNode   = Route{Method: "POST", Path: BasePath + "/remote-access/deregister-node"}
-	RouteCreateSession    = Route{Method: "POST", Path: BasePath + "/remote-access/create-session"}
-	RouteHealthz          = Route{Method: "GET", Path: "/healthz"}
+	RouteJWTSign             = Route{Method: "POST", Path: BasePath + "/jwt/sign"}
+	RouteJWTVerify           = Route{Method: "POST", Path: BasePath + "/jwt/verify"}
+	RouteRemoteAccessInit    = Route{Method: "POST", Path: BasePath + "/remote-access/initialize"}
+	RouteRegisterNodeAgent   = Route{Method: "POST", Path: BasePath + "/remote-access/register-node-agent"}
+	RouteDeregisterNodeAgent = Route{Method: "POST", Path: BasePath + "/remote-access/deregister-node-agent"}
+	RouteCreateSession       = Route{Method: "POST", Path: BasePath + "/remote-access/create-session"}
+	RouteHealthz             = Route{Method: "GET", Path: "/healthz"}
 )
 
 // Route defines an HTTP method and path for a plugin endpoint.

--- a/api/plugin/v1alpha1/routes.go
+++ b/api/plugin/v1alpha1/routes.go
@@ -1,0 +1,31 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package v1alpha1
+
+// API version prefix for all plugin routes.
+const BasePath = "/v1alpha1"
+
+// Plugin HTTP routes. Each route defines its path and HTTP method.
+var (
+	RouteJWTSign              = Route{Method: "POST", Path: BasePath + "/jwt/sign"}
+	RouteJWTVerify            = Route{Method: "POST", Path: BasePath + "/jwt/verify"}
+	RouteRemoteAccessInit     = Route{Method: "POST", Path: BasePath + "/remote-access/initialize"}
+	RouteRegisterNode         = Route{Method: "POST", Path: BasePath + "/remote-access/register-node"}
+	RouteDeregisterNode       = Route{Method: "POST", Path: BasePath + "/remote-access/deregister-node"}
+	RouteCreateSession        = Route{Method: "POST", Path: BasePath + "/remote-access/create-session"}
+	RouteHealthz              = Route{Method: "GET", Path: "/healthz"}
+)
+
+// Route defines an HTTP method and path for a plugin endpoint.
+type Route struct {
+	Method string
+	Path   string
+}
+
+// Pattern returns the method + path string used by Go 1.22+ ServeMux (e.g. "POST /v1alpha1/jwt/sign").
+func (r Route) Pattern() string {
+	return r.Method + " " + r.Path
+}

--- a/api/plugin/v1alpha1/routes.go
+++ b/api/plugin/v1alpha1/routes.go
@@ -5,18 +5,18 @@ Distributed under the terms of the MIT license
 
 package v1alpha1
 
-// API version prefix for all plugin routes.
+// BasePath is the API version prefix for all plugin routes.
 const BasePath = "/v1alpha1"
 
 // Plugin HTTP routes. Each route defines its path and HTTP method.
 var (
-	RouteJWTSign              = Route{Method: "POST", Path: BasePath + "/jwt/sign"}
-	RouteJWTVerify            = Route{Method: "POST", Path: BasePath + "/jwt/verify"}
-	RouteRemoteAccessInit     = Route{Method: "POST", Path: BasePath + "/remote-access/initialize"}
-	RouteRegisterNode         = Route{Method: "POST", Path: BasePath + "/remote-access/register-node"}
-	RouteDeregisterNode       = Route{Method: "POST", Path: BasePath + "/remote-access/deregister-node"}
-	RouteCreateSession        = Route{Method: "POST", Path: BasePath + "/remote-access/create-session"}
-	RouteHealthz              = Route{Method: "GET", Path: "/healthz"}
+	RouteJWTSign          = Route{Method: "POST", Path: BasePath + "/jwt/sign"}
+	RouteJWTVerify        = Route{Method: "POST", Path: BasePath + "/jwt/verify"}
+	RouteRemoteAccessInit = Route{Method: "POST", Path: BasePath + "/remote-access/initialize"}
+	RouteRegisterNode     = Route{Method: "POST", Path: BasePath + "/remote-access/register-node"}
+	RouteDeregisterNode   = Route{Method: "POST", Path: BasePath + "/remote-access/deregister-node"}
+	RouteCreateSession    = Route{Method: "POST", Path: BasePath + "/remote-access/create-session"}
+	RouteHealthz          = Route{Method: "GET", Path: "/healthz"}
 )
 
 // Route defines an HTTP method and path for a plugin endpoint.

--- a/api/plugin/v1alpha1/types_test.go
+++ b/api/plugin/v1alpha1/types_test.go
@@ -7,6 +7,7 @@ package v1alpha1
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -193,21 +194,8 @@ func TestOmitEmptyFields(t *testing.T) {
 	str := string(data)
 	// Fields with omitempty should not appear when zero-valued
 	for _, field := range []string{"extra", "connectionContext"} {
-		if contains(str, field) {
+		if strings.Contains(str, field) {
 			t.Errorf("expected %q to be omitted, got: %s", field, str)
 		}
 	}
-}
-
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && searchString(s, substr)
-}
-
-func searchString(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
 }

--- a/api/plugin/v1alpha1/types_test.go
+++ b/api/plugin/v1alpha1/types_test.go
@@ -1,0 +1,213 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package v1alpha1
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestSignRequestRoundTrip(t *testing.T) {
+	req := SignRequest{
+		User:      "alice",
+		Groups:    []string{"admin", "dev"},
+		UID:       "uid-123",
+		Extra:     map[string][]string{"team": {"infra"}},
+		Path:      "/workspaces/ns/ws",
+		Domain:    "example.com",
+		TokenType: "bootstrap",
+		ConnectionContext: map[string]string{
+			"kmsKeyId": "arn:aws:kms:us-east-1:123:key/abc",
+		},
+	}
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got SignRequest
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.User != req.User || got.Path != req.Path || got.ConnectionContext["kmsKeyId"] != req.ConnectionContext["kmsKeyId"] {
+		t.Errorf("round-trip mismatch: got %+v", got)
+	}
+}
+
+func TestSignResponseRoundTrip(t *testing.T) {
+	resp := SignResponse{Token: "mock-jwt-token.test.sig"}
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got SignResponse
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Token != resp.Token {
+		t.Errorf("expected token %q, got %q", resp.Token, got.Token)
+	}
+}
+
+func TestVerifyRequestRoundTrip(t *testing.T) {
+	req := VerifyRequest{Token: "some-token"}
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got VerifyRequest
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Token != req.Token {
+		t.Errorf("expected token %q, got %q", req.Token, got.Token)
+	}
+}
+
+func TestVerifyResponseRoundTrip(t *testing.T) {
+	resp := VerifyResponse{
+		Claims: &VerifyClaims{
+			Subject:   "alice",
+			Groups:    []string{"admin"},
+			UID:       "uid-123",
+			Extra:     map[string][]string{"team": {"infra"}},
+			Path:      "/workspaces/ns/ws",
+			Domain:    "example.com",
+			TokenType: "bootstrap",
+			ExpiresAt: 1234567890,
+		},
+	}
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got VerifyResponse
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Claims.Subject != "alice" || got.Claims.ExpiresAt != 1234567890 {
+		t.Errorf("round-trip mismatch: got %+v", got.Claims)
+	}
+}
+
+func TestRegisterNodeRoundTrip(t *testing.T) {
+	req := RegisterNodeRequest{
+		PodUID:        "pod-uid-1",
+		WorkspaceName: "my-ws",
+		Namespace:     "default",
+		PodEventsContext: map[string]string{
+			"ssmDocumentName": "MyDoc",
+		},
+	}
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got RegisterNodeRequest
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.PodUID != req.PodUID || got.PodEventsContext["ssmDocumentName"] != "MyDoc" {
+		t.Errorf("round-trip mismatch: got %+v", got)
+	}
+}
+
+func TestRegisterNodeResponseRoundTrip(t *testing.T) {
+	resp := RegisterNodeResponse{
+		ActivationID:   "act-123",
+		ActivationCode: "code-456",
+	}
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got RegisterNodeResponse
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.ActivationID != resp.ActivationID || got.ActivationCode != resp.ActivationCode {
+		t.Errorf("round-trip mismatch: got %+v", got)
+	}
+}
+
+func TestCreateSessionRequestRoundTrip(t *testing.T) {
+	req := CreateSessionRequest{
+		PodUID:        "pod-uid-1",
+		WorkspaceName: "my-ws",
+		Namespace:     "default",
+		ConnectionContext: map[string]string{
+			"ssmDocumentName": "MyDoc",
+		},
+	}
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got CreateSessionRequest
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.PodUID != req.PodUID || got.ConnectionContext["ssmDocumentName"] != "MyDoc" {
+		t.Errorf("round-trip mismatch: got %+v", got)
+	}
+}
+
+func TestCreateSessionResponseRoundTrip(t *testing.T) {
+	resp := CreateSessionResponse{ConnectionURL: "vscode://some-url"}
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got CreateSessionResponse
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.ConnectionURL != resp.ConnectionURL {
+		t.Errorf("expected %q, got %q", resp.ConnectionURL, got.ConnectionURL)
+	}
+}
+
+func TestErrorResponseRoundTrip(t *testing.T) {
+	resp := ErrorResponse{Error: "something went wrong"}
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got ErrorResponse
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Error != resp.Error {
+		t.Errorf("expected %q, got %q", resp.Error, got.Error)
+	}
+}
+
+func TestOmitEmptyFields(t *testing.T) {
+	req := SignRequest{User: "alice", Path: "/ws", Domain: "d", TokenType: "bootstrap"}
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	str := string(data)
+	// Fields with omitempty should not appear when zero-valued
+	for _, field := range []string{"extra", "connectionContext"} {
+		if contains(str, field) {
+			t.Errorf("expected %q to be omitted, got: %s", field, str)
+		}
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && searchString(s, substr)
+}
+
+func searchString(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/api/plugin/v1alpha1/types_test.go
+++ b/api/plugin/v1alpha1/types_test.go
@@ -92,8 +92,8 @@ func TestVerifyResponseRoundTrip(t *testing.T) {
 	}
 }
 
-func TestRegisterNodeRoundTrip(t *testing.T) {
-	req := RegisterNodeRequest{
+func TestRegisterNodeAgentRoundTrip(t *testing.T) {
+	req := RegisterNodeAgentRequest{
 		PodUID:        "pod-uid-1",
 		WorkspaceName: "my-ws",
 		Namespace:     "default",
@@ -105,7 +105,7 @@ func TestRegisterNodeRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
-	var got RegisterNodeRequest
+	var got RegisterNodeAgentRequest
 	if err := json.Unmarshal(data, &got); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
@@ -114,8 +114,8 @@ func TestRegisterNodeRoundTrip(t *testing.T) {
 	}
 }
 
-func TestRegisterNodeResponseRoundTrip(t *testing.T) {
-	resp := RegisterNodeResponse{
+func TestRegisterNodeAgentResponseRoundTrip(t *testing.T) {
+	resp := RegisterNodeAgentResponse{
 		ActivationID:   "act-123",
 		ActivationCode: "code-456",
 	}
@@ -123,7 +123,7 @@ func TestRegisterNodeResponseRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
-	var got RegisterNodeResponse
+	var got RegisterNodeAgentResponse
 	if err := json.Unmarshal(data, &got); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}

--- a/internal/pluginclient/client.go
+++ b/internal/pluginclient/client.go
@@ -1,0 +1,30 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+// Package pluginclient provides HTTP clients that implement core operator interfaces
+// (jwt.SignerFactory, RemoteAccessStrategyInterface) by calling plugin sidecar endpoints.
+package pluginclient
+
+import (
+	"errors"
+	"net/http"
+)
+
+// ErrNotImplemented is returned by shell methods that are not yet implemented.
+var ErrNotImplemented = errors.New("plugin client: not implemented")
+
+// PluginClient is the shared HTTP client for communicating with a plugin sidecar.
+type PluginClient struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+// NewPluginClient creates a new PluginClient for the given plugin base URL.
+func NewPluginClient(baseURL string) *PluginClient {
+	return &PluginClient{
+		baseURL:    baseURL,
+		httpClient: &http.Client{},
+	}
+}

--- a/internal/pluginclient/client_test.go
+++ b/internal/pluginclient/client_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package pluginclient
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jupyter-infra/jupyter-k8s/internal/jwt"
+
+	workspacev1alpha1 "github.com/jupyter-infra/jupyter-k8s/api/v1alpha1"
+)
+
+// Compile-time interface conformance checks.
+var (
+	_ jwt.SignerFactory = (*PluginSignerFactory)(nil)
+	_ jwt.Signer        = (*PluginSigner)(nil)
+)
+
+func TestPluginSignerFactory_CreateSigner_ReturnsNotImplemented(t *testing.T) {
+	factory := NewPluginSignerFactory("http://localhost:8080")
+	_, err := factory.CreateSigner(&workspacev1alpha1.WorkspaceAccessStrategy{})
+	if !errors.Is(err, ErrNotImplemented) {
+		t.Errorf("expected ErrNotImplemented, got %v", err)
+	}
+}
+
+func TestPluginSigner_GenerateToken_ReturnsNotImplemented(t *testing.T) {
+	signer := &PluginSigner{client: NewPluginClient("http://localhost:8080")}
+	_, err := signer.GenerateToken("user", []string{"g"}, "uid", nil, "/path", "domain", "bootstrap")
+	if !errors.Is(err, ErrNotImplemented) {
+		t.Errorf("expected ErrNotImplemented, got %v", err)
+	}
+}
+
+func TestPluginSigner_ValidateToken_ReturnsNotImplemented(t *testing.T) {
+	signer := &PluginSigner{client: NewPluginClient("http://localhost:8080")}
+	_, err := signer.ValidateToken("some-token")
+	if !errors.Is(err, ErrNotImplemented) {
+		t.Errorf("expected ErrNotImplemented, got %v", err)
+	}
+}
+
+func TestPluginRemoteAccessClient_SetupContainers_ReturnsNotImplemented(t *testing.T) {
+	strategy := NewPluginRemoteAccessClient("http://localhost:8080")
+	err := strategy.SetupContainers(context.Background(), nil, nil, nil)
+	if !errors.Is(err, ErrNotImplemented) {
+		t.Errorf("expected ErrNotImplemented, got %v", err)
+	}
+}
+
+func TestPluginRemoteAccessClient_DeregisterNode_ReturnsNotImplemented(t *testing.T) {
+	strategy := NewPluginRemoteAccessClient("http://localhost:8080")
+	err := strategy.DeregisterNode(context.Background(), nil)
+	if !errors.Is(err, ErrNotImplemented) {
+		t.Errorf("expected ErrNotImplemented, got %v", err)
+	}
+}
+
+func TestPluginRemoteAccessClient_Initialize_ReturnsNotImplemented(t *testing.T) {
+	strategy := NewPluginRemoteAccessClient("http://localhost:8080")
+	err := strategy.Initialize(context.Background())
+	if !errors.Is(err, ErrNotImplemented) {
+		t.Errorf("expected ErrNotImplemented, got %v", err)
+	}
+}
+
+func TestPluginRemoteAccessClient_CreateSession_ReturnsNotImplemented(t *testing.T) {
+	strategy := NewPluginRemoteAccessClient("http://localhost:8080")
+	_, err := strategy.CreateSession(context.Background(), "ws", "ns", "pod-uid", nil)
+	if !errors.Is(err, ErrNotImplemented) {
+		t.Errorf("expected ErrNotImplemented, got %v", err)
+	}
+}

--- a/internal/pluginclient/client_test.go
+++ b/internal/pluginclient/client_test.go
@@ -53,9 +53,9 @@ func TestPluginRemoteAccessClient_SetupContainers_ReturnsNotImplemented(t *testi
 	}
 }
 
-func TestPluginRemoteAccessClient_DeregisterNode_ReturnsNotImplemented(t *testing.T) {
+func TestPluginRemoteAccessClient_DeregisterNodeAgent_ReturnsNotImplemented(t *testing.T) {
 	strategy := NewPluginRemoteAccessClient("http://localhost:8080")
-	err := strategy.DeregisterNode(context.Background(), nil)
+	err := strategy.DeregisterNodeAgent(context.Background(), nil)
 	if !errors.Is(err, ErrNotImplemented) {
 		t.Errorf("expected ErrNotImplemented, got %v", err)
 	}

--- a/internal/pluginclient/jwt_client.go
+++ b/internal/pluginclient/jwt_client.go
@@ -1,0 +1,43 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package pluginclient
+
+import (
+	workspacev1alpha1 "github.com/jupyter-infra/jupyter-k8s/api/v1alpha1"
+	"github.com/jupyter-infra/jupyter-k8s/internal/jwt"
+)
+
+// PluginSignerFactory implements jwt.SignerFactory by delegating to a plugin sidecar.
+type PluginSignerFactory struct {
+	client *PluginClient
+}
+
+// NewPluginSignerFactory creates a new PluginSignerFactory for the given plugin endpoint.
+func NewPluginSignerFactory(baseURL string) *PluginSignerFactory {
+	return &PluginSignerFactory{
+		client: NewPluginClient(baseURL),
+	}
+}
+
+// CreateSigner returns a PluginSigner that delegates JWT operations to the plugin.
+func (f *PluginSignerFactory) CreateSigner(_ *workspacev1alpha1.WorkspaceAccessStrategy) (jwt.Signer, error) {
+	return nil, ErrNotImplemented
+}
+
+// PluginSigner implements jwt.Signer by delegating to a plugin sidecar over HTTP.
+type PluginSigner struct {
+	client *PluginClient
+}
+
+// GenerateToken delegates token generation to the plugin via POST /v1alpha1/jwt/sign.
+func (s *PluginSigner) GenerateToken(_ string, _ []string, _ string, _ map[string][]string, _, _, _ string) (string, error) {
+	return "", ErrNotImplemented
+}
+
+// ValidateToken delegates token validation to the plugin via POST /v1alpha1/jwt/verify.
+func (s *PluginSigner) ValidateToken(_ string) (*jwt.Claims, error) {
+	return nil, ErrNotImplemented
+}

--- a/internal/pluginclient/remote_access_client.go
+++ b/internal/pluginclient/remote_access_client.go
@@ -1,0 +1,47 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package pluginclient
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+
+	workspacev1alpha1 "github.com/jupyter-infra/jupyter-k8s/api/v1alpha1"
+)
+
+// PluginRemoteAccessClient implements the controller's SSMRemoteAccessStrategyInterface
+// by delegating cloud SDK operations to a plugin sidecar over HTTP.
+type PluginRemoteAccessClient struct {
+	client *PluginClient
+}
+
+// NewPluginRemoteAccessClient creates a new PluginRemoteAccessClient for the given plugin endpoint.
+func NewPluginRemoteAccessClient(baseURL string) *PluginRemoteAccessClient {
+	return &PluginRemoteAccessClient{
+		client: NewPluginClient(baseURL),
+	}
+}
+
+// SetupContainers delegates pod setup to the plugin via POST /v1alpha1/remote-access/register-node.
+func (s *PluginRemoteAccessClient) SetupContainers(_ context.Context, _ *corev1.Pod, _ *workspacev1alpha1.Workspace, _ *workspacev1alpha1.WorkspaceAccessStrategy) error {
+	return ErrNotImplemented
+}
+
+// DeregisterNode delegates cleanup to the plugin via POST /v1alpha1/remote-access/deregister-node.
+func (s *PluginRemoteAccessClient) DeregisterNode(_ context.Context, _ *corev1.Pod) error {
+	return ErrNotImplemented
+}
+
+// Initialize delegates one-time resource creation to the plugin via POST /v1alpha1/remote-access/initialize.
+func (s *PluginRemoteAccessClient) Initialize(_ context.Context) error {
+	return ErrNotImplemented
+}
+
+// CreateSession delegates session creation to the plugin via POST /v1alpha1/remote-access/create-session.
+func (s *PluginRemoteAccessClient) CreateSession(_ context.Context, _ string, _ string, _ string, _ *workspacev1alpha1.WorkspaceAccessStrategy) (string, error) {
+	return "", ErrNotImplemented
+}

--- a/internal/pluginclient/remote_access_client.go
+++ b/internal/pluginclient/remote_access_client.go
@@ -26,13 +26,13 @@ func NewPluginRemoteAccessClient(baseURL string) *PluginRemoteAccessClient {
 	}
 }
 
-// SetupContainers delegates pod setup to the plugin via POST /v1alpha1/remote-access/register-node.
+// SetupContainers delegates pod setup to the plugin via POST /v1alpha1/remote-access/register-node-agent.
 func (s *PluginRemoteAccessClient) SetupContainers(_ context.Context, _ *corev1.Pod, _ *workspacev1alpha1.Workspace, _ *workspacev1alpha1.WorkspaceAccessStrategy) error {
 	return ErrNotImplemented
 }
 
-// DeregisterNode delegates cleanup to the plugin via POST /v1alpha1/remote-access/deregister-node.
-func (s *PluginRemoteAccessClient) DeregisterNode(_ context.Context, _ *corev1.Pod) error {
+// DeregisterNodeAgent delegates cleanup to the plugin via POST /v1alpha1/remote-access/deregister-node-agent.
+func (s *PluginRemoteAccessClient) DeregisterNodeAgent(_ context.Context, _ *corev1.Pod) error {
 	return ErrNotImplemented
 }
 

--- a/internal/pluginserver/handler.go
+++ b/internal/pluginserver/handler.go
@@ -24,7 +24,7 @@ type JWTHandler interface {
 // for remote access operations.
 type RemoteAccessHandler interface {
 	Initialize(ctx context.Context, req *pluginapi.InitializeRequest) (*pluginapi.InitializeResponse, error)
-	RegisterNode(ctx context.Context, req *pluginapi.RegisterNodeRequest) (*pluginapi.RegisterNodeResponse, error)
-	DeregisterNode(ctx context.Context, req *pluginapi.DeregisterNodeRequest) (*pluginapi.DeregisterNodeResponse, error)
+	RegisterNodeAgent(ctx context.Context, req *pluginapi.RegisterNodeAgentRequest) (*pluginapi.RegisterNodeAgentResponse, error)
+	DeregisterNodeAgent(ctx context.Context, req *pluginapi.DeregisterNodeAgentRequest) (*pluginapi.DeregisterNodeAgentResponse, error)
 	CreateSession(ctx context.Context, req *pluginapi.CreateSessionRequest) (*pluginapi.CreateSessionResponse, error)
 }

--- a/internal/pluginserver/handler.go
+++ b/internal/pluginserver/handler.go
@@ -1,0 +1,30 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+// Package pluginserver provides HTTP server scaffolding for plugin implementations.
+// Plugin authors implement the handler interfaces; the server handles routing,
+// JSON encoding/decoding, health checks, and error formatting.
+package pluginserver
+
+import (
+	"context"
+
+	pluginapi "github.com/jupyter-infra/jupyter-k8s/api/plugin/v1alpha1"
+)
+
+// JWTHandler defines the interface that plugin implementations must satisfy for JWT operations.
+type JWTHandler interface {
+	Sign(ctx context.Context, req *pluginapi.SignRequest) (*pluginapi.SignResponse, error)
+	Verify(ctx context.Context, req *pluginapi.VerifyRequest) (*pluginapi.VerifyResponse, error)
+}
+
+// RemoteAccessHandler defines the interface that plugin implementations must satisfy
+// for remote access operations.
+type RemoteAccessHandler interface {
+	Initialize(ctx context.Context, req *pluginapi.InitializeRequest) (*pluginapi.InitializeResponse, error)
+	RegisterNode(ctx context.Context, req *pluginapi.RegisterNodeRequest) (*pluginapi.RegisterNodeResponse, error)
+	DeregisterNode(ctx context.Context, req *pluginapi.DeregisterNodeRequest) (*pluginapi.DeregisterNodeResponse, error)
+	CreateSession(ctx context.Context, req *pluginapi.CreateSessionRequest) (*pluginapi.CreateSessionResponse, error)
+}

--- a/internal/pluginserver/server.go
+++ b/internal/pluginserver/server.go
@@ -114,9 +114,7 @@ func (s *Server) withMiddleware(next http.HandlerFunc) http.Handler {
 					"error", rec,
 					"stack", string(debug.Stack()),
 				)
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusInternalServerError)
-				_ = json.NewEncoder(w).Encode(pluginapi.ErrorResponse{Error: "internal server error"})
+				writeJSON(w, http.StatusInternalServerError, pluginapi.ErrorResponse{Error: "internal server error"})
 			}
 		}()
 
@@ -136,14 +134,16 @@ func generateRequestID() string {
 	return hex.EncodeToString(b)
 }
 
-func (s *Server) handleHealthz(w http.ResponseWriter, _ *http.Request) {
+func writeJSON(w http.ResponseWriter, status int, body any) {
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	_ = json.NewEncoder(w).Encode(struct{}{})
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+func (s *Server) handleHealthz(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, struct{}{})
 }
 
 func (s *Server) handleNotImplemented(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusNotImplemented) // 501
-	_ = json.NewEncoder(w).Encode(pluginapi.ErrorResponse{Error: "not implemented"})
+	writeJSON(w, http.StatusNotImplemented, pluginapi.ErrorResponse{Error: "not implemented"})
 }

--- a/internal/pluginserver/server.go
+++ b/internal/pluginserver/server.go
@@ -1,0 +1,149 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package pluginserver
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"runtime/debug"
+	"time"
+
+	pluginapi "github.com/jupyter-infra/jupyter-k8s/api/plugin/v1alpha1"
+)
+
+// HeaderRequestID is the HTTP header used to pass a request ID between the controller and plugin.
+const HeaderRequestID = "X-Request-ID"
+
+// requestIDKey is the context key for the request ID.
+type requestIDKey struct{}
+
+// RequestIDFromContext returns the request ID from the context, or empty string if not set.
+func RequestIDFromContext(ctx context.Context) string {
+	if id, ok := ctx.Value(requestIDKey{}).(string); ok {
+		return id
+	}
+	return ""
+}
+
+// Server is the HTTP server that routes requests to plugin handler implementations.
+type Server struct {
+	jwtHandler          JWTHandler
+	remoteAccessHandler RemoteAccessHandler
+	httpServer          *http.Server
+	mux                 *http.ServeMux
+	logger              *slog.Logger
+}
+
+// NewServer creates a new plugin Server with the given handlers and port.
+func NewServer(jwtHandler JWTHandler, remoteAccessHandler RemoteAccessHandler, port int) *Server {
+	mux := http.NewServeMux()
+	logger := slog.Default()
+	s := &Server{
+		jwtHandler:          jwtHandler,
+		remoteAccessHandler: remoteAccessHandler,
+		mux:                 mux,
+		logger:              logger,
+		httpServer: &http.Server{
+			Addr:    fmt.Sprintf(":%d", port),
+			Handler: mux,
+		},
+	}
+	s.registerRoutes()
+	return s
+}
+
+// Handler returns the underlying http.Handler for testing.
+func (s *Server) Handler() http.Handler {
+	return s.mux
+}
+
+// ListenAndServe starts the HTTP server.
+func (s *Server) ListenAndServe() error {
+	s.logger.Info("starting plugin server", "addr", s.httpServer.Addr)
+	return s.httpServer.ListenAndServe()
+}
+
+// Shutdown gracefully drains in-flight requests and stops the server.
+func (s *Server) Shutdown(ctx context.Context) error {
+	s.logger.Info("shutting down plugin server")
+	return s.httpServer.Shutdown(ctx)
+}
+
+func (s *Server) registerRoutes() {
+	s.mux.Handle("POST /v1alpha1/jwt/sign", s.withMiddleware(s.handleNotImplemented))
+	s.mux.Handle("POST /v1alpha1/jwt/verify", s.withMiddleware(s.handleNotImplemented))
+	s.mux.Handle("POST /v1alpha1/remote-access/initialize", s.withMiddleware(s.handleNotImplemented))
+	s.mux.Handle("POST /v1alpha1/remote-access/register-node", s.withMiddleware(s.handleNotImplemented))
+	s.mux.Handle("POST /v1alpha1/remote-access/deregister-node", s.withMiddleware(s.handleNotImplemented))
+	s.mux.Handle("POST /v1alpha1/remote-access/create-session", s.withMiddleware(s.handleNotImplemented))
+	s.mux.Handle("GET /healthz", s.withMiddleware(s.handleHealthz))
+}
+
+// withMiddleware wraps a handler with request ID extraction, panic recovery, and request logging.
+func (s *Server) withMiddleware(next http.HandlerFunc) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+
+		// Extract or generate request ID
+		requestID := r.Header.Get(HeaderRequestID)
+		if requestID == "" {
+			requestID = generateRequestID()
+		}
+
+		// Add request ID to response header and request context
+		w.Header().Set(HeaderRequestID, requestID)
+		ctx := context.WithValue(r.Context(), requestIDKey{}, requestID)
+		r = r.WithContext(ctx)
+
+		logger := s.logger.With("requestID", requestID)
+
+		defer func() {
+			if rec := recover(); rec != nil {
+				logger.Error("panic recovered",
+					"method", r.Method,
+					"path", r.URL.Path,
+					"duration", time.Since(start),
+					"error", rec,
+					"stack", string(debug.Stack()),
+				)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusInternalServerError)
+				_ = json.NewEncoder(w).Encode(pluginapi.ErrorResponse{Error: "internal server error"})
+			}
+		}()
+
+		next.ServeHTTP(w, r)
+
+		logger.Info("request handled",
+			"method", r.Method,
+			"path", r.URL.Path,
+			"duration", time.Since(start),
+		)
+	})
+}
+
+func generateRequestID() string {
+	b := make([]byte, 8)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
+}
+
+func (s *Server) handleHealthz(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(struct{}{})
+}
+
+func (s *Server) handleNotImplemented(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusNotImplemented) // 501
+	_ = json.NewEncoder(w).Encode(pluginapi.ErrorResponse{Error: "not implemented"})
+}

--- a/internal/pluginserver/server.go
+++ b/internal/pluginserver/server.go
@@ -81,8 +81,8 @@ func (s *Server) registerRoutes() {
 	s.mux.Handle(pluginapi.RouteJWTSign.Pattern(), s.withMiddleware(s.handleNotImplemented))
 	s.mux.Handle(pluginapi.RouteJWTVerify.Pattern(), s.withMiddleware(s.handleNotImplemented))
 	s.mux.Handle(pluginapi.RouteRemoteAccessInit.Pattern(), s.withMiddleware(s.handleNotImplemented))
-	s.mux.Handle(pluginapi.RouteRegisterNode.Pattern(), s.withMiddleware(s.handleNotImplemented))
-	s.mux.Handle(pluginapi.RouteDeregisterNode.Pattern(), s.withMiddleware(s.handleNotImplemented))
+	s.mux.Handle(pluginapi.RouteRegisterNodeAgent.Pattern(), s.withMiddleware(s.handleNotImplemented))
+	s.mux.Handle(pluginapi.RouteDeregisterNodeAgent.Pattern(), s.withMiddleware(s.handleNotImplemented))
 	s.mux.Handle(pluginapi.RouteCreateSession.Pattern(), s.withMiddleware(s.handleNotImplemented))
 	s.mux.Handle(pluginapi.RouteHealthz.Pattern(), s.withMiddleware(s.handleHealthz))
 }

--- a/internal/pluginserver/server.go
+++ b/internal/pluginserver/server.go
@@ -78,13 +78,13 @@ func (s *Server) Shutdown(ctx context.Context) error {
 }
 
 func (s *Server) registerRoutes() {
-	s.mux.Handle("POST /v1alpha1/jwt/sign", s.withMiddleware(s.handleNotImplemented))
-	s.mux.Handle("POST /v1alpha1/jwt/verify", s.withMiddleware(s.handleNotImplemented))
-	s.mux.Handle("POST /v1alpha1/remote-access/initialize", s.withMiddleware(s.handleNotImplemented))
-	s.mux.Handle("POST /v1alpha1/remote-access/register-node", s.withMiddleware(s.handleNotImplemented))
-	s.mux.Handle("POST /v1alpha1/remote-access/deregister-node", s.withMiddleware(s.handleNotImplemented))
-	s.mux.Handle("POST /v1alpha1/remote-access/create-session", s.withMiddleware(s.handleNotImplemented))
-	s.mux.Handle("GET /healthz", s.withMiddleware(s.handleHealthz))
+	s.mux.Handle(pluginapi.RouteJWTSign.Pattern(), s.withMiddleware(s.handleNotImplemented))
+	s.mux.Handle(pluginapi.RouteJWTVerify.Pattern(), s.withMiddleware(s.handleNotImplemented))
+	s.mux.Handle(pluginapi.RouteRemoteAccessInit.Pattern(), s.withMiddleware(s.handleNotImplemented))
+	s.mux.Handle(pluginapi.RouteRegisterNode.Pattern(), s.withMiddleware(s.handleNotImplemented))
+	s.mux.Handle(pluginapi.RouteDeregisterNode.Pattern(), s.withMiddleware(s.handleNotImplemented))
+	s.mux.Handle(pluginapi.RouteCreateSession.Pattern(), s.withMiddleware(s.handleNotImplemented))
+	s.mux.Handle(pluginapi.RouteHealthz.Pattern(), s.withMiddleware(s.handleHealthz))
 }
 
 // withMiddleware wraps a handler with request ID extraction, panic recovery, and request logging.

--- a/internal/pluginserver/server_test.go
+++ b/internal/pluginserver/server_test.go
@@ -108,8 +108,8 @@ func TestRoutes_ReturnNotImplemented(t *testing.T) {
 		{http.MethodPost, "/v1alpha1/jwt/sign"},
 		{http.MethodPost, "/v1alpha1/jwt/verify"},
 		{http.MethodPost, "/v1alpha1/remote-access/initialize"},
-		{http.MethodPost, "/v1alpha1/remote-access/register-node"},
-		{http.MethodPost, "/v1alpha1/remote-access/deregister-node"},
+		{http.MethodPost, "/v1alpha1/remote-access/register-node-agent"},
+		{http.MethodPost, "/v1alpha1/remote-access/deregister-node-agent"},
 		{http.MethodPost, "/v1alpha1/remote-access/create-session"},
 	}
 

--- a/internal/pluginserver/server_test.go
+++ b/internal/pluginserver/server_test.go
@@ -1,0 +1,136 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package pluginserver
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	pluginapi "github.com/jupyter-infra/jupyter-k8s/api/plugin/v1alpha1"
+)
+
+func newTestServer() *Server {
+	// Handlers are unused since all routes return 501 in the shell.
+	return NewServer(nil, nil, 0)
+}
+
+
+func TestHealthz(t *testing.T) {
+	srv := newTestServer()
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestPanicRecovery(t *testing.T) {
+	srv := newTestServer()
+	panicHandler := srv.withMiddleware(func(_ http.ResponseWriter, _ *http.Request) {
+		panic("test panic")
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/test", nil)
+	w := httptest.NewRecorder()
+	panicHandler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", w.Code)
+	}
+
+	var errResp pluginapi.ErrorResponse
+	if err := json.NewDecoder(w.Body).Decode(&errResp); err != nil {
+		t.Fatalf("failed to decode error response: %v", err)
+	}
+	if errResp.Error != "internal server error" {
+		t.Errorf("expected error %q, got %q", "internal server error", errResp.Error)
+	}
+}
+
+func TestRequestID_PassedThrough(t *testing.T) {
+	srv := newTestServer()
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	req.Header.Set(HeaderRequestID, "caller-id-123")
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	got := w.Header().Get(HeaderRequestID)
+	if got != "caller-id-123" {
+		t.Errorf("expected request ID %q echoed back, got %q", "caller-id-123", got)
+	}
+}
+
+func TestRequestID_GeneratedWhenMissing(t *testing.T) {
+	srv := newTestServer()
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	got := w.Header().Get(HeaderRequestID)
+	if got == "" {
+		t.Error("expected a generated request ID, got empty string")
+	}
+	if len(got) != 16 { // 8 bytes = 16 hex chars
+		t.Errorf("expected 16-char hex request ID, got %q (len %d)", got, len(got))
+	}
+}
+
+func TestRequestID_AvailableInContext(t *testing.T) {
+	srv := newTestServer()
+	var capturedID string
+	handler := srv.withMiddleware(func(_ http.ResponseWriter, r *http.Request) {
+		capturedID = RequestIDFromContext(r.Context())
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/test", nil)
+	req.Header.Set(HeaderRequestID, "ctx-test-456")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if capturedID != "ctx-test-456" {
+		t.Errorf("expected context request ID %q, got %q", "ctx-test-456", capturedID)
+	}
+}
+
+func TestRoutes_ReturnNotImplemented(t *testing.T) {
+	srv := newTestServer()
+
+	routes := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodPost, "/v1alpha1/jwt/sign"},
+		{http.MethodPost, "/v1alpha1/jwt/verify"},
+		{http.MethodPost, "/v1alpha1/remote-access/initialize"},
+		{http.MethodPost, "/v1alpha1/remote-access/register-node"},
+		{http.MethodPost, "/v1alpha1/remote-access/deregister-node"},
+		{http.MethodPost, "/v1alpha1/remote-access/create-session"},
+	}
+
+	for _, rt := range routes {
+		t.Run(rt.path, func(t *testing.T) {
+			req := httptest.NewRequest(rt.method, rt.path, nil)
+			w := httptest.NewRecorder()
+			srv.Handler().ServeHTTP(w, req)
+
+			if w.Code != http.StatusNotImplemented {
+				t.Errorf("expected 501, got %d", w.Code)
+			}
+
+			var errResp pluginapi.ErrorResponse
+			if err := json.NewDecoder(w.Body).Decode(&errResp); err != nil {
+				t.Fatalf("failed to decode error response: %v", err)
+			}
+			if errResp.Error != "not implemented" {
+				t.Errorf("expected error %q, got %q", "not implemented", errResp.Error)
+			}
+		})
+	}
+}

--- a/internal/pluginserver/server_test.go
+++ b/internal/pluginserver/server_test.go
@@ -19,7 +19,6 @@ func newTestServer() *Server {
 	return NewServer(nil, nil, 0)
 }
 
-
 func TestHealthz(t *testing.T) {
 	srv := newTestServer()
 	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -146,6 +146,16 @@ var _ = Describe("Manager", Ordered, func() {
 			}
 			Eventually(verifyMetricsServerStarted).Should(Succeed())
 
+			By("waiting for the controller to acquire leader lease")
+			verifyLeaderAcquired := func(g Gomega) {
+				cmd := exec.Command("kubectl", "logs", controllerPodName, "-n", OperatorNamespace)
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(ContainSubstring("successfully acquired lease"),
+					"Controller has not yet acquired leader lease")
+			}
+			Eventually(verifyLeaderAcquired).Should(Succeed())
+
 			By("creating the curl-metrics pod to access the metrics endpoint")
 			cmd = exec.Command("kubectl", "run", "curl-metrics", "--restart=Never",
 				"-n", OperatorNamespace,

--- a/test/e2e/helpers_volume.go
+++ b/test/e2e/helpers_volume.go
@@ -165,7 +165,7 @@ func VerifyPodCanAccessExternalVolumes(workspaceName, namespace, pvcName, mountP
 			return fmt.Errorf("failed to write to %s: %w", filepath, writeErr)
 		}
 		return nil
-	}, 30*time.Second, 5*time.Second).Should(gomega.Succeed(),
+	}, 60*time.Second, 2*time.Second).Should(gomega.Succeed(),
 		fmt.Sprintf("Failed to write to %s after retries", filepath))
 
 	// Confirm the file is visible. Also retried for the same transient exec reasons.
@@ -180,7 +180,7 @@ func VerifyPodCanAccessExternalVolumes(workspaceName, namespace, pvcName, mountP
 			return fmt.Errorf("ls output for %s was empty", filepath)
 		}
 		return nil
-	}, 30*time.Second, 5*time.Second).Should(gomega.Succeed(),
+	}, 60*time.Second, 2*time.Second).Should(gomega.Succeed(),
 		fmt.Sprintf("Failed to verify file %s exists after retries", filepath))
 }
 
@@ -232,6 +232,6 @@ func VerifyHomeVolumeDataPersisted(workspaceName, namespace string) {
 			return fmt.Errorf("ls output for %s was empty", filepath)
 		}
 		return nil
-	}, 30*time.Second, 5*time.Second).Should(gomega.Succeed(),
+	}, 60*time.Second, 2*time.Second).Should(gomega.Succeed(),
 		fmt.Sprintf("Failed to verify persisted file %s after retries", filepath))
 }


### PR DESCRIPTION
This PR creates the base contract between the controller/extensionapi container and their cloud-provider plugins. In the P0 architecture, a cloud provider plugin runs as a sidecar within the pod of the controller/extensionapi. However this is extensible to separate deployments outside of the pod network.

Refer to #337

### Implementation
- define plugin interface in `api/plugin`
- add a generic client in `internal/pluginclient` to be used by the extensionapi / controller
- add a generic server in `internal/pluginserver` to be used by plugins
- basic implementation `pluginserver` as a `net/http` server

### Testing
- not wired up yet, rely on unit tests only


