### PR TITLE
feat: plugin client-server scaffolding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 ## Project Overview
 
 Jupyter-k8s is a Kubernetes operator for Jupyter notebooks and other IDEs. It manages compute, storage, networking, and access control for multiple users in a secure, scalable, usable and flexible way.
-- the project is not live yet, do not worry about backward compatibility.
+- the project is live, be mindful of backward compatibility.
 
 ### Kubernetes Custom Resources
 

--- a/internal/plugin/constants.go
+++ b/internal/plugin/constants.go
@@ -1,0 +1,15 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+// Package plugin provides shared types and constants for the plugin client/server protocol.
+package plugin
+
+// HTTP headers for request ID correlation between client and plugin.
+const (
+	// HeaderPluginRequestID identifies a single client→plugin HTTP call.
+	HeaderPluginRequestID = "X-Plugin-Request-ID"
+	// HeaderOriginRequestID traces back to the original trigger (extensionapi request, controller event).
+	HeaderOriginRequestID = "X-Origin-Request-ID"
+)

--- a/internal/plugin/errors.go
+++ b/internal/plugin/errors.go
@@ -1,0 +1,23 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package plugin
+
+import "fmt"
+
+// StatusError represents an HTTP error with a status code and message.
+// Used by both the plugin server (handler returns it to set the HTTP status)
+// and the plugin client (created when parsing a non-200 response).
+type StatusError struct {
+	Code    int
+	Message string
+}
+
+func (e *StatusError) Error() string {
+	if e.Message != "" {
+		return fmt.Sprintf("plugin error (HTTP %d): %s", e.Code, e.Message)
+	}
+	return fmt.Sprintf("plugin error (HTTP %d)", e.Code)
+}

--- a/internal/plugin/utils.go
+++ b/internal/plugin/utils.go
@@ -1,0 +1,37 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package plugin
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+)
+
+// originRequestIDKey is the context key for the origin request ID.
+type originRequestIDKey struct{}
+
+// ContextWithOriginRequestID returns a context with the given origin request ID.
+// The client propagates this to the plugin via the X-Origin-Request-ID header.
+func ContextWithOriginRequestID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, originRequestIDKey{}, id)
+}
+
+// OriginRequestID returns the origin request ID from the context, or empty string.
+func OriginRequestID(ctx context.Context) string {
+	if id, ok := ctx.Value(originRequestIDKey{}).(string); ok {
+		return id
+	}
+	return ""
+}
+
+// GenerateRequestID returns a random 16-character hex string (8 bytes of entropy).
+// Used by both the client (call IDs) and server (request IDs when none is provided).
+func GenerateRequestID() string {
+	b := make([]byte, 8)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
+}

--- a/internal/plugin/utils_test.go
+++ b/internal/plugin/utils_test.go
@@ -1,0 +1,42 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package plugin
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContextWithOriginRequestID_RoundTrip(t *testing.T) {
+	ctx := ContextWithOriginRequestID(context.Background(), "req-abc-123")
+	assert.Equal(t, "req-abc-123", OriginRequestID(ctx))
+}
+
+func TestOriginRequestID_EmptyWhenNotSet(t *testing.T) {
+	assert.Equal(t, "", OriginRequestID(context.Background()))
+}
+
+func TestOriginRequestID_Overwrite(t *testing.T) {
+	ctx := ContextWithOriginRequestID(context.Background(), "first")
+	ctx = ContextWithOriginRequestID(ctx, "second")
+	assert.Equal(t, "second", OriginRequestID(ctx))
+}
+
+func TestGenerateRequestID_Format(t *testing.T) {
+	id := GenerateRequestID()
+	assert.Len(t, id, 16, "8 random bytes = 16 hex chars")
+}
+
+func TestGenerateRequestID_Unique(t *testing.T) {
+	seen := make(map[string]bool)
+	for range 100 {
+		id := GenerateRequestID()
+		assert.False(t, seen[id], "duplicate request ID: %s", id)
+		seen[id] = true
+	}
+}

--- a/internal/pluginclient/client.go
+++ b/internal/pluginclient/client.go
@@ -8,23 +8,160 @@ Distributed under the terms of the MIT license
 package pluginclient
 
 import (
-	"errors"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
 	"net/http"
-)
+	"time"
 
-// ErrNotImplemented is returned by shell methods that are not yet implemented.
-var ErrNotImplemented = errors.New("plugin client: not implemented")
+	pluginapi "github.com/jupyter-infra/jupyter-k8s/api/plugin/v1alpha1"
+	"github.com/jupyter-infra/jupyter-k8s/internal/plugin"
+)
 
 // PluginClient is the shared HTTP client for communicating with a plugin sidecar.
 type PluginClient struct {
-	baseURL    string
-	httpClient *http.Client
+	baseURL     string
+	httpClient  *http.Client
+	logger      *slog.Logger
+	retryCount  int
+	retryDelay  time.Duration
+	callTimeout time.Duration
 }
 
 // NewPluginClient creates a new PluginClient for the given plugin base URL.
-func NewPluginClient(baseURL string) *PluginClient {
-	return &PluginClient{
-		baseURL:    baseURL,
-		httpClient: &http.Client{},
+func NewPluginClient(baseURL string, logger *slog.Logger) *PluginClient {
+	if logger == nil {
+		logger = slog.Default()
 	}
+	return &PluginClient{
+		baseURL:     baseURL,
+		httpClient:  &http.Client{},
+		logger:      logger,
+		retryCount:  defaultRetryCount,
+		retryDelay:  defaultRetryDelay,
+		callTimeout: defaultCallTimeout,
+	}
+}
+
+// doPost sends a JSON POST request to the plugin and decodes the response.
+//
+// Retry behavior (see isRetryableError for the full contract):
+//   - Retries only on transport-level errors where no response was received
+//     (connection refused, reset, EOF). These indicate sidecar unavailability.
+//   - Never retries on HTTP responses (including 500/503) — the plugin already
+//     processed the request and owns retrying its own cloud provider calls.
+//   - Never retries on context cancellation or timeout — respects caller intent.
+//
+// No per-retry header is needed: since retries only happen on transport failures,
+// the plugin never receives a request on failed attempts. By the time a request
+// reaches the plugin, it is always the first delivery of that X-Plugin-Request-ID.
+//
+// Each attempt gets its own per-call timeout derived from callTimeout.
+// The caller's context is checked before each retry to allow early exit.
+func doPost[Resp any](ctx context.Context, c *PluginClient, path string, reqBody any) (*Resp, int, error) {
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, 0, fmt.Errorf("plugin client: marshal request: %w", err)
+	}
+
+	callID := plugin.GenerateRequestID()
+	logAttrs := []any{
+		"path", path,
+		"pluginRequestID", callID,
+	}
+	if originID := plugin.OriginRequestID(ctx); originID != "" {
+		logAttrs = append(logAttrs, "originRequestID", originID)
+	}
+
+	originalStart := time.Now()
+	start := originalStart
+	var lastErr error
+	var lastDuration time.Duration
+	for attempt := range c.retryCount + 1 {
+		if attempt > 0 {
+			c.logger.WarnContext(ctx, "retrying plugin call",
+				append(logAttrs, "attempt", attempt+1, "maxAttempts", c.retryCount+1,
+					"lastError", lastErr, "lastDuration", lastDuration)...)
+
+			// Wait for retry delay, but respect the caller's context.
+			select {
+			case <-ctx.Done():
+				return nil, 0, fmt.Errorf("plugin client: terminated before retry %d to %s: %w", attempt, path, ctx.Err())
+			case <-time.After(c.retryDelay):
+			}
+			start = time.Now()
+		}
+
+		resp, err := c.doSinglePost(ctx, path, body, callID)
+
+		if err != nil {
+			lastDuration = time.Since(start)
+			lastErr = err
+			if isRetryableError(err) {
+				continue
+			}
+			// Non-retryable transport error (context canceled, timeout, unknown).
+			c.logger.ErrorContext(ctx, "plugin call failed (non-retryable)",
+				append(logAttrs, "attempt", attempt+1, "duration", lastDuration,
+					"totalDuration", time.Since(originalStart), "error", err)...)
+			return nil, 0, fmt.Errorf("plugin client: do request to %s: %w", path, err)
+		}
+
+		// Got an HTTP response — never retry from here, regardless of status code.
+		return handleResponse[Resp](c, ctx, path, resp, logAttrs, time.Since(originalStart))
+	}
+
+	// All retries exhausted — the sidecar was unreachable on every attempt.
+	c.logger.ErrorContext(ctx, "plugin call failed (retries exhausted)",
+		append(logAttrs, "attempts", c.retryCount+1, "totalDuration", time.Since(originalStart), "error", lastErr)...)
+	return nil, 0, fmt.Errorf("plugin client: %d attempts to %s failed: %w", c.retryCount+1, path, lastErr)
+}
+
+// doSinglePost executes one HTTP POST with a per-call timeout.
+func (c *PluginClient) doSinglePost(ctx context.Context, path string, body []byte, callID string) (*http.Response, error) {
+	callCtx, cancel := context.WithTimeout(ctx, c.callTimeout)
+	defer cancel()
+
+	httpReq, err := http.NewRequestWithContext(callCtx, http.MethodPost, c.baseURL+path, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set(plugin.HeaderPluginRequestID, callID)
+	if originID := plugin.OriginRequestID(ctx); originID != "" {
+		httpReq.Header.Set(plugin.HeaderOriginRequestID, originID)
+	}
+
+	return c.httpClient.Do(httpReq)
+}
+
+// handleResponse reads and decodes an HTTP response. Called only when we got a
+// response from the plugin (any status code).
+func handleResponse[Resp any](c *PluginClient, ctx context.Context, path string, resp *http.Response, baseLogAttrs []any, totalDuration time.Duration) (*Resp, int, error) {
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, resp.StatusCode, fmt.Errorf("plugin client: read response from %s: %w", path, err)
+	}
+
+	logAttrs := append(append([]any{}, baseLogAttrs...), "status", resp.StatusCode, "totalDuration", totalDuration)
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		var errResp pluginapi.ErrorResponse
+		_ = json.Unmarshal(respBody, &errResp)
+		c.logger.ErrorContext(ctx, "plugin call returned error", append(logAttrs, "error", errResp.Error)...)
+		return nil, resp.StatusCode, &plugin.StatusError{Code: resp.StatusCode, Message: errResp.Error}
+	}
+
+	c.logger.InfoContext(ctx, "plugin call succeeded", logAttrs...)
+
+	var result Resp
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, resp.StatusCode, fmt.Errorf("plugin client: decode response from %s: %w", path, err)
+	}
+	return &result, resp.StatusCode, nil
 }

--- a/internal/pluginclient/client_test.go
+++ b/internal/pluginclient/client_test.go
@@ -8,6 +8,7 @@ package pluginclient
 import (
 	"context"
 	"encoding/json"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -174,43 +175,39 @@ func newTestClient(baseURL string) *PluginClient {
 }
 
 func TestDoPost_RetriesOnConnectionRefused(t *testing.T) {
-	// First two attempts: connection refused (server not started).
-	// Third attempt: server is up.
-	var attempts int
-	var srv *httptest.Server
-	srv = httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		attempts++
+	// Grab a fixed listener so the client address stays valid across retries.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := ln.Addr().String()
+	// Close the listener so the port is unbound — first attempts get ECONNREFUSED.
+	require.NoError(t, ln.Close())
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(pluginapi.SignResponse{Token: "ok"})
-	}))
+		_ = json.NewEncoder(w).Encode(pluginapi.SignResponse{Token: "recovered"})
+	})
 
-	// Point client at the server's listener address before starting it.
-	client := newTestClient("http://" + srv.Listener.Addr().String())
-	srv.Close() // Close the unstarted server to free the port.
+	client := newTestClient("http://" + addr)
 
