### PR TITLE
fix: harden ws status E2E test

### DIFF
--- a/test/e2e/workspace_status_test.go
+++ b/test/e2e/workspace_status_test.go
@@ -41,14 +41,10 @@ var _ = Describe("Workspace Status", Ordered, func() {
 			By("creating workspace with desiredStatus=Running")
 			createWorkspaceForTest(runningWorkspace, statusGroupDir, statusSubgroupDir)
 
-			By("checking initial conditions: Progressing=True, Degraded=False, Available=False, Stopped=False")
-			VerifyWorkspaceConditions(runningWorkspace, statusTestNamespace, map[string]string{
-				ConditionTypeProgressing: ConditionTrue,
-				ConditionTypeDegraded:    ConditionFalse,
-				ConditionTypeAvailable:   ConditionFalse,
-				ConditionTypeStopped:     ConditionFalse,
-			})
-
+			// NOTE: We intentionally do NOT assert Progressing=True immediately after creation.
+			// The controller sets .status.conditions asynchronously, so on slow/loaded CI runners
+			// the conditions may still be empty when checked, causing flaky failures.
+			// See https://github.com/jupyter-infra/jupyter-k8s/issues/350
 			By("waiting for Available condition to become True")
 			WaitForWorkspaceToReachCondition(
 				runningWorkspace,


### PR DESCRIPTION
This PR attempts to address painful CI flakiness in `workspace_status` E2E test.

Closes #350 

The root cause was that the basic status test asserts that the `workspace.status` passes through `Progressing` state before reaching `Available`. That opens up avenue for race condition where the reconciliation loop hasn't yet started, in which case `workspace.status.conditions` is an empty array. Similarly, if the workspace became `Available` too quickly, the test case would incorrectly fail as well.

