### PR TITLE
feat: create conn handler map in access strategy

### DIFF
--- a/api/plugin/v1alpha1/remote_access_types.go
+++ b/api/plugin/v1alpha1/remote_access_types.go
@@ -23,6 +23,7 @@ type RegisterNodeAgentRequest struct {
 type RegisterNodeAgentResponse struct {
 	ActivationID   string `json:"activationId"`
 	ActivationCode string `json:"activationCode"`
+	Region         string `json:"region"`
 }
 
 // DeregisterNodeAgentRequest is the request body for POST /v1alpha1/remote-access/deregister-node-agent.
@@ -38,6 +39,7 @@ type CreateSessionRequest struct {
 	PodUID            string            `json:"podUID"`
 	WorkspaceName     string            `json:"workspaceName"`
 	Namespace         string            `json:"namespace"`
+	ConnectionType    string            `json:"connectionType,omitempty"`
 	ConnectionContext map[string]string `json:"connectionContext,omitempty"`
 }
 

--- a/api/plugin/v1alpha1/remote_access_types.go
+++ b/api/plugin/v1alpha1/remote_access_types.go
@@ -23,7 +23,6 @@ type RegisterNodeAgentRequest struct {
 type RegisterNodeAgentResponse struct {
 	ActivationID   string `json:"activationId"`
 	ActivationCode string `json:"activationCode"`
-	Region         string `json:"region"`
 }
 
 // DeregisterNodeAgentRequest is the request body for POST /v1alpha1/remote-access/deregister-node-agent.

--- a/api/v1alpha1/workspaceaccessstrategy_types.go
+++ b/api/v1alpha1/workspaceaccessstrategy_types.go
@@ -97,11 +97,19 @@ type WorkspaceAccessStrategySpec struct {
 	// +optional
 	BearerAuthURLTemplate string `json:"bearerAuthURLTemplate,omitempty"`
 
-	// CreateConnectionHandler specifies the handler for connection creation
+	// CreateConnectionHandler specifies the default handler for connection creation (e.g., "k8s-native").
+	// Used as fallback when CreateConnectionHandlerMap does not contain the requested connection type.
 	// +optional
 	CreateConnectionHandler string `json:"createConnectionHandler,omitempty"`
 
-	// PodEventsHandler specifies the handler for pod lifecycle events
+	// CreateConnectionHandlerMap maps connection types to handler references in "plugin:action" format.
+	// Example: {"vscode-remote": "aws:createSession"}
+	// Falls back to CreateConnectionHandler if the requested connection type is not in this map.
+	// +optional
+	CreateConnectionHandlerMap map[string]string `json:"createConnectionHandlerMap,omitempty"`
+
+	// PodEventsHandler specifies the handler for pod lifecycle events in "plugin:action" format.
+	// Example: "aws:ssm-remote-access"
 	// +optional
 	PodEventsHandler string `json:"podEventsHandler,omitempty"`
 

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -524,6 +524,13 @@ func (in *WorkspaceAccessStrategySpec) DeepCopyInto(out *WorkspaceAccessStrategy
 		*out = make([]AccessResourceTemplate, len(*in))
 		copy(*out, *in)
 	}
+	if in.CreateConnectionHandlerMap != nil {
+		in, out := &in.CreateConnectionHandlerMap, &out.CreateConnectionHandlerMap
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.CreateConnectionContext != nil {
 		in, out := &in.CreateConnectionContext, &out.CreateConnectionContext
 		*out = make(map[string]string, len(*in))

--- a/config/crd/bases/workspace.jupyter.org_workspaceaccessstrategies.yaml
+++ b/config/crd/bases/workspace.jupyter.org_workspaceaccessstrategies.yaml
@@ -94,9 +94,18 @@ spec:
                   connection handler
                 type: object
               createConnectionHandler:
-                description: CreateConnectionHandler specifies the handler for connection
-                  creation
+                description: |-
+                  CreateConnectionHandler specifies the default handler for connection creation (e.g., "k8s-native").
+                  Used as fallback when CreateConnectionHandlerMap does not contain the requested connection type.
                 type: string
+              createConnectionHandlerMap:
+                additionalProperties:
+                  type: string
+                description: |-
+                  CreateConnectionHandlerMap maps connection types to handler references in "plugin:action" format.
+                  Example: {"vscode-remote": "aws:createSession"}
+                  Falls back to CreateConnectionHandler if the requested connection type is not in this map.
+                type: object
               deploymentModifications:
                 description: DeploymentModifications defines modifications to apply
                   to workspace deployments
@@ -5182,8 +5191,9 @@ spec:
                   handler
                 type: object
               podEventsHandler:
-                description: PodEventsHandler specifies the handler for pod lifecycle
-                  events
+                description: |-
+                  PodEventsHandler specifies the handler for pod lifecycle events in "plugin:action" format.
+                  Example: "aws:ssm-remote-access"
                 type: string
             required:
             - accessResourceTemplates

--- a/dist/chart/templates/crd/workspace.jupyter.org_workspaceaccessstrategies.yaml
+++ b/dist/chart/templates/crd/workspace.jupyter.org_workspaceaccessstrategies.yaml
@@ -100,9 +100,18 @@ spec:
                   connection handler
                 type: object
               createConnectionHandler:
-                description: CreateConnectionHandler specifies the handler for connection
-                  creation
+                description: |-
+                  CreateConnectionHandler specifies the default handler for connection creation (e.g., "k8s-native").
+                  Used as fallback when CreateConnectionHandlerMap does not contain the requested connection type.
                 type: string
+              createConnectionHandlerMap:
+                additionalProperties:
+                  type: string
+                description: |-
+                  CreateConnectionHandlerMap maps connection types to handler references in "plugin:action" format.
+                  Example: {"vscode-remote": "aws:createSession"}
+                  Falls back to CreateConnectionHandler if the requested connection type is not in this map.
+                type: object
               deploymentModifications:
                 description: DeploymentModifications defines modifications to apply
                   to workspace deployments
@@ -5188,8 +5197,9 @@ spec:
                   handler
                 type: object
               podEventsHandler:
-                description: PodEventsHandler specifies the handler for pod lifecycle
-                  events
+                description: |-
+                  PodEventsHandler specifies the handler for pod lifecycle events in "plugin:action" format.
+                  Example: "aws:ssm-remote-access"
                 type: string
             required:
             - accessResourceTemplates


### PR DESCRIPTION
First of 4 PRs to migrate all AWS calls to a sidecar running alongside the controller (a "plugin").

This first PR is very limited in scope, and modifies the shape of the CRD / plugin APIs:
1. introduces a new attribute to `WorkspaceAccessStrategy.spec`: `CreateConnectionHandlerMap`
2. add new attribute `ConnectionType` to the plugin API  `CreateSessionRequest`

### Future PRs
- **PR 2: Plugin infrastructure** — New packages (`internal/plugin/`, `internal/pluginadapters/`, `internal/awsadapter/`), `pluginclient`/`pluginserver` refactors (slog→logr, interface consolidation), `cmd/aws-plugin/main.go` + Dockerfile. All additive — nothing in the controller or extensionapi imports the new code yet.
- **PR 3 [BREAKING]: Controller + extension API wiring** — Connect plugin infra: `cmd/main.go` (plugin-endpoints flag), `internal/controller/` (pod_event_handler adapter dispatch), `internal/extensionapi/` (multi-plugin connection), `internal/authmiddleware/` cleanup, delete `internal/aws/`.
- **PR 4: Helm, charts, e2e** — Plugin sidecar Helm configuration, Makefile targets, guided-chart updates, sample workspaces, and e2e test fixtures.

In order to merge PR 2, 3, 4, we may want to create a feature branch.

### Testing
- w/ combined code changes of PR 1-4, I tested E2E against a hyperpod cluster: jupyterlab (web access), code editor (web access + remote access). All worked as expected.