-	// Start the server after a brief delay (simulates sidecar coming up).
+	// Re-bind the same port after a delay, simulating the sidecar coming up.
+	srv := &http.Server{Handler: handler}
+	listenErr := make(chan error, 1)
 	go func() {
 		time.Sleep(15 * time.Millisecond)
-		srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			attempts++
-			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(pluginapi.SignResponse{Token: "ok"})
-		}))
+		newLn, err := net.Listen("tcp", addr)
+		if err != nil {
+			listenErr <- err
+			return
+		}
+		listenErr <- nil
+		_ = srv.Serve(newLn) // returns when listener is closed
 	}()
+	defer srv.Close()
 
-	// Wait for the goroutine to start the server, then update the client URL.
-	time.Sleep(30 * time.Millisecond)
-	if srv != nil {
-		defer srv.Close()
-		client.baseURL = srv.URL
-	}
-
-	// Directly test that connection refused IS retried by using an unreachable port.
-	unreachableClient := newTestClient("http://127.0.0.1:1")
-	_, _, err := doPost[pluginapi.SignResponse](context.Background(), unreachableClient, "/test", &pluginapi.SignRequest{})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "attempts")
-	assert.Contains(t, err.Error(), "failed")
+	resp, _, err := doPost[pluginapi.SignResponse](context.Background(), client, "/test", &pluginapi.SignRequest{})
+	require.NoError(t, <-listenErr, "failed to re-bind listener in background")
+	require.NoError(t, err)
+	assert.Equal(t, "recovered", resp.Token)
 }
 
 func TestDoPost_DoesNotRetryOnHTTPError(t *testing.T) {
@@ -261,11 +258,11 @@ func TestDoPost_SucceedsAfterTransientFailure(t *testing.T) {
 		if attempts <= 1 {
 			// Simulate transient failure by closing the connection.
 			hj, ok := w.(http.Hijacker)
-			if ok {
-				conn, _, _ := hj.Hijack()
-				_ = conn.Close()
-				return
-			}
+			require.True(t, ok, "ResponseWriter must support Hijacker")
+			conn, _, err := hj.Hijack()
+			require.NoError(t, err, "Hijack must succeed")
+			require.NoError(t, conn.Close(), "connection close must succeed")
+			return
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(pluginapi.SignResponse{Token: "recovered"})

--- a/internal/pluginclient/client_test.go
+++ b/internal/pluginclient/client_test.go
@@ -202,7 +202,7 @@ func TestDoPost_RetriesOnConnectionRefused(t *testing.T) {
 		listenErr <- nil
 		_ = srv.Serve(newLn) // returns when listener is closed
 	}()
-	defer srv.Close()
+	defer func() { _ = srv.Close() }()
 
 	resp, _, err := doPost[pluginapi.SignResponse](context.Background(), client, "/test", &pluginapi.SignRequest{})
 	require.NoError(t, <-listenErr, "failed to re-bind listener in background")

--- a/internal/pluginclient/client_test.go
+++ b/internal/pluginclient/client_test.go
@@ -7,12 +7,18 @@ package pluginclient
 
 import (
 	"context"
-	"errors"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
+	pluginapi "github.com/jupyter-infra/jupyter-k8s/api/plugin/v1alpha1"
 	"github.com/jupyter-infra/jupyter-k8s/internal/jwt"
+	"github.com/jupyter-infra/jupyter-k8s/internal/plugin"
 
-	workspacev1alpha1 "github.com/jupyter-infra/jupyter-k8s/api/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Compile-time interface conformance checks.
@@ -21,58 +27,254 @@ var (
 	_ jwt.Signer        = (*PluginSigner)(nil)
 )
 
-func TestPluginSignerFactory_CreateSigner_ReturnsNotImplemented(t *testing.T) {
-	factory := NewPluginSignerFactory("http://localhost:8080")
-	_, err := factory.CreateSigner(&workspacev1alpha1.WorkspaceAccessStrategy{})
-	if !errors.Is(err, ErrNotImplemented) {
-		t.Errorf("expected ErrNotImplemented, got %v", err)
+func TestStatusError_Error(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      *plugin.StatusError
+		expected string
+	}{
+		{
+			name:     "with message",
+			err:      &plugin.StatusError{Code: 401, Message: "unauthorized"},
+			expected: "plugin error (HTTP 401): unauthorized",
+		},
+		{
+			name:     "without message",
+			err:      &plugin.StatusError{Code: 500},
+			expected: "plugin error (HTTP 500)",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.err.Error())
+		})
 	}
 }
 
-func TestPluginSigner_GenerateToken_ReturnsNotImplemented(t *testing.T) {
-	signer := &PluginSigner{client: NewPluginClient("http://localhost:8080")}
-	_, err := signer.GenerateToken("user", []string{"g"}, "uid", nil, "/path", "domain", "bootstrap")
-	if !errors.Is(err, ErrNotImplemented) {
-		t.Errorf("expected ErrNotImplemented, got %v", err)
+func TestDoPost_ErrorStatusCodes(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		errMsg     string
+	}{
+		{"bad request", http.StatusBadRequest, "invalid input"},
+		{"unauthorized", http.StatusUnauthorized, "invalid token"},
+		{"internal server error", http.StatusInternalServerError, "something broke"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.statusCode)
+				_ = json.NewEncoder(w).Encode(pluginapi.ErrorResponse{Error: tt.errMsg})
+			}))
+			defer srv.Close()
+
+			client := NewPluginClient(srv.URL, nil)
+			_, _, err := doPost[pluginapi.SignResponse](context.Background(), client, "/test", &pluginapi.SignRequest{})
+			require.Error(t, err)
+
+			var pe *plugin.StatusError
+			require.ErrorAs(t, err, &pe)
+			assert.Equal(t, tt.statusCode, pe.Code)
+			assert.Equal(t, tt.errMsg, pe.Message)
+		})
 	}
 }
 
-func TestPluginSigner_ValidateToken_ReturnsNotImplemented(t *testing.T) {
-	signer := &PluginSigner{client: NewPluginClient("http://localhost:8080")}
-	_, err := signer.ValidateToken("some-token")
-	if !errors.Is(err, ErrNotImplemented) {
-		t.Errorf("expected ErrNotImplemented, got %v", err)
-	}
+func TestDoPost_InvalidResponseJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("not json"))
+	}))
+	defer srv.Close()
+
+	client := NewPluginClient(srv.URL, nil)
+	_, _, err := doPost[pluginapi.SignResponse](context.Background(), client, "/test", &pluginapi.SignRequest{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decode response")
 }
 
-func TestPluginRemoteAccessClient_SetupContainers_ReturnsNotImplemented(t *testing.T) {
-	strategy := NewPluginRemoteAccessClient("http://localhost:8080")
-	err := strategy.SetupContainers(context.Background(), nil, nil, nil)
-	if !errors.Is(err, ErrNotImplemented) {
-		t.Errorf("expected ErrNotImplemented, got %v", err)
-	}
+func TestDoPost_NonJSONErrorBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte("bad gateway"))
+	}))
+	defer srv.Close()
+
+	client := NewPluginClient(srv.URL, nil)
+	_, _, err := doPost[pluginapi.SignResponse](context.Background(), client, "/test", &pluginapi.SignRequest{})
+	require.Error(t, err)
+
+	var pe *plugin.StatusError
+	require.ErrorAs(t, err, &pe)
+	assert.Equal(t, http.StatusBadGateway, pe.Code)
+	assert.Empty(t, pe.Message) // Non-JSON error body, message is empty
 }
 
-func TestPluginRemoteAccessClient_DeregisterNodeAgent_ReturnsNotImplemented(t *testing.T) {
-	strategy := NewPluginRemoteAccessClient("http://localhost:8080")
-	err := strategy.DeregisterNodeAgent(context.Background(), nil)
-	if !errors.Is(err, ErrNotImplemented) {
-		t.Errorf("expected ErrNotImplemented, got %v", err)
-	}
+func TestDoPost_SendsPluginRequestID(t *testing.T) {
+	var receivedPluginID string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedPluginID = r.Header.Get(plugin.HeaderPluginRequestID)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(pluginapi.SignResponse{Token: "t"})
+	}))
+	defer srv.Close()
+
+	client := NewPluginClient(srv.URL, nil)
+	_, _, err := doPost[pluginapi.SignResponse](context.Background(), client, "/test", &pluginapi.SignRequest{})
+	require.NoError(t, err)
+	assert.NotEmpty(t, receivedPluginID)
+	assert.Len(t, receivedPluginID, 16)
 }
 
-func TestPluginRemoteAccessClient_Initialize_ReturnsNotImplemented(t *testing.T) {
-	strategy := NewPluginRemoteAccessClient("http://localhost:8080")
-	err := strategy.Initialize(context.Background())
-	if !errors.Is(err, ErrNotImplemented) {
-		t.Errorf("expected ErrNotImplemented, got %v", err)
-	}
+func TestDoPost_PropagatesOriginRequestID(t *testing.T) {
+	var receivedOriginID, receivedPluginID string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedOriginID = r.Header.Get(plugin.HeaderOriginRequestID)
+		receivedPluginID = r.Header.Get(plugin.HeaderPluginRequestID)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(pluginapi.SignResponse{Token: "t"})
+	}))
+	defer srv.Close()
+
+	ctx := plugin.ContextWithOriginRequestID(context.Background(), "origin-abc-123")
+	client := NewPluginClient(srv.URL, nil)
+	_, _, err := doPost[pluginapi.SignResponse](ctx, client, "/test", &pluginapi.SignRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, "origin-abc-123", receivedOriginID)
+	assert.NotEmpty(t, receivedPluginID)
+	assert.NotEqual(t, receivedOriginID, receivedPluginID)
 }
 
-func TestPluginRemoteAccessClient_CreateSession_ReturnsNotImplemented(t *testing.T) {
-	strategy := NewPluginRemoteAccessClient("http://localhost:8080")
-	_, err := strategy.CreateSession(context.Background(), "ws", "ns", "pod-uid", nil)
-	if !errors.Is(err, ErrNotImplemented) {
-		t.Errorf("expected ErrNotImplemented, got %v", err)
+func TestDoPost_NoOriginHeader_WhenNotInContext(t *testing.T) {
+	var hasOriginHeader bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hasOriginHeader = r.Header.Get(plugin.HeaderOriginRequestID) != ""
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(pluginapi.SignResponse{Token: "t"})
+	}))
+	defer srv.Close()
+
+	client := NewPluginClient(srv.URL, nil)
+	_, _, err := doPost[pluginapi.SignResponse](context.Background(), client, "/test", &pluginapi.SignRequest{})
+	require.NoError(t, err)
+	assert.False(t, hasOriginHeader)
+}
+
+// newTestClient creates a PluginClient with fast retry settings for tests.
+func newTestClient(baseURL string) *PluginClient {
+	c := NewPluginClient(baseURL, nil)
+	c.retryCount = 2
+	c.retryDelay = 10 * time.Millisecond // fast retries for tests
+	c.callTimeout = 2 * time.Second
+	return c
+}
+
+func TestDoPost_RetriesOnConnectionRefused(t *testing.T) {
+	// First two attempts: connection refused (server not started).
+	// Third attempt: server is up.
+	var attempts int
+	var srv *httptest.Server
+	srv = httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts++
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(pluginapi.SignResponse{Token: "ok"})
+	}))
+
+	// Point client at the server's listener address before starting it.
+	client := newTestClient("http://" + srv.Listener.Addr().String())
+	srv.Close() // Close the unstarted server to free the port.
+
+	// Start the server after a brief delay (simulates sidecar coming up).
+	go func() {
+		time.Sleep(15 * time.Millisecond)
+		srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			attempts++
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(pluginapi.SignResponse{Token: "ok"})
+		}))
+	}()
+
+	// Wait for the goroutine to start the server, then update the client URL.
+	time.Sleep(30 * time.Millisecond)
+	if srv != nil {
+		defer srv.Close()
+		client.baseURL = srv.URL
 	}
+
+	// Directly test that connection refused IS retried by using an unreachable port.
+	unreachableClient := newTestClient("http://127.0.0.1:1")
+	_, _, err := doPost[pluginapi.SignResponse](context.Background(), unreachableClient, "/test", &pluginapi.SignRequest{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "attempts")
+	assert.Contains(t, err.Error(), "failed")
+}
+
+func TestDoPost_DoesNotRetryOnHTTPError(t *testing.T) {
+	var attempts int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_ = json.NewEncoder(w).Encode(pluginapi.ErrorResponse{Error: "plugin internal error"})
+	}))
+	defer srv.Close()
+
+	client := newTestClient(srv.URL)
+	_, _, err := doPost[pluginapi.SignResponse](context.Background(), client, "/test", &pluginapi.SignRequest{})
+	require.Error(t, err)
+
+	// Should have made exactly 1 attempt — no retries on HTTP responses.
+	assert.Equal(t, 1, attempts)
+
+	var pe *plugin.StatusError
+	require.ErrorAs(t, err, &pe)
+	assert.Equal(t, http.StatusInternalServerError, pe.Code)
+}
+
+func TestDoPost_DoesNotRetryOnContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately.
+
+	client := newTestClient("http://127.0.0.1:1")
+	_, _, err := doPost[pluginapi.SignResponse](ctx, client, "/test", &pluginapi.SignRequest{})
+	require.Error(t, err)
+	// Should fail immediately without retrying.
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestDoPost_RetriesExhausted_ReturnsLastError(t *testing.T) {
+	// All attempts fail with connection refused.
+	client := newTestClient("http://127.0.0.1:1")
+	_, _, err := doPost[pluginapi.SignResponse](context.Background(), client, "/test", &pluginapi.SignRequest{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "3 attempts") // retryCount(2) + 1 = 3
+}
+
+func TestDoPost_SucceedsAfterTransientFailure(t *testing.T) {
+	var attempts int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts++
+		if attempts <= 1 {
+			// Simulate transient failure by closing the connection.
+			hj, ok := w.(http.Hijacker)
+			if ok {
+				conn, _, _ := hj.Hijack()
+				_ = conn.Close()
+				return
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(pluginapi.SignResponse{Token: "recovered"})
+	}))
+	defer srv.Close()
+
+	client := newTestClient(srv.URL)
+	resp, _, err := doPost[pluginapi.SignResponse](context.Background(), client, "/test", &pluginapi.SignRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, "recovered", resp.Token)
+	assert.Equal(t, 2, attempts)
 }

--- a/internal/pluginclient/constants.go
+++ b/internal/pluginclient/constants.go
@@ -11,7 +11,12 @@ import "time"
 // These are tuned for the sidecar (localhost) deployment model where
 // transient failures are brief (sidecar starting up or restarting).
 const (
-	defaultRetryCount  = 2                      // 2 retries = 3 total attempts
-	defaultRetryDelay  = 100 * time.Millisecond // fixed delay between retries (no backoff — it's localhost)
+	// Retry defaults are sized for a sidecar container restart on localhost.
+	// A Go binary in a distroless image boots in ~200-500ms (dominated by
+	// container sandbox creation, not process startup). 4 attempts at 500ms
+	// intervals cover a ~1.5s window — well beyond typical restart latency,
+	// while failing fast enough to avoid masking CrashLoopBackOff or config errors.
+	defaultRetryCount  = 3                      // 3 retries = 4 total attempts
+	defaultRetryDelay  = 500 * time.Millisecond // fixed delay between retries (no backoff — it's localhost)
 	defaultCallTimeout = 30 * time.Second       // per-call timeout; generous for cloud SDK operations
 )

--- a/internal/pluginclient/constants.go
+++ b/internal/pluginclient/constants.go
@@ -1,0 +1,17 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package pluginclient
+
+import "time"
+
+// Default retry and timeout configuration for the plugin client.
+// These are tuned for the sidecar (localhost) deployment model where
+// transient failures are brief (sidecar starting up or restarting).
+const (
+	defaultRetryCount  = 2                      // 2 retries = 3 total attempts
+	defaultRetryDelay  = 100 * time.Millisecond // fixed delay between retries (no backoff — it's localhost)
+	defaultCallTimeout = 30 * time.Second       // per-call timeout; generous for cloud SDK operations
+)

--- a/internal/pluginclient/errors.go
+++ b/internal/pluginclient/errors.go
@@ -1,0 +1,65 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package pluginclient
+
+import (
+	"context"
+	"errors"
+	"io"
+	"syscall"
+)
+
+// isRetryableError determines whether a failed HTTP call to the plugin sidecar
+// should be retried. The decision is based on a strict whitelist of errors that
+// prove the sidecar was unreachable — i.e., no response was received.
+//
+// Retry contract:
+//   - Transport errors (connection refused, reset, EOF): RETRY.
+//     These indicate the sidecar is not ready (starting up, crashed, restarting).
+//     Since it's localhost, transient unavailability resolves in seconds.
+//   - Context cancellation / deadline exceeded: NEVER RETRY.
+//     context.Canceled means the caller explicitly canceled — retrying would
+//     ignore their intent. context.DeadlineExceeded means either the caller's
+//     deadline or our per-call timeout expired — if the plugin is alive but slow,
+//     retrying adds load without helping.
+//   - Any HTTP response (including 500/503): NEVER RETRY.
+//     If we got a response, the plugin processed the request. The plugin owns
+//     retrying its own cloud provider calls (with exponential backoff via the
+//     AWS SDK or equivalent). Retrying from the client would layer retries
+//     and risk storms.
+//   - Unknown errors: NEVER RETRY.
+//     We only retry what we can positively identify as transient transport failures.
+//     Anything else (DNS errors, TLS errors, etc.) indicates a configuration
+//     problem that retrying won't fix.
+func isRetryableError(err error) bool {
+	// Caller canceled or their deadline expired — respect their intent.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+
+	// ECONNREFUSED: sidecar not listening. Most common transient failure —
+	// the sidecar container hasn't started its HTTP server yet, or kubelet
+	// is restarting it after a crash.
+	if errors.Is(err, syscall.ECONNREFUSED) {
+		return true
+	}
+
+	// ECONNRESET: sidecar dropped the connection before sending a response.
+	// Since all plugin operations are idempotent, safe to retry even if the
+	// request may have been partially received.
+	if errors.Is(err, syscall.ECONNRESET) {
+		return true
+	}
+
+	// EOF / UnexpectedEOF: connection closed cleanly or mid-stream before
+	// any HTTP response was read. Same reasoning as ECONNRESET — the sidecar
+	// went away before responding.
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+
+	return false
+}

--- a/internal/pluginclient/errors_test.go
+++ b/internal/pluginclient/errors_test.go
@@ -1,0 +1,90 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package pluginclient
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsRetryableError(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		retryable bool
+	}{
+		// Retryable: transport-level errors proving sidecar is unreachable
+		{
+			name:      "ECONNREFUSED — sidecar not listening",
+			err:       &net.OpError{Op: "dial", Err: &os.SyscallError{Syscall: "connect", Err: syscall.ECONNREFUSED}},
+			retryable: true,
+		},
+		{
+			name:      "ECONNRESET — sidecar dropped connection",
+			err:       &net.OpError{Op: "read", Err: &os.SyscallError{Syscall: "read", Err: syscall.ECONNRESET}},
+			retryable: true,
+		},
+		{
+			name:      "EOF — connection closed before response",
+			err:       io.EOF,
+			retryable: true,
+		},
+		{
+			name:      "UnexpectedEOF — partial read",
+			err:       io.ErrUnexpectedEOF,
+			retryable: true,
+		},
+		{
+			name:      "wrapped ECONNREFUSED",
+			err:       fmt.Errorf("Get http://localhost:8080/test: %w", &net.OpError{Op: "dial", Err: &os.SyscallError{Syscall: "connect", Err: syscall.ECONNREFUSED}}),
+			retryable: true,
+		},
+
+		// Not retryable: caller intent
+		{
+			name:      "context.Canceled — caller canceled",
+			err:       context.Canceled,
+			retryable: false,
+		},
+		{
+			name:      "context.DeadlineExceeded — timeout",
+			err:       context.DeadlineExceeded,
+			retryable: false,
+		},
+		{
+			name:      "wrapped context.Canceled",
+			err:       fmt.Errorf("something: %w", context.Canceled),
+			retryable: false,
+		},
+
+		// Not retryable: unknown errors
+		{
+			name:      "generic error",
+			err:       errors.New("something went wrong"),
+			retryable: false,
+		},
+		{
+			name:      "nil error",
+			err:       nil,
+			retryable: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isRetryableError(tt.err)
+			assert.Equal(t, tt.retryable, got)
+		})
+	}
+}

--- a/internal/pluginclient/jwt_client.go
+++ b/internal/pluginclient/jwt_client.go
@@ -7,12 +7,12 @@ package pluginclient
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	pluginapi "github.com/jupyter-infra/jupyter-k8s/api/plugin/v1alpha1"
 	workspacev1alpha1 "github.com/jupyter-infra/jupyter-k8s/api/v1alpha1"
 	"github.com/jupyter-infra/jupyter-k8s/internal/jwt"
-	"github.com/jupyter-infra/jupyter-k8s/internal/plugin"
 
 	jwt5 "github.com/golang-jwt/jwt/v5"
 )
@@ -74,7 +74,7 @@ func (s *PluginSigner) ValidateToken(tokenString string) (*jwt.Claims, error) {
 		return nil, err
 	}
 	if resp.Claims == nil {
-		return nil, &plugin.StatusError{Code: 200, Message: "verify returned nil claims"}
+		return nil, fmt.Errorf("plugin: verify returned nil claims")
 	}
 	return verifyClaims(resp.Claims), nil
 }

--- a/internal/pluginclient/jwt_client.go
+++ b/internal/pluginclient/jwt_client.go
@@ -6,8 +6,15 @@ Distributed under the terms of the MIT license
 package pluginclient
 
 import (
+	"context"
+	"time"
+
+	pluginapi "github.com/jupyter-infra/jupyter-k8s/api/plugin/v1alpha1"
 	workspacev1alpha1 "github.com/jupyter-infra/jupyter-k8s/api/v1alpha1"
 	"github.com/jupyter-infra/jupyter-k8s/internal/jwt"
+	"github.com/jupyter-infra/jupyter-k8s/internal/plugin"
+
+	jwt5 "github.com/golang-jwt/jwt/v5"
 )
 
 // PluginSignerFactory implements jwt.SignerFactory by delegating to a plugin sidecar.
@@ -15,29 +22,75 @@ type PluginSignerFactory struct {
 	client *PluginClient
 }
 
-// NewPluginSignerFactory creates a new PluginSignerFactory for the given plugin endpoint.
-func NewPluginSignerFactory(baseURL string) *PluginSignerFactory {
-	return &PluginSignerFactory{
-		client: NewPluginClient(baseURL),
-	}
+// NewPluginSignerFactory creates a new PluginSignerFactory backed by the given shared client.
+func NewPluginSignerFactory(client *PluginClient) *PluginSignerFactory {
+	return &PluginSignerFactory{client: client}
 }
 
 // CreateSigner returns a PluginSigner that delegates JWT operations to the plugin.
-func (f *PluginSignerFactory) CreateSigner(_ *workspacev1alpha1.WorkspaceAccessStrategy) (jwt.Signer, error) {
-	return nil, ErrNotImplemented
+func (f *PluginSignerFactory) CreateSigner(accessStrategy *workspacev1alpha1.WorkspaceAccessStrategy) (jwt.Signer, error) {
+	var connectionContext map[string]string
+	if accessStrategy != nil {
+		connectionContext = accessStrategy.Spec.CreateConnectionContext
+	}
+	return &PluginSigner{
+		client:            f.client,
+		connectionContext: connectionContext,
+	}, nil
 }
 
 // PluginSigner implements jwt.Signer by delegating to a plugin sidecar over HTTP.
 type PluginSigner struct {
-	client *PluginClient
+	client            *PluginClient
+	connectionContext map[string]string
 }
 
 // GenerateToken delegates token generation to the plugin via POST /v1alpha1/jwt/sign.
-func (s *PluginSigner) GenerateToken(_ string, _ []string, _ string, _ map[string][]string, _, _, _ string) (string, error) {
-	return "", ErrNotImplemented
+// Uses context.Background() because the jwt.Signer interface does not accept a context.
+func (s *PluginSigner) GenerateToken(user string, groups []string, uid string, extra map[string][]string, path, domain, tokenType string) (string, error) {
+	req := &pluginapi.SignRequest{
+		User:              user,
+		Groups:            groups,
+		UID:               uid,
+		Extra:             extra,
+		Path:              path,
+		Domain:            domain,
+		TokenType:         tokenType,
+		ConnectionContext: s.connectionContext,
+	}
+	resp, _, err := doPost[pluginapi.SignResponse](context.Background(), s.client, pluginapi.RouteJWTSign.Path, req)
+	if err != nil {
+		return "", err
+	}
+	return resp.Token, nil
 }
 
 // ValidateToken delegates token validation to the plugin via POST /v1alpha1/jwt/verify.
-func (s *PluginSigner) ValidateToken(_ string) (*jwt.Claims, error) {
-	return nil, ErrNotImplemented
+// Uses context.Background() because the jwt.Signer interface does not accept a context.
+func (s *PluginSigner) ValidateToken(tokenString string) (*jwt.Claims, error) {
+	req := &pluginapi.VerifyRequest{Token: tokenString}
+	resp, _, err := doPost[pluginapi.VerifyResponse](context.Background(), s.client, pluginapi.RouteJWTVerify.Path, req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.Claims == nil {
+		return nil, &plugin.StatusError{Code: 200, Message: "verify returned nil claims"}
+	}
+	return verifyClaims(resp.Claims), nil
+}
+
+func verifyClaims(vc *pluginapi.VerifyClaims) *jwt.Claims {
+	return &jwt.Claims{
+		RegisteredClaims: jwt5.RegisteredClaims{
+			Subject:   vc.Subject,
+			ExpiresAt: jwt5.NewNumericDate(time.Unix(vc.ExpiresAt, 0)),
+		},
+		User:      vc.Subject,
+		Groups:    vc.Groups,
+		UID:       vc.UID,
+		Extra:     vc.Extra,
+		Path:      vc.Path,
+		Domain:    vc.Domain,
+		TokenType: vc.TokenType,
+	}
 }

--- a/internal/pluginclient/jwt_client_test.go
+++ b/internal/pluginclient/jwt_client_test.go
@@ -1,0 +1,163 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package pluginclient
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	pluginapi "github.com/jupyter-infra/jupyter-k8s/api/plugin/v1alpha1"
+	workspacev1alpha1 "github.com/jupyter-infra/jupyter-k8s/api/v1alpha1"
+	"github.com/jupyter-infra/jupyter-k8s/internal/plugin"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPluginSignerFactory_CreateSigner(t *testing.T) {
+	factory := NewPluginSignerFactory(NewPluginClient("http://localhost:8080", nil))
+
+	t.Run("with access strategy", func(t *testing.T) {
+		as := &workspacev1alpha1.WorkspaceAccessStrategy{
+			Spec: workspacev1alpha1.WorkspaceAccessStrategySpec{
+				CreateConnectionContext: map[string]string{"kmsKeyId": "test-key"},
+			},
+		}
+		signer, err := factory.CreateSigner(as)
+		require.NoError(t, err)
+		assert.NotNil(t, signer)
+		ps := signer.(*PluginSigner)
+		assert.Equal(t, "test-key", ps.connectionContext["kmsKeyId"])
+	})
+
+	t.Run("nil access strategy", func(t *testing.T) {
+		signer, err := factory.CreateSigner(nil)
+		require.NoError(t, err)
+		assert.NotNil(t, signer)
+	})
+}
+
+func TestPluginSigner_GenerateToken_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, pluginapi.RouteJWTSign.Path, r.URL.Path)
+
+		var req pluginapi.SignRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		assert.Equal(t, "alice", req.User)
+		assert.Equal(t, []string{"admin"}, req.Groups)
+		assert.Equal(t, "uid-1", req.UID)
+		assert.Equal(t, "/ws/ns/ws1", req.Path)
+		assert.Equal(t, "example.com", req.Domain)
+		assert.Equal(t, "bootstrap", req.TokenType)
+		assert.Equal(t, "test-key", req.ConnectionContext["kmsKeyId"])
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(pluginapi.SignResponse{Token: "signed-token-123"})
+	}))
+	defer srv.Close()
+
+	factory := NewPluginSignerFactory(NewPluginClient(srv.URL, nil))
+	as := &workspacev1alpha1.WorkspaceAccessStrategy{
+		Spec: workspacev1alpha1.WorkspaceAccessStrategySpec{
+			CreateConnectionContext: map[string]string{"kmsKeyId": "test-key"},
+		},
+	}
+	signer, err := factory.CreateSigner(as)
+	require.NoError(t, err)
+
+	token, err := signer.GenerateToken("alice", []string{"admin"}, "uid-1", nil, "/ws/ns/ws1", "example.com", "bootstrap")
+	require.NoError(t, err)
+	assert.Equal(t, "signed-token-123", token)
+}
+
+func TestPluginSigner_GenerateToken_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_ = json.NewEncoder(w).Encode(pluginapi.ErrorResponse{Error: "KMS unavailable"})
+	}))
+	defer srv.Close()
+
+	signer := &PluginSigner{client: NewPluginClient(srv.URL, nil)}
+	_, err := signer.GenerateToken("alice", nil, "", nil, "/p", "d", "bootstrap")
+	require.Error(t, err)
+
+	var pe *plugin.StatusError
+	require.ErrorAs(t, err, &pe)
+	assert.Equal(t, http.StatusInternalServerError, pe.Code)
+	assert.Equal(t, "KMS unavailable", pe.Message)
+}
+
+func TestPluginSigner_ValidateToken_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, pluginapi.RouteJWTVerify.Path, r.URL.Path)
+
+		var req pluginapi.VerifyRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		assert.Equal(t, "test-token", req.Token)
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(pluginapi.VerifyResponse{
+			Claims: &pluginapi.VerifyClaims{
+				Subject:   "alice",
+				Groups:    []string{"admin"},
+				UID:       "uid-1",
+				Path:      "/ws/ns/ws1",
+				Domain:    "example.com",
+				TokenType: "bootstrap",
+				ExpiresAt: 1700000000,
+			},
+		})
+	}))
+	defer srv.Close()
+
+	signer := &PluginSigner{client: NewPluginClient(srv.URL, nil)}
+	claims, err := signer.ValidateToken("test-token")
+	require.NoError(t, err)
+	assert.Equal(t, "alice", claims.User)
+	assert.Equal(t, "alice", claims.Subject)
+	assert.Equal(t, []string{"admin"}, claims.Groups)
+	assert.Equal(t, "uid-1", claims.UID)
+	assert.Equal(t, "/ws/ns/ws1", claims.Path)
+	assert.Equal(t, "example.com", claims.Domain)
+	assert.Equal(t, "bootstrap", claims.TokenType)
+	assert.Equal(t, int64(1700000000), claims.ExpiresAt.Unix())
+}
+
+func TestPluginSigner_ValidateToken_Unauthorized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_ = json.NewEncoder(w).Encode(pluginapi.ErrorResponse{Error: "invalid or expired token"})
+	}))
+	defer srv.Close()
+
+	signer := &PluginSigner{client: NewPluginClient(srv.URL, nil)}
+	_, err := signer.ValidateToken("bad-token")
+	require.Error(t, err)
+
+	var pe *plugin.StatusError
+	require.ErrorAs(t, err, &pe)
+	assert.Equal(t, http.StatusUnauthorized, pe.Code)
+	assert.Equal(t, "invalid or expired token", pe.Message)
+}
+
+func TestPluginSigner_ConnectionRefused(t *testing.T) {
+	client := NewPluginClient("http://127.0.0.1:1", nil)
+	client.retryCount = 0 // no retries — fail fast for this test
+	signer := &PluginSigner{client: client}
+
+	_, err := signer.GenerateToken("alice", nil, "", nil, "/p", "d", "bootstrap")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "connection refused")
+
+	_, err = signer.ValidateToken("token")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "connection refused")
+}

--- a/internal/pluginclient/plugin_client_server_test.go
+++ b/internal/pluginclient/plugin_client_server_test.go
@@ -1,0 +1,173 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package pluginclient_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	pluginapi "github.com/jupyter-infra/jupyter-k8s/api/plugin/v1alpha1"
+	workspacev1alpha1 "github.com/jupyter-infra/jupyter-k8s/api/v1alpha1"
+	"github.com/jupyter-infra/jupyter-k8s/internal/plugin"
+	"github.com/jupyter-infra/jupyter-k8s/internal/pluginclient"
+	"github.com/jupyter-infra/jupyter-k8s/internal/pluginserver"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// stubJWTHandler implements pluginserver.JWTHandler with hardcoded responses for integration testing.
+type stubJWTHandler struct{}
+
+func (h *stubJWTHandler) Sign(_ context.Context, req *pluginapi.SignRequest) (*pluginapi.SignResponse, error) {
+	return &pluginapi.SignResponse{Token: "signed-" + req.User + "-" + req.TokenType}, nil
+}
+
+func (h *stubJWTHandler) Verify(_ context.Context, req *pluginapi.VerifyRequest) (*pluginapi.VerifyResponse, error) {
+	if req.Token == "invalid" {
+		return nil, &plugin.StatusError{Code: 401, Message: "invalid token"}
+	}
+	return &pluginapi.VerifyResponse{
+		Claims: &pluginapi.VerifyClaims{
+			Subject:   "alice",
+			Groups:    []string{"admin"},
+			UID:       "uid-1",
+			Path:      "/ws/ns/ws1",
+			Domain:    "example.com",
+			TokenType: "bootstrap",
+			ExpiresAt: 1700000000,
+		},
+	}, nil
+}
+
+// stubRemoteAccessHandler implements pluginserver.RemoteAccessHandler for integration testing.
+type stubRemoteAccessHandler struct{}
+
+func (h *stubRemoteAccessHandler) Initialize(_ context.Context, _ *pluginapi.InitializeRequest) (*pluginapi.InitializeResponse, error) {
+	return &pluginapi.InitializeResponse{}, nil
+}
+
+func (h *stubRemoteAccessHandler) RegisterNodeAgent(_ context.Context, req *pluginapi.RegisterNodeAgentRequest) (*pluginapi.RegisterNodeAgentResponse, error) {
+	return &pluginapi.RegisterNodeAgentResponse{
+		ActivationID:   "act-" + req.PodUID,
+		ActivationCode: "code-" + req.PodUID,
+	}, nil
+}
+
+func (h *stubRemoteAccessHandler) DeregisterNodeAgent(_ context.Context, _ *pluginapi.DeregisterNodeAgentRequest) (*pluginapi.DeregisterNodeAgentResponse, error) {
+	return &pluginapi.DeregisterNodeAgentResponse{}, nil
+}
+
+func (h *stubRemoteAccessHandler) CreateSession(_ context.Context, req *pluginapi.CreateSessionRequest) (*pluginapi.CreateSessionResponse, error) {
+	return &pluginapi.CreateSessionResponse{
+		ConnectionURL: "vscode://connect?ws=" + req.WorkspaceName,
+	}, nil
+}
+
+func setupIntegrationServer(t *testing.T) string {
+	t.Helper()
+	srv := pluginserver.NewServer(pluginserver.ServerConfig{
+		JWTHandler:          &stubJWTHandler{},
+		RemoteAccessHandler: &stubRemoteAccessHandler{},
+	})
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+	return ts.URL
+}
+
+func TestIntegration_JWTSignAndVerify(t *testing.T) {
+	baseURL := setupIntegrationServer(t)
+	factory := pluginclient.NewPluginSignerFactory(pluginclient.NewPluginClient(baseURL, nil))
+
+	as := &workspacev1alpha1.WorkspaceAccessStrategy{
+		Spec: workspacev1alpha1.WorkspaceAccessStrategySpec{
+			CreateConnectionContext: map[string]string{"kmsKeyId": "test-key"},
+		},
+	}
+	signer, err := factory.CreateSigner(as)
+	require.NoError(t, err)
+
+	// Sign
+	token, err := signer.GenerateToken("alice", []string{"admin"}, "uid-1", nil, "/ws/ns/ws1", "example.com", "bootstrap")
+	require.NoError(t, err)
+	assert.Equal(t, "signed-alice-bootstrap", token)
+
+	// Verify
+	claims, err := signer.ValidateToken("any-valid-token")
+	require.NoError(t, err)
+	assert.Equal(t, "alice", claims.User)
+	assert.Equal(t, "alice", claims.Subject)
+	assert.Equal(t, []string{"admin"}, claims.Groups)
+	assert.Equal(t, "/ws/ns/ws1", claims.Path)
+	assert.Equal(t, "example.com", claims.Domain)
+	assert.Equal(t, "bootstrap", claims.TokenType)
+	assert.Equal(t, int64(1700000000), claims.ExpiresAt.Unix())
+}
+
+func TestIntegration_JWTVerify_Unauthorized(t *testing.T) {
+	baseURL := setupIntegrationServer(t)
+	factory := pluginclient.NewPluginSignerFactory(pluginclient.NewPluginClient(baseURL, nil))
+	signer, err := factory.CreateSigner(nil)
+	require.NoError(t, err)
+
+	_, err = signer.ValidateToken("invalid")
+	require.Error(t, err)
+
+	var pe *plugin.StatusError
+	require.ErrorAs(t, err, &pe)
+	assert.Equal(t, 401, pe.Code)
+}
+
+func TestIntegration_RemoteAccess_Initialize(t *testing.T) {
+	baseURL := setupIntegrationServer(t)
+	client := pluginclient.NewPluginRemoteAccessClient(pluginclient.NewPluginClient(baseURL, nil))
+
+	err := client.Initialize(context.Background())
+	require.NoError(t, err)
+}
+
+func TestIntegration_RemoteAccess_RegisterNodeAgent(t *testing.T) {
+	baseURL := setupIntegrationServer(t)
+	client := pluginclient.NewPluginRemoteAccessClient(pluginclient.NewPluginClient(baseURL, nil))
+
+	resp, err := client.RegisterNodeAgent(context.Background(), &pluginapi.RegisterNodeAgentRequest{
+		PodUID:        "pod-123",
+		WorkspaceName: "ws1",
+		Namespace:     "ns1",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "act-pod-123", resp.ActivationID)
+	assert.Equal(t, "code-pod-123", resp.ActivationCode)
+}
+
+func TestIntegration_RemoteAccess_DeregisterNodeAgent(t *testing.T) {
+	baseURL := setupIntegrationServer(t)
+	client := pluginclient.NewPluginRemoteAccessClient(pluginclient.NewPluginClient(baseURL, nil))
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{UID: types.UID("pod-uid-xyz")},
+	}
+	err := client.DeregisterNodeAgent(context.Background(), pod)
+	require.NoError(t, err)
+}
+
+func TestIntegration_RemoteAccess_CreateSession(t *testing.T) {
+	baseURL := setupIntegrationServer(t)
+	client := pluginclient.NewPluginRemoteAccessClient(pluginclient.NewPluginClient(baseURL, nil))
+
+	as := &workspacev1alpha1.WorkspaceAccessStrategy{
+		Spec: workspacev1alpha1.WorkspaceAccessStrategySpec{
+			CreateConnectionContext: map[string]string{"ssmDocumentName": "doc"},
+		},
+	}
+	url, err := client.CreateSession(context.Background(), "test-ws", "test-ns", "pod-uid-123", as)
+	require.NoError(t, err)
+	assert.Equal(t, "vscode://connect?ws=test-ws", url)
+}

--- a/internal/pluginclient/remote_access_client.go
+++ b/internal/pluginclient/remote_access_client.go
@@ -8,40 +8,62 @@ package pluginclient
 import (
 	"context"
 
-	corev1 "k8s.io/api/core/v1"
-
+	pluginapi "github.com/jupyter-infra/jupyter-k8s/api/plugin/v1alpha1"
 	workspacev1alpha1 "github.com/jupyter-infra/jupyter-k8s/api/v1alpha1"
+
+	corev1 "k8s.io/api/core/v1"
 )
 
-// PluginRemoteAccessClient implements the controller's SSMRemoteAccessStrategyInterface
-// by delegating cloud SDK operations to a plugin sidecar over HTTP.
+// PluginRemoteAccessClient delegates remote access operations to a plugin sidecar over HTTP.
+// It handles only pure cloud SDK operations (register, deregister, create-session).
+// The controller owns k8s orchestration (pod exec, state files, restart detection) and
+// calls these methods where it previously called the AWS SDK directly.
 type PluginRemoteAccessClient struct {
 	client *PluginClient
 }
 
-// NewPluginRemoteAccessClient creates a new PluginRemoteAccessClient for the given plugin endpoint.
-func NewPluginRemoteAccessClient(baseURL string) *PluginRemoteAccessClient {
-	return &PluginRemoteAccessClient{
-		client: NewPluginClient(baseURL),
-	}
-}
-
-// SetupContainers delegates pod setup to the plugin via POST /v1alpha1/remote-access/register-node-agent.
-func (s *PluginRemoteAccessClient) SetupContainers(_ context.Context, _ *corev1.Pod, _ *workspacev1alpha1.Workspace, _ *workspacev1alpha1.WorkspaceAccessStrategy) error {
-	return ErrNotImplemented
-}
-
-// DeregisterNodeAgent delegates cleanup to the plugin via POST /v1alpha1/remote-access/deregister-node-agent.
-func (s *PluginRemoteAccessClient) DeregisterNodeAgent(_ context.Context, _ *corev1.Pod) error {
-	return ErrNotImplemented
+// NewPluginRemoteAccessClient creates a new PluginRemoteAccessClient backed by the given shared client.
+func NewPluginRemoteAccessClient(client *PluginClient) *PluginRemoteAccessClient {
+	return &PluginRemoteAccessClient{client: client}
 }
 
 // Initialize delegates one-time resource creation to the plugin via POST /v1alpha1/remote-access/initialize.
-func (s *PluginRemoteAccessClient) Initialize(_ context.Context) error {
-	return ErrNotImplemented
+func (s *PluginRemoteAccessClient) Initialize(ctx context.Context) error {
+	_, _, err := doPost[pluginapi.InitializeResponse](ctx, s.client, pluginapi.RouteRemoteAccessInit.Path, &pluginapi.InitializeRequest{})
+	return err
+}
+
+// RegisterNodeAgent calls the plugin to create an activation and returns the credentials.
+// The controller uses these to exec the registration script in the pod.
+func (s *PluginRemoteAccessClient) RegisterNodeAgent(ctx context.Context, req *pluginapi.RegisterNodeAgentRequest) (*pluginapi.RegisterNodeAgentResponse, error) {
+	resp, _, err := doPost[pluginapi.RegisterNodeAgentResponse](ctx, s.client, pluginapi.RouteRegisterNodeAgent.Path, req)
+	return resp, err
+}
+
+// DeregisterNodeAgent delegates cleanup to the plugin via POST /v1alpha1/remote-access/deregister-node-agent.
+func (s *PluginRemoteAccessClient) DeregisterNodeAgent(ctx context.Context, pod *corev1.Pod) error {
+	req := &pluginapi.DeregisterNodeAgentRequest{
+		PodUID: string(pod.UID),
+	}
+	_, _, err := doPost[pluginapi.DeregisterNodeAgentResponse](ctx, s.client, pluginapi.RouteDeregisterNodeAgent.Path, req)
+	return err
 }
 
 // CreateSession delegates session creation to the plugin via POST /v1alpha1/remote-access/create-session.
-func (s *PluginRemoteAccessClient) CreateSession(_ context.Context, _ string, _ string, _ string, _ *workspacev1alpha1.WorkspaceAccessStrategy) (string, error) {
-	return "", ErrNotImplemented
+func (s *PluginRemoteAccessClient) CreateSession(ctx context.Context, workspaceName string, namespace string, podUID string, accessStrategy *workspacev1alpha1.WorkspaceAccessStrategy) (string, error) {
+	var connectionContext map[string]string
+	if accessStrategy != nil {
+		connectionContext = accessStrategy.Spec.CreateConnectionContext
+	}
+	req := &pluginapi.CreateSessionRequest{
+		PodUID:            podUID,
+		WorkspaceName:     workspaceName,
+		Namespace:         namespace,
+		ConnectionContext: connectionContext,
+	}
+	resp, _, err := doPost[pluginapi.CreateSessionResponse](ctx, s.client, pluginapi.RouteCreateSession.Path, req)
+	if err != nil {
+		return "", err
+	}
+	return resp.ConnectionURL, nil
 }

--- a/internal/pluginclient/remote_access_client_test.go
+++ b/internal/pluginclient/remote_access_client_test.go
@@ -1,0 +1,194 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package pluginclient
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	pluginapi "github.com/jupyter-infra/jupyter-k8s/api/plugin/v1alpha1"
+	workspacev1alpha1 "github.com/jupyter-infra/jupyter-k8s/api/v1alpha1"
+	"github.com/jupyter-infra/jupyter-k8s/internal/plugin"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func testPod() *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ws-pod-0",
+			Namespace: "test-ns",
+			UID:       types.UID("pod-uid-123"),
+		},
+	}
+}
+
+func testAccessStrategy() *workspacev1alpha1.WorkspaceAccessStrategy {
+	return &workspacev1alpha1.WorkspaceAccessStrategy{
+		Spec: workspacev1alpha1.WorkspaceAccessStrategySpec{
+			PodEventsHandler: "aws",
+			PodEventsContext: map[string]string{
+				"ssmDocumentName": "test-doc",
+			},
+			CreateConnectionHandler: "aws",
+			CreateConnectionContext: map[string]string{
+				"ssmDocumentName": "test-doc",
+			},
+		},
+	}
+}
+
+func TestInitialize_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, pluginapi.RouteRemoteAccessInit.Path, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(pluginapi.InitializeResponse{})
+	}))
+	defer srv.Close()
+
+	client := NewPluginRemoteAccessClient(NewPluginClient(srv.URL, nil))
+	err := client.Initialize(context.Background())
+	require.NoError(t, err)
+}
+
+func TestInitialize_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_ = json.NewEncoder(w).Encode(pluginapi.ErrorResponse{Error: "init failed"})
+	}))
+	defer srv.Close()
+
+	client := NewPluginRemoteAccessClient(NewPluginClient(srv.URL, nil))
+	err := client.Initialize(context.Background())
+	require.Error(t, err)
+
+	var pe *plugin.StatusError
+	require.ErrorAs(t, err, &pe)
+	assert.Equal(t, http.StatusInternalServerError, pe.Code)
+}
+
+func TestRegisterNodeAgent_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, pluginapi.RouteRegisterNodeAgent.Path, r.URL.Path)
+
+		var req pluginapi.RegisterNodeAgentRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		assert.Equal(t, "pod-uid-123", req.PodUID)
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(pluginapi.RegisterNodeAgentResponse{
+			ActivationID:   "act-123",
+			ActivationCode: "code-456",
+		})
+	}))
+	defer srv.Close()
+
+	client := NewPluginRemoteAccessClient(NewPluginClient(srv.URL, nil))
+	resp, err := client.RegisterNodeAgent(context.Background(), &pluginapi.RegisterNodeAgentRequest{
+		PodUID:        "pod-uid-123",
+		WorkspaceName: "test-ws",
+		Namespace:     "test-ns",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "act-123", resp.ActivationID)
+	assert.Equal(t, "code-456", resp.ActivationCode)
+}
+
+func TestDeregisterNodeAgent_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, pluginapi.RouteDeregisterNodeAgent.Path, r.URL.Path)
+
+		var req pluginapi.DeregisterNodeAgentRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		assert.Equal(t, "pod-uid-123", req.PodUID)
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(pluginapi.DeregisterNodeAgentResponse{})
+	}))
+	defer srv.Close()
+
+	client := NewPluginRemoteAccessClient(NewPluginClient(srv.URL, nil))
+	err := client.DeregisterNodeAgent(context.Background(), testPod())
+	require.NoError(t, err)
+}
+
+func TestDeregisterNodeAgent_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_ = json.NewEncoder(w).Encode(pluginapi.ErrorResponse{Error: "cleanup failed"})
+	}))
+	defer srv.Close()
+
+	client := NewPluginRemoteAccessClient(NewPluginClient(srv.URL, nil))
+	err := client.DeregisterNodeAgent(context.Background(), testPod())
+	require.Error(t, err)
+
+	var pe *plugin.StatusError
+	require.ErrorAs(t, err, &pe)
+	assert.Equal(t, "cleanup failed", pe.Message)
+}
+
+func TestCreateSession_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, pluginapi.RouteCreateSession.Path, r.URL.Path)
+
+		var req pluginapi.CreateSessionRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		assert.Equal(t, "pod-uid-123", req.PodUID)
+		assert.Equal(t, "test-ws", req.WorkspaceName)
+		assert.Equal(t, "test-ns", req.Namespace)
+		assert.Equal(t, "test-doc", req.ConnectionContext["ssmDocumentName"])
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(pluginapi.CreateSessionResponse{
+			ConnectionURL: "vscode://jupyter.workspace/connect?session=abc",
+		})
+	}))
+	defer srv.Close()
+
+	client := NewPluginRemoteAccessClient(NewPluginClient(srv.URL, nil))
+	url, err := client.CreateSession(context.Background(), "test-ws", "test-ns", "pod-uid-123", testAccessStrategy())
+	require.NoError(t, err)
+	assert.Equal(t, "vscode://jupyter.workspace/connect?session=abc", url)
+}
+
+func TestCreateSession_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_ = json.NewEncoder(w).Encode(pluginapi.ErrorResponse{Error: "session failed"})
+	}))
+	defer srv.Close()
+
+	client := NewPluginRemoteAccessClient(NewPluginClient(srv.URL, nil))
+	_, err := client.CreateSession(context.Background(), "test-ws", "test-ns", "pod-uid-123", testAccessStrategy())
+	require.Error(t, err)
+}
+
+func TestRemoteAccess_ConnectionRefused(t *testing.T) {
+	client := NewPluginRemoteAccessClient(NewPluginClient("http://127.0.0.1:1", nil))
+	client.client.retryCount = 0 // no retries — fail fast for this test
+
+	err := client.Initialize(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "connection refused")
+
+	err = client.DeregisterNodeAgent(context.Background(), testPod())
+	require.Error(t, err)
+
+	_, err = client.CreateSession(context.Background(), "ws", "ns", "uid", testAccessStrategy())
+	require.Error(t, err)
+}

--- a/internal/pluginserver/config.go
+++ b/internal/pluginserver/config.go
@@ -1,0 +1,41 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package pluginserver
+
+// Default values for server configuration.
+const (
+	// DefaultListenAddress is the IPv4 loopback address. This is a literal IP,
+	// not a DNS name like "localhost", so it is resolved entirely by the kernel
+	// network stack — no DNS lookup, no /etc/hosts override, no ambiguity
+	// between IPv4 and IPv6.
+	DefaultListenAddress = "127.0.0.1"
+)
+
+// ServerConfig holds all configuration for the plugin server.
+type ServerConfig struct {
+	// Port the server listens on. Required — no default, since multiple
+	// plugin sidecars in the same pod need distinct ports.
+	Port int
+
+	// ListenAddress is the IP address the server binds to. Defaults to "127.0.0.1"
+	// (localhost only), since the plugin runs as a sidecar in the same pod.
+	ListenAddress string
+
+	// JWTHandler implements JWT signing and verification.
+	// If nil, all JWT endpoints return 501 Not Implemented.
+	JWTHandler JWTHandler
+
+	// RemoteAccessHandler implements remote access operations.
+	// If nil, all remote access endpoints return 501 Not Implemented.
+	RemoteAccessHandler RemoteAccessHandler
+}
+
+// applyDefaults fills in zero-value fields with sensible defaults.
+func (c *ServerConfig) applyDefaults() {
+	if c.ListenAddress == "" {
+		c.ListenAddress = DefaultListenAddress
+	}
+}

--- a/internal/pluginserver/config_test.go
+++ b/internal/pluginserver/config_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package pluginserver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestApplyDefaults_ListenAddress(t *testing.T) {
+	cfg := ServerConfig{Port: 9090}
+	cfg.applyDefaults()
+	assert.Equal(t, DefaultListenAddress, cfg.ListenAddress)
+}
+
+func TestApplyDefaults_PreservesExplicitListenAddress(t *testing.T) {
+	cfg := ServerConfig{Port: 9090, ListenAddress: "0.0.0.0"}
+	cfg.applyDefaults()
+	assert.Equal(t, "0.0.0.0", cfg.ListenAddress)
+}
+
+func TestApplyDefaults_DoesNotSetPort(t *testing.T) {
+	cfg := ServerConfig{}
+	cfg.applyDefaults()
+	assert.Equal(t, 0, cfg.Port, "port should remain zero — it is required, not defaulted")
+}
+
+func TestNewServer_NilHandlersDefaultToNotImplemented(t *testing.T) {
+	srv := NewServer(ServerConfig{Port: 8080})
+	assert.NotNil(t, srv.jwtHandler)
+	assert.NotNil(t, srv.remoteAccessHandler)
+	assert.IsType(t, NotImplementedJWTHandler{}, srv.jwtHandler)
+	assert.IsType(t, NotImplementedRemoteAccessHandler{}, srv.remoteAccessHandler)
+}
+
+func TestNewServer_PreservesExplicitHandlers(t *testing.T) {
+	jwt := &mockJWTHandler{}
+	ra := &mockRemoteAccessHandler{}
+	srv := NewServer(ServerConfig{Port: 8080, JWTHandler: jwt, RemoteAccessHandler: ra})
+	assert.Same(t, jwt, srv.jwtHandler)
+	assert.Same(t, ra, srv.remoteAccessHandler)
+}
+
+func TestNewServer_Addr(t *testing.T) {
+	srv := NewServer(ServerConfig{Port: 9090})
+	assert.Equal(t, "127.0.0.1:9090", srv.httpServer.Addr)
+}
+
+func TestNewServer_CustomListenAddress(t *testing.T) {
+	srv := NewServer(ServerConfig{Port: 9090, ListenAddress: "0.0.0.0"})
+	assert.Equal(t, "0.0.0.0:9090", srv.httpServer.Addr)
+}

--- a/internal/pluginserver/handler.go
+++ b/internal/pluginserver/handler.go
@@ -10,8 +10,10 @@ package pluginserver
 
 import (
 	"context"
+	"net/http"
 
 	pluginapi "github.com/jupyter-infra/jupyter-k8s/api/plugin/v1alpha1"
+	"github.com/jupyter-infra/jupyter-k8s/internal/plugin"
 )
 
 // JWTHandler defines the interface that plugin implementations must satisfy for JWT operations.
@@ -27,4 +29,44 @@ type RemoteAccessHandler interface {
 	RegisterNodeAgent(ctx context.Context, req *pluginapi.RegisterNodeAgentRequest) (*pluginapi.RegisterNodeAgentResponse, error)
 	DeregisterNodeAgent(ctx context.Context, req *pluginapi.DeregisterNodeAgentRequest) (*pluginapi.DeregisterNodeAgentResponse, error)
 	CreateSession(ctx context.Context, req *pluginapi.CreateSessionRequest) (*pluginapi.CreateSessionResponse, error)
+}
+
+var errNotImplemented = &plugin.StatusError{Code: http.StatusNotImplemented, Message: "not implemented"}
+
+// NotImplementedJWTHandler returns 501 for all JWT operations.
+// Used as the default when no JWTHandler is provided to NewServer.
+type NotImplementedJWTHandler struct{}
+
+// Sign implements JWTHandler.
+func (NotImplementedJWTHandler) Sign(context.Context, *pluginapi.SignRequest) (*pluginapi.SignResponse, error) {
+	return nil, errNotImplemented
+}
+
+// Verify implements JWTHandler.
+func (NotImplementedJWTHandler) Verify(context.Context, *pluginapi.VerifyRequest) (*pluginapi.VerifyResponse, error) {
+	return nil, errNotImplemented
+}
+
+// NotImplementedRemoteAccessHandler returns 501 for all remote access operations.
+// Used as the default when no RemoteAccessHandler is provided to NewServer.
+type NotImplementedRemoteAccessHandler struct{}
+
+// Initialize implements RemoteAccessHandler.
+func (NotImplementedRemoteAccessHandler) Initialize(context.Context, *pluginapi.InitializeRequest) (*pluginapi.InitializeResponse, error) {
+	return nil, errNotImplemented
+}
+
+// RegisterNodeAgent implements RemoteAccessHandler.
+func (NotImplementedRemoteAccessHandler) RegisterNodeAgent(context.Context, *pluginapi.RegisterNodeAgentRequest) (*pluginapi.RegisterNodeAgentResponse, error) {
+	return nil, errNotImplemented
+}
+
+// DeregisterNodeAgent implements RemoteAccessHandler.
+func (NotImplementedRemoteAccessHandler) DeregisterNodeAgent(context.Context, *pluginapi.DeregisterNodeAgentRequest) (*pluginapi.DeregisterNodeAgentResponse, error) {
+	return nil, errNotImplemented
+}
+
+// CreateSession implements RemoteAccessHandler.
+func (NotImplementedRemoteAccessHandler) CreateSession(context.Context, *pluginapi.CreateSessionRequest) (*pluginapi.CreateSessionResponse, error) {
+	return nil, errNotImplemented
 }

--- a/internal/pluginserver/server.go
+++ b/internal/pluginserver/server.go
@@ -7,8 +7,6 @@ package pluginserver
 
 import (
 	"context"
-	"crypto/rand"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -17,17 +15,15 @@ import (
 	"time"
 
 	pluginapi "github.com/jupyter-infra/jupyter-k8s/api/plugin/v1alpha1"
+	"github.com/jupyter-infra/jupyter-k8s/internal/plugin"
 )
 
-// HeaderRequestID is the HTTP header used to pass a request ID between the controller and plugin.
-const HeaderRequestID = "X-Request-ID"
+// pluginRequestIDKey is the context key for the plugin request ID.
+type pluginRequestIDKey struct{}
 
-// requestIDKey is the context key for the request ID.
-type requestIDKey struct{}
-
-// RequestIDFromContext returns the request ID from the context, or empty string if not set.
-func RequestIDFromContext(ctx context.Context) string {
-	if id, ok := ctx.Value(requestIDKey{}).(string); ok {
+// PluginRequestID returns the plugin request ID from the context, or empty string.
+func PluginRequestID(ctx context.Context) string {
+	if id, ok := ctx.Value(pluginRequestIDKey{}).(string); ok {
 		return id
 	}
 	return ""
@@ -42,17 +38,28 @@ type Server struct {
 	logger              *slog.Logger
 }
 
-// NewServer creates a new plugin Server with the given handlers and port.
-func NewServer(jwtHandler JWTHandler, remoteAccessHandler RemoteAccessHandler, port int) *Server {
+// NewServer creates a new plugin Server from the given config.
+// The server listens on localhost only, since the plugin runs as a sidecar
+// in the same pod as the controller. Nil handlers default to returning
+// 501 Not Implemented for all their endpoints.
+func NewServer(cfg ServerConfig) *Server {
+	cfg.applyDefaults()
+	if cfg.JWTHandler == nil {
+		cfg.JWTHandler = NotImplementedJWTHandler{}
+	}
+	if cfg.RemoteAccessHandler == nil {
+		cfg.RemoteAccessHandler = NotImplementedRemoteAccessHandler{}
+	}
+
 	mux := http.NewServeMux()
 	logger := slog.Default()
 	s := &Server{
-		jwtHandler:          jwtHandler,
-		remoteAccessHandler: remoteAccessHandler,
+		jwtHandler:          cfg.JWTHandler,
+		remoteAccessHandler: cfg.RemoteAccessHandler,
 		mux:                 mux,
 		logger:              logger,
 		httpServer: &http.Server{
-			Addr:    fmt.Sprintf(":%d", port),
+			Addr:    fmt.Sprintf("%s:%d", cfg.ListenAddress, cfg.Port),
 			Handler: mux,
 		},
 	}
@@ -78,12 +85,12 @@ func (s *Server) Shutdown(ctx context.Context) error {
 }
 
 func (s *Server) registerRoutes() {
-	s.mux.Handle(pluginapi.RouteJWTSign.Pattern(), s.withMiddleware(s.handleNotImplemented))
-	s.mux.Handle(pluginapi.RouteJWTVerify.Pattern(), s.withMiddleware(s.handleNotImplemented))
-	s.mux.Handle(pluginapi.RouteRemoteAccessInit.Pattern(), s.withMiddleware(s.handleNotImplemented))
-	s.mux.Handle(pluginapi.RouteRegisterNodeAgent.Pattern(), s.withMiddleware(s.handleNotImplemented))
-	s.mux.Handle(pluginapi.RouteDeregisterNodeAgent.Pattern(), s.withMiddleware(s.handleNotImplemented))
-	s.mux.Handle(pluginapi.RouteCreateSession.Pattern(), s.withMiddleware(s.handleNotImplemented))
+	s.mux.Handle(pluginapi.RouteJWTSign.Pattern(), s.withMiddleware(s.handleJWTSign))
+	s.mux.Handle(pluginapi.RouteJWTVerify.Pattern(), s.withMiddleware(s.handleJWTVerify))
+	s.mux.Handle(pluginapi.RouteRemoteAccessInit.Pattern(), s.withMiddleware(s.handleRemoteAccessInit))
+	s.mux.Handle(pluginapi.RouteRegisterNodeAgent.Pattern(), s.withMiddleware(s.handleRegisterNodeAgent))
+	s.mux.Handle(pluginapi.RouteDeregisterNodeAgent.Pattern(), s.withMiddleware(s.handleDeregisterNodeAgent))
+	s.mux.Handle(pluginapi.RouteCreateSession.Pattern(), s.withMiddleware(s.handleCreateSession))
 	s.mux.Handle(pluginapi.RouteHealthz.Pattern(), s.withMiddleware(s.handleHealthz))
 }
 
@@ -92,18 +99,25 @@ func (s *Server) withMiddleware(next http.HandlerFunc) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
 
-		// Extract or generate request ID
-		requestID := r.Header.Get(HeaderRequestID)
-		if requestID == "" {
-			requestID = generateRequestID()
+		// Extract or generate plugin request ID
+		pluginRequestID := r.Header.Get(plugin.HeaderPluginRequestID)
+		if pluginRequestID == "" {
+			pluginRequestID = plugin.GenerateRequestID()
 		}
+		originRequestID := r.Header.Get(plugin.HeaderOriginRequestID)
 
-		// Add request ID to response header and request context
-		w.Header().Set(HeaderRequestID, requestID)
-		ctx := context.WithValue(r.Context(), requestIDKey{}, requestID)
+		// Echo plugin request ID back in response
+		w.Header().Set(plugin.HeaderPluginRequestID, pluginRequestID)
+
+		// Add plugin request ID to request context
+		ctx := context.WithValue(r.Context(), pluginRequestIDKey{}, pluginRequestID)
 		r = r.WithContext(ctx)
 
-		logger := s.logger.With("requestID", requestID)
+		// Build sub-logger with both IDs
+		logger := s.logger.With("pluginRequestID", pluginRequestID)
+		if originRequestID != "" {
+			logger = logger.With("originRequestID", originRequestID)
+		}
 
 		defer func() {
 			if rec := recover(); rec != nil {
@@ -128,12 +142,6 @@ func (s *Server) withMiddleware(next http.HandlerFunc) http.Handler {
 	})
 }
 
-func generateRequestID() string {
-	b := make([]byte, 8)
-	_, _ = rand.Read(b)
-	return hex.EncodeToString(b)
-}
-
 func writeJSON(w http.ResponseWriter, status int, body any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
@@ -144,6 +152,51 @@ func (s *Server) handleHealthz(w http.ResponseWriter, _ *http.Request) {
 	writeJSON(w, http.StatusOK, struct{}{})
 }
 
-func (s *Server) handleNotImplemented(w http.ResponseWriter, _ *http.Request) {
-	writeJSON(w, http.StatusNotImplemented, pluginapi.ErrorResponse{Error: "not implemented"})
+// handleRequest is a generic handler that decodes the request, calls the handler function,
+// and encodes the response.
+func handleRequest[Req any, Resp any](w http.ResponseWriter, r *http.Request, handlerFn func(context.Context, *Req) (*Resp, error)) {
+	var req Req
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, pluginapi.ErrorResponse{Error: "invalid request body: " + err.Error()})
+		return
+	}
+
+	resp, err := handlerFn(r.Context(), &req)
+	if err != nil {
+		// Handlers return *plugin.StatusError for known errors (e.g. 400, 401) where
+		// the handler deliberately chose the HTTP status code.
+		// Any other error is treated as an unexpected failure and returns 500.
+		if se, ok := err.(*plugin.StatusError); ok {
+			writeJSON(w, se.Code, pluginapi.ErrorResponse{Error: se.Message})
+			return
+		}
+		writeJSON(w, http.StatusInternalServerError, pluginapi.ErrorResponse{Error: err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (s *Server) handleJWTSign(w http.ResponseWriter, r *http.Request) {
+	handleRequest(w, r, s.jwtHandler.Sign)
+}
+
+func (s *Server) handleJWTVerify(w http.ResponseWriter, r *http.Request) {
+	handleRequest(w, r, s.jwtHandler.Verify)
+}
+
+func (s *Server) handleRemoteAccessInit(w http.ResponseWriter, r *http.Request) {
+	handleRequest(w, r, s.remoteAccessHandler.Initialize)
+}
+
+func (s *Server) handleRegisterNodeAgent(w http.ResponseWriter, r *http.Request) {
+	handleRequest(w, r, s.remoteAccessHandler.RegisterNodeAgent)
+}
+
+func (s *Server) handleDeregisterNodeAgent(w http.ResponseWriter, r *http.Request) {
+	handleRequest(w, r, s.remoteAccessHandler.DeregisterNodeAgent)
+}
+
+func (s *Server) handleCreateSession(w http.ResponseWriter, r *http.Request) {
+	handleRequest(w, r, s.remoteAccessHandler.CreateSession)
 }

--- a/internal/pluginserver/server_test.go
+++ b/internal/pluginserver/server_test.go
@@ -6,32 +6,81 @@ Distributed under the terms of the MIT license
 package pluginserver
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	pluginapi "github.com/jupyter-infra/jupyter-k8s/api/plugin/v1alpha1"
+	"github.com/jupyter-infra/jupyter-k8s/internal/plugin"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func newTestServer() *Server {
-	// Handlers are unused since all routes return 501 in the shell.
-	return NewServer(nil, nil, 0)
+// mockJWTHandler implements JWTHandler for testing.
+type mockJWTHandler struct {
+	signFn   func(ctx context.Context, req *pluginapi.SignRequest) (*pluginapi.SignResponse, error)
+	verifyFn func(ctx context.Context, req *pluginapi.VerifyRequest) (*pluginapi.VerifyResponse, error)
 }
 
+func (m *mockJWTHandler) Sign(ctx context.Context, req *pluginapi.SignRequest) (*pluginapi.SignResponse, error) {
+	return m.signFn(ctx, req)
+}
+
+func (m *mockJWTHandler) Verify(ctx context.Context, req *pluginapi.VerifyRequest) (*pluginapi.VerifyResponse, error) {
+	return m.verifyFn(ctx, req)
+}
+
+// mockRemoteAccessHandler implements RemoteAccessHandler for testing.
+type mockRemoteAccessHandler struct {
+	initializeFn          func(ctx context.Context, req *pluginapi.InitializeRequest) (*pluginapi.InitializeResponse, error)
+	registerNodeAgentFn   func(ctx context.Context, req *pluginapi.RegisterNodeAgentRequest) (*pluginapi.RegisterNodeAgentResponse, error)
+	deregisterNodeAgentFn func(ctx context.Context, req *pluginapi.DeregisterNodeAgentRequest) (*pluginapi.DeregisterNodeAgentResponse, error)
+	createSessionFn       func(ctx context.Context, req *pluginapi.CreateSessionRequest) (*pluginapi.CreateSessionResponse, error)
+}
+
+func (m *mockRemoteAccessHandler) Initialize(ctx context.Context, req *pluginapi.InitializeRequest) (*pluginapi.InitializeResponse, error) {
+	return m.initializeFn(ctx, req)
+}
+
+func (m *mockRemoteAccessHandler) RegisterNodeAgent(ctx context.Context, req *pluginapi.RegisterNodeAgentRequest) (*pluginapi.RegisterNodeAgentResponse, error) {
+	return m.registerNodeAgentFn(ctx, req)
+}
+
+func (m *mockRemoteAccessHandler) DeregisterNodeAgent(ctx context.Context, req *pluginapi.DeregisterNodeAgentRequest) (*pluginapi.DeregisterNodeAgentResponse, error) {
+	return m.deregisterNodeAgentFn(ctx, req)
+}
+
+func (m *mockRemoteAccessHandler) CreateSession(ctx context.Context, req *pluginapi.CreateSessionRequest) (*pluginapi.CreateSessionResponse, error) {
+	return m.createSessionFn(ctx, req)
+}
+
+func newMockServer(jwt *mockJWTHandler, ra *mockRemoteAccessHandler) *Server {
+	return NewServer(ServerConfig{
+		JWTHandler:          jwt,
+		RemoteAccessHandler: ra,
+	})
+}
+
+// --- Healthz ---
+
 func TestHealthz(t *testing.T) {
-	srv := newTestServer()
+	srv := NewServer(ServerConfig{})
 	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
 	w := httptest.NewRecorder()
 	srv.Handler().ServeHTTP(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Errorf("expected 200, got %d", w.Code)
-	}
+	assert.Equal(t, http.StatusOK, w.Code)
 }
 
+// --- Middleware ---
+
 func TestPanicRecovery(t *testing.T) {
-	srv := newTestServer()
+	srv := NewServer(ServerConfig{})
 	panicHandler := srv.withMiddleware(func(_ http.ResponseWriter, _ *http.Request) {
 		panic("test panic")
 	})
@@ -40,96 +89,272 @@ func TestPanicRecovery(t *testing.T) {
 	w := httptest.NewRecorder()
 	panicHandler.ServeHTTP(w, req)
 
-	if w.Code != http.StatusInternalServerError {
-		t.Errorf("expected 500, got %d", w.Code)
-	}
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
 
 	var errResp pluginapi.ErrorResponse
-	if err := json.NewDecoder(w.Body).Decode(&errResp); err != nil {
-		t.Fatalf("failed to decode error response: %v", err)
-	}
-	if errResp.Error != "internal server error" {
-		t.Errorf("expected error %q, got %q", "internal server error", errResp.Error)
-	}
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&errResp))
+	assert.Equal(t, "internal server error", errResp.Error)
 }
 
 func TestRequestID_PassedThrough(t *testing.T) {
-	srv := newTestServer()
+	srv := NewServer(ServerConfig{})
 	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
-	req.Header.Set(HeaderRequestID, "caller-id-123")
+	req.Header.Set(plugin.HeaderPluginRequestID, "caller-id-123")
 	w := httptest.NewRecorder()
 	srv.Handler().ServeHTTP(w, req)
 
-	got := w.Header().Get(HeaderRequestID)
-	if got != "caller-id-123" {
-		t.Errorf("expected request ID %q echoed back, got %q", "caller-id-123", got)
-	}
+	assert.Equal(t, "caller-id-123", w.Header().Get(plugin.HeaderPluginRequestID))
 }
 
 func TestRequestID_GeneratedWhenMissing(t *testing.T) {
-	srv := newTestServer()
+	srv := NewServer(ServerConfig{})
 	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
 	w := httptest.NewRecorder()
 	srv.Handler().ServeHTTP(w, req)
 
-	got := w.Header().Get(HeaderRequestID)
-	if got == "" {
-		t.Error("expected a generated request ID, got empty string")
-	}
-	if len(got) != 16 { // 8 bytes = 16 hex chars
-		t.Errorf("expected 16-char hex request ID, got %q (len %d)", got, len(got))
-	}
+	got := w.Header().Get(plugin.HeaderPluginRequestID)
+	assert.NotEmpty(t, got)
+	assert.Len(t, got, 16) // 8 bytes = 16 hex chars
 }
 
 func TestRequestID_AvailableInContext(t *testing.T) {
-	srv := newTestServer()
+	srv := NewServer(ServerConfig{})
 	var capturedID string
 	handler := srv.withMiddleware(func(_ http.ResponseWriter, r *http.Request) {
-		capturedID = RequestIDFromContext(r.Context())
+		capturedID = PluginRequestID(r.Context())
 	})
 
 	req := httptest.NewRequest(http.MethodPost, "/test", nil)
-	req.Header.Set(HeaderRequestID, "ctx-test-456")
+	req.Header.Set(plugin.HeaderPluginRequestID, "ctx-test-456")
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, req)
 
-	if capturedID != "ctx-test-456" {
-		t.Errorf("expected context request ID %q, got %q", "ctx-test-456", capturedID)
-	}
+	assert.Equal(t, "ctx-test-456", capturedID)
 }
 
-func TestRoutes_ReturnNotImplemented(t *testing.T) {
-	srv := newTestServer()
+// --- JWT Sign ---
 
-	routes := []struct {
-		method string
-		path   string
-	}{
-		{http.MethodPost, "/v1alpha1/jwt/sign"},
-		{http.MethodPost, "/v1alpha1/jwt/verify"},
-		{http.MethodPost, "/v1alpha1/remote-access/initialize"},
-		{http.MethodPost, "/v1alpha1/remote-access/register-node-agent"},
-		{http.MethodPost, "/v1alpha1/remote-access/deregister-node-agent"},
-		{http.MethodPost, "/v1alpha1/remote-access/create-session"},
+func TestJWTSign_Success(t *testing.T) {
+	jwtH := &mockJWTHandler{
+		signFn: func(_ context.Context, req *pluginapi.SignRequest) (*pluginapi.SignResponse, error) {
+			assert.Equal(t, "alice", req.User)
+			assert.Equal(t, "bootstrap", req.TokenType)
+			return &pluginapi.SignResponse{Token: "signed-token"}, nil
+		},
 	}
+	srv := newMockServer(jwtH, &mockRemoteAccessHandler{})
 
-	for _, rt := range routes {
-		t.Run(rt.path, func(t *testing.T) {
-			req := httptest.NewRequest(rt.method, rt.path, nil)
-			w := httptest.NewRecorder()
-			srv.Handler().ServeHTTP(w, req)
+	body, _ := json.Marshal(pluginapi.SignRequest{User: "alice", TokenType: "bootstrap"})
+	req := httptest.NewRequest(http.MethodPost, pluginapi.RouteJWTSign.Path, bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
 
-			if w.Code != http.StatusNotImplemented {
-				t.Errorf("expected 501, got %d", w.Code)
-			}
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp pluginapi.SignResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Equal(t, "signed-token", resp.Token)
+}
 
-			var errResp pluginapi.ErrorResponse
-			if err := json.NewDecoder(w.Body).Decode(&errResp); err != nil {
-				t.Fatalf("failed to decode error response: %v", err)
-			}
-			if errResp.Error != "not implemented" {
-				t.Errorf("expected error %q, got %q", "not implemented", errResp.Error)
-			}
-		})
+func TestJWTSign_HandlerError(t *testing.T) {
+	jwtH := &mockJWTHandler{
+		signFn: func(_ context.Context, _ *pluginapi.SignRequest) (*pluginapi.SignResponse, error) {
+			return nil, fmt.Errorf("KMS unavailable")
+		},
 	}
+	srv := newMockServer(jwtH, &mockRemoteAccessHandler{})
+
+	body, _ := json.Marshal(pluginapi.SignRequest{User: "alice"})
+	req := httptest.NewRequest(http.MethodPost, pluginapi.RouteJWTSign.Path, bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	var errResp pluginapi.ErrorResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&errResp))
+	assert.Equal(t, "KMS unavailable", errResp.Error)
+}
+
+func TestJWTSign_StatusError(t *testing.T) {
+	jwtH := &mockJWTHandler{
+		signFn: func(_ context.Context, _ *pluginapi.SignRequest) (*pluginapi.SignResponse, error) {
+			return nil, &plugin.StatusError{Code: http.StatusBadRequest, Message: "missing user field"}
+		},
+	}
+	srv := newMockServer(jwtH, &mockRemoteAccessHandler{})
+
+	body, _ := json.Marshal(pluginapi.SignRequest{})
+	req := httptest.NewRequest(http.MethodPost, pluginapi.RouteJWTSign.Path, bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	var errResp pluginapi.ErrorResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&errResp))
+	assert.Equal(t, "missing user field", errResp.Error)
+}
+
+func TestJWTSign_InvalidBody(t *testing.T) {
+	srv := newMockServer(&mockJWTHandler{}, &mockRemoteAccessHandler{})
+
+	req := httptest.NewRequest(http.MethodPost, pluginapi.RouteJWTSign.Path, bytes.NewReader([]byte("not json")))
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	var errResp pluginapi.ErrorResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&errResp))
+	assert.Contains(t, errResp.Error, "invalid request body")
+}
+
+// --- JWT Verify ---
+
+func TestJWTVerify_Success(t *testing.T) {
+	jwtH := &mockJWTHandler{
+		verifyFn: func(_ context.Context, req *pluginapi.VerifyRequest) (*pluginapi.VerifyResponse, error) {
+			assert.Equal(t, "test-token", req.Token)
+			return &pluginapi.VerifyResponse{
+				Claims: &pluginapi.VerifyClaims{
+					Subject:   "alice",
+					TokenType: "bootstrap",
+					ExpiresAt: 1700000000,
+				},
+			}, nil
+		},
+	}
+	srv := newMockServer(jwtH, &mockRemoteAccessHandler{})
+
+	body, _ := json.Marshal(pluginapi.VerifyRequest{Token: "test-token"})
+	req := httptest.NewRequest(http.MethodPost, pluginapi.RouteJWTVerify.Path, bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp pluginapi.VerifyResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Equal(t, "alice", resp.Claims.Subject)
+}
+
+func TestJWTVerify_Unauthorized(t *testing.T) {
+	jwtH := &mockJWTHandler{
+		verifyFn: func(_ context.Context, _ *pluginapi.VerifyRequest) (*pluginapi.VerifyResponse, error) {
+			return nil, &plugin.StatusError{Code: http.StatusUnauthorized, Message: "invalid or expired token"}
+		},
+	}
+	srv := newMockServer(jwtH, &mockRemoteAccessHandler{})
+
+	body, _ := json.Marshal(pluginapi.VerifyRequest{Token: "bad-token"})
+	req := httptest.NewRequest(http.MethodPost, pluginapi.RouteJWTVerify.Path, bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+// --- Remote Access ---
+
+func TestRemoteAccessInit_Success(t *testing.T) {
+	raH := &mockRemoteAccessHandler{
+		initializeFn: func(_ context.Context, _ *pluginapi.InitializeRequest) (*pluginapi.InitializeResponse, error) {
+			return &pluginapi.InitializeResponse{}, nil
+		},
+	}
+	srv := newMockServer(&mockJWTHandler{}, raH)
+
+	body, _ := json.Marshal(pluginapi.InitializeRequest{})
+	req := httptest.NewRequest(http.MethodPost, pluginapi.RouteRemoteAccessInit.Path, bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestRegisterNodeAgent_Success(t *testing.T) {
+	raH := &mockRemoteAccessHandler{
+		registerNodeAgentFn: func(_ context.Context, req *pluginapi.RegisterNodeAgentRequest) (*pluginapi.RegisterNodeAgentResponse, error) {
+			assert.Equal(t, "pod-uid-123", req.PodUID)
+			assert.Equal(t, "test-ws", req.WorkspaceName)
+			return &pluginapi.RegisterNodeAgentResponse{
+				ActivationID:   "act-1",
+				ActivationCode: "code-1",
+			}, nil
+		},
+	}
+	srv := newMockServer(&mockJWTHandler{}, raH)
+
+	body, _ := json.Marshal(pluginapi.RegisterNodeAgentRequest{
+		PodUID:        "pod-uid-123",
+		WorkspaceName: "test-ws",
+		Namespace:     "test-ns",
+	})
+	req := httptest.NewRequest(http.MethodPost, pluginapi.RouteRegisterNodeAgent.Path, bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp pluginapi.RegisterNodeAgentResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Equal(t, "act-1", resp.ActivationID)
+	assert.Equal(t, "code-1", resp.ActivationCode)
+}
+
+func TestDeregisterNodeAgent_Success(t *testing.T) {
+	raH := &mockRemoteAccessHandler{
+		deregisterNodeAgentFn: func(_ context.Context, req *pluginapi.DeregisterNodeAgentRequest) (*pluginapi.DeregisterNodeAgentResponse, error) {
+			assert.Equal(t, "pod-uid-123", req.PodUID)
+			return &pluginapi.DeregisterNodeAgentResponse{}, nil
+		},
+	}
+	srv := newMockServer(&mockJWTHandler{}, raH)
+
+	body, _ := json.Marshal(pluginapi.DeregisterNodeAgentRequest{PodUID: "pod-uid-123"})
+	req := httptest.NewRequest(http.MethodPost, pluginapi.RouteDeregisterNodeAgent.Path, bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestCreateSession_Success(t *testing.T) {
+	raH := &mockRemoteAccessHandler{
+		createSessionFn: func(_ context.Context, req *pluginapi.CreateSessionRequest) (*pluginapi.CreateSessionResponse, error) {
+			assert.Equal(t, "pod-uid-123", req.PodUID)
+			return &pluginapi.CreateSessionResponse{
+				ConnectionURL: "vscode://test",
+			}, nil
+		},
+	}
+	srv := newMockServer(&mockJWTHandler{}, raH)
+
+	body, _ := json.Marshal(pluginapi.CreateSessionRequest{
+		PodUID:        "pod-uid-123",
+		WorkspaceName: "ws",
+		Namespace:     "ns",
+	})
+	req := httptest.NewRequest(http.MethodPost, pluginapi.RouteCreateSession.Path, bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp pluginapi.CreateSessionResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Equal(t, "vscode://test", resp.ConnectionURL)
+}
+
+func TestCreateSession_HandlerError(t *testing.T) {
+	raH := &mockRemoteAccessHandler{
+		createSessionFn: func(_ context.Context, _ *pluginapi.CreateSessionRequest) (*pluginapi.CreateSessionResponse, error) {
+			return nil, fmt.Errorf("session creation failed")
+		},
+	}
+	srv := newMockServer(&mockJWTHandler{}, raH)
+
+	body, _ := json.Marshal(pluginapi.CreateSessionRequest{PodUID: "pod-uid-123"})
+	req := httptest.NewRequest(http.MethodPost, pluginapi.RouteCreateSession.Path, bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	var errResp pluginapi.ErrorResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&errResp))
+	assert.Equal(t, "session creation failed", errResp.Error)
 }


### PR DESCRIPTION
This PR implements the scaffolding of the plugin client and plugin server, without concrete method implementations yet.
- the extensionapi / controller will have n-instances of plugin clients, one for each plugin declared
- each plugin will consist in a sidecar running alongside the extensionapi/controller in its pod, and it will implement the plugin server
- communication between a plugin client and server will go over HTTP in the pod local network (localhost)

This PR just implements the basic HTTP server configuration, along with standard functionality such as JSON parsing/encoding, logging, error handling and connection retries.

### Implementation
- client logic in `internal/pluginclient` package
- server logic in `internal/pluginserver` package
- define shared headers to trace back the origin request (either an `extensionapi` call, a reconciliation loop interation or a pod event), and the current request (in case a single request makes several plugin calls)
- note: the plugin client retries only connection errors to the plugin; it delegates retry of all other AWS SDK operations to the plugins. Rationale: we want to avoid retry storms.

### Testing
- not wired up yet, rely on unit tests only