### PR TITLE
feat: plugin adapters

### DIFF
--- a/api/plugin/v1alpha1/remote_access_types.go
+++ b/api/plugin/v1alpha1/remote_access_types.go
@@ -23,6 +23,7 @@ type RegisterNodeAgentRequest struct {
 type RegisterNodeAgentResponse struct {
 	ActivationID   string `json:"activationId"`
 	ActivationCode string `json:"activationCode"`
+	Region         string `json:"region"`
 }
 
 // DeregisterNodeAgentRequest is the request body for POST /v1alpha1/remote-access/deregister-node-agent.

--- a/api/plugin/v1alpha1/remote_access_types.go
+++ b/api/plugin/v1alpha1/remote_access_types.go
@@ -23,7 +23,6 @@ type RegisterNodeAgentRequest struct {
 type RegisterNodeAgentResponse struct {
 	ActivationID   string `json:"activationId"`
 	ActivationCode string `json:"activationCode"`
-	Region         string `json:"region"`
 }
 
 // DeregisterNodeAgentRequest is the request body for POST /v1alpha1/remote-access/deregister-node-agent.

--- a/internal/awsadapter/context_entries.go
+++ b/internal/awsadapter/context_entries.go
@@ -1,0 +1,35 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+// Package awsadapter provides the SSM-based pod event adapter implementation.
+// It reads all configuration from the podEventsContext map defined in the AccessStrategy.
+package awsadapter
+
+import "github.com/jupyter-infra/jupyter-k8s/internal/plugin"
+
+// Pod event context keys resolved from the AccessStrategy's podEventsContext map.
+// These keys have no defaults — values must be provided in the AccessStrategy.
+var (
+	// ContextKeyPodUID is the context key for the pod UID (resolved from controller::PodUid()).
+	ContextKeyPodUID = plugin.ContextEntry{Key: "podUid"}
+	// ContextKeySsmManagedNodeRole is the context key for the IAM role used for SSM activation.
+	ContextKeySsmManagedNodeRole = plugin.ContextEntry{Key: "ssmManagedNodeRole"}
+	// ContextKeySidecarContainerName is the context key for the SSM agent sidecar container name.
+	ContextKeySidecarContainerName = plugin.ContextEntry{Key: "sidecarContainerName"}
+	// ContextKeyWorkspaceContainerName is the context key for the main workspace container name.
+	ContextKeyWorkspaceContainerName = plugin.ContextEntry{Key: "workspaceContainerName"}
+	// ContextKeyRegistrationStateFile is the context key for the state file path in the shared volume.
+	ContextKeyRegistrationStateFile = plugin.ContextEntry{Key: "registrationStateFile"}
+	// ContextKeyRegistrationMarkerFile is the context key for the legacy marker file path.
+	ContextKeyRegistrationMarkerFile = plugin.ContextEntry{Key: "registrationMarkerFile"}
+	// ContextKeyRegistrationScript is the context key for the SSM registration script path.
+	ContextKeyRegistrationScript = plugin.ContextEntry{Key: "registrationScript"}
+	// ContextKeyRemoteAccessServerScript is the context key for the remote access server startup script.
+	ContextKeyRemoteAccessServerScript = plugin.ContextEntry{Key: "remoteAccessServerScript"}
+	// ContextKeyRemoteAccessServerPort is the context key for the remote access server port.
+	ContextKeyRemoteAccessServerPort = plugin.ContextEntry{Key: "remoteAccessServerPort"}
+	// ContextKeyRegion is the context key for the AWS region used in SSM registration.
+	ContextKeyRegion = plugin.ContextEntry{Key: "region"}
+)

--- a/internal/awsadapter/ssm_pod_event_adapter.go
+++ b/internal/awsadapter/ssm_pod_event_adapter.go
@@ -1,0 +1,339 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package awsadapter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"time"
+
+	pluginapi "github.com/jupyter-infra/jupyter-k8s/api/plugin/v1alpha1"
+	"github.com/jupyter-infra/jupyter-k8s/internal/plugin"
+	"github.com/jupyter-infra/jupyter-k8s/internal/pluginadapters"
+	corev1 "k8s.io/api/core/v1"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// RegistrationState tracks SSM registration state across container restarts
+type RegistrationState struct {
+	SidecarRestartCount   int32     `json:"sidecarRestartCount"`
+	WorkspaceRestartCount int32     `json:"workspaceRestartCount"`
+	SetupInProgress       bool      `json:"setupInProgress,omitempty"`
+	SetupStartedAt        time.Time `json:"setupStartedAt,omitempty"`
+}
+
+// AwsSsmPodEventAdapter handles SSM-based pod lifecycle events.
+// It owns Kubernetes-side orchestration (pod exec, state file I/O, restart detection)
+// and delegates pure cloud SDK operations to a plugin sidecar via plugin.RemoteAccessPluginApis.
+// All configuration (container names, script paths, etc.) comes from the podEventsContext map.
+type AwsSsmPodEventAdapter struct {
+	pluginClient plugin.RemoteAccessPluginApis
+	podExecUtil  pluginadapters.PodExecInterface
+}
+
+// NewAwsSsmPodEventAdapter creates a new AwsSsmPodEventAdapter,
+// which implements pluginadapters.PodEventPluginAdapter for SSM-based remote access.
+// pluginClient handles cloud SDK operations (register, deregister).
+// podExecUtil handles pod exec operations (state files, registration scripts).
+func NewAwsSsmPodEventAdapter(pluginClient plugin.RemoteAccessPluginApis, podExecUtil pluginadapters.PodExecInterface) (*AwsSsmPodEventAdapter, error) {
+	if podExecUtil == nil {
+		return nil, fmt.Errorf("podExecUtil is required")
+	}
+
+	return &AwsSsmPodEventAdapter{
+		pluginClient: pluginClient,
+		podExecUtil:  podExecUtil,
+	}, nil
+}
+
+// HandlePodRunning initializes SSM agent and remote access server for workspace containers.
+// Handles both first-time setup and recovery from container restarts.
+//
+// Container Restart Detection:
+// - Uses persistent state file (path from podEventsContext["registrationStateFile"])
+// - Compares stored restart counts with current pod status to detect restarts
+// - Selectively re-setups only affected containers (sidecar and/or workspace)
+//
+// Concurrency Protection:
+// - Random delay (0-2s) spreads out concurrent pod events
+// - SetupInProgress flag prevents duplicate setup attempts
+func (s *AwsSsmPodEventAdapter) HandlePodRunning(ctx context.Context, pod *corev1.Pod, workspaceName, namespace string, podEventsContext map[string]string) error {
+	logger := logf.FromContext(ctx).WithValues("pod", pod.Name, "namespace", namespace, "workspace", workspaceName)
+
+	if s.pluginClient == nil {
+		return fmt.Errorf("plugin client not available")
+	}
+
+	// Propagate a request ID so plugin logs can be correlated with this pod event
+	ctx = plugin.ContextWithOriginRequestID(ctx, plugin.GenerateRequestID())
+
+	sidecarContainer := ContextKeySidecarContainerName.ResolveStr(podEventsContext)
+
+	// Early exit if sidecar not running yet
+	if !pluginadapters.IsContainerRunning(pod, sidecarContainer) {
+		logger.V(1).Info("Sidecar container not running yet, waiting")
+		return nil
+	}
+
+	// Random delay to spread out concurrent events
+	delay := time.Duration(rand.Intn(2000)) * time.Millisecond
+	logger.V(1).Info("Adding random delay before setup", "delay", delay)
+	time.Sleep(delay)
+
+	// Get current restart counts
+	workspaceContainer := ContextKeyWorkspaceContainerName.ResolveStr(podEventsContext)
+	currentSidecarRestarts := pluginadapters.GetContainerRestartCount(pod, sidecarContainer)
+	currentWorkspaceRestarts := pluginadapters.GetContainerRestartCount(pod, workspaceContainer)
+	logger.V(1).Info("Current restart counts",
+		"sidecar", currentSidecarRestarts,
+		"workspace", currentWorkspaceRestarts)
+
+	stateFile := ContextKeyRegistrationStateFile.ResolveStr(podEventsContext)
+
+	// Read state from shared volume
+	state, err := s.readRegistrationState(ctx, pod, sidecarContainer, stateFile)
+
+	// Check if setup is already in progress
+	if state != nil && state.SetupInProgress {
+		logger.V(1).Info("Setup already in progress by another event, skipping")
+		return nil
+	}
+
+	// Determine what needs to be setup
+	var needSidecarSetup, needWorkspaceSetup, needCleanup bool
+
+	if state == nil {
+		if err != nil {
+			// File exists but is corrupted - need cleanup
+			logger.Info("State file was corrupted, will cleanup before setup")
+			needCleanup = true
+		} else {
+			// File doesn't exist - first time setup, no cleanup needed
+			logger.V(1).Info("No state file found, first time setup")
+			needCleanup = false
+		}
+		needSidecarSetup = true
+		needWorkspaceSetup = true
+	} else {
+		// Check for restarts
+		sidecarRestarted := currentSidecarRestarts > state.SidecarRestartCount
+		workspaceRestarted := currentWorkspaceRestarts > state.WorkspaceRestartCount
+
+		if !sidecarRestarted && !workspaceRestarted {
+			logger.V(1).Info("No restarts detected, already setup")
+			return nil
+		}
+
+		logger.Info("Container restart detected",
+			"sidecarRestarted", sidecarRestarted,
+			"workspaceRestarted", workspaceRestarted)
+
+		needSidecarSetup = sidecarRestarted
+		needWorkspaceSetup = workspaceRestarted
+		needCleanup = sidecarRestarted // Only cleanup if sidecar restarted
+	}
+
+	// Mark setup as in progress
+	inProgressState := &RegistrationState{
+		SidecarRestartCount:   currentSidecarRestarts,
+		WorkspaceRestartCount: currentWorkspaceRestarts,
+		SetupInProgress:       true,
+		SetupStartedAt:        time.Now(),
+	}
+	if err := s.writeRegistrationState(ctx, pod, sidecarContainer, stateFile, inProgressState); err != nil {
+		logger.Error(err, "Failed to write in-progress state, continuing anyway")
+	} else {
+		logger.V(1).Info("Marked setup as in progress")
+	}
+
+	// Setup containers as needed
+	var setupErr error
+	if needSidecarSetup {
+		logger.V(1).Info("Setting up sidecar container")
+		if err := s.setupSidecarContainer(ctx, pod, workspaceName, namespace, podEventsContext, needCleanup); err != nil {
+			setupErr = err
+		}
+	}
+
+	if setupErr == nil && needWorkspaceSetup {
+		logger.V(1).Info("Setting up workspace container")
+		if err := s.setupWorkspaceContainer(ctx, pod, podEventsContext); err != nil {
+			setupErr = err
+		}
+	}
+
+	// Mark setup as complete (or failed)
+	finalState := &RegistrationState{
+		SidecarRestartCount:   currentSidecarRestarts,
+		WorkspaceRestartCount: currentWorkspaceRestarts,
+		SetupInProgress:       false, // Clear the flag
+	}
+	if err := s.writeRegistrationState(ctx, pod, sidecarContainer, stateFile, finalState); err != nil {
+		logger.Error(err, "Failed to write final state")
+	} else {
+		logger.V(1).Info("Marked setup as complete")
+	}
+
+	if setupErr != nil {
+		return setupErr
+	}
+
+	logger.Info("Container setup completed")
+	return nil
+}
+
+// HandlePodDeleted delegates cleanup to the plugin sidecar
+func (s *AwsSsmPodEventAdapter) HandlePodDeleted(ctx context.Context, pod *corev1.Pod, _ map[string]string) error {
+	if s.pluginClient == nil {
+		return fmt.Errorf("plugin client not available")
+	}
+
+	ctx = plugin.ContextWithOriginRequestID(ctx, plugin.GenerateRequestID())
+	_, err := s.pluginClient.DeregisterNodeAgent(ctx, &pluginapi.DeregisterNodeAgentRequest{
+		PodUID: string(pod.UID),
+	})
+	return err
+}
+
+// readRegistrationState reads state from shared volume
+// Returns:
+//   - (*RegistrationState, nil) if state file exists and is valid
+//   - (nil, nil) if state file doesn't exist (first time setup)
+//   - (nil, error) if state file exists but is corrupted
+func (s *AwsSsmPodEventAdapter) readRegistrationState(ctx context.Context, pod *corev1.Pod, sidecarContainer, stateFile string) (*RegistrationState, error) {
+	logger := logf.FromContext(ctx).WithValues("pod", pod.Name, "namespace", pod.Namespace)
+
+	cmd := []string{"cat", stateFile}
+	output, err := s.podExecUtil.ExecInPod(ctx, pod, sidecarContainer, cmd, "")
+	if err != nil {
+		// File doesn't exist - this is first time setup
+		logger.V(1).Info("State file not found, treating as first registration")
+		return nil, nil
+	}
+
+	var state RegistrationState
+	if err := json.Unmarshal([]byte(output), &state); err != nil {
+		// File exists but is corrupted - need cleanup
+		logger.Error(err, "Failed to parse state file, corrupted state detected")
+		return nil, err
+	}
+
+	logger.V(1).Info("Read registration state",
+		"sidecarRestartCount", state.SidecarRestartCount,
+		"workspaceRestartCount", state.WorkspaceRestartCount)
+	return &state, nil
+}
+
+// writeRegistrationState writes state to shared volume
+func (s *AwsSsmPodEventAdapter) writeRegistrationState(ctx context.Context, pod *corev1.Pod, sidecarContainer, stateFile string, state *RegistrationState) error {
+	logger := logf.FromContext(ctx).WithValues("pod", pod.Name, "namespace", pod.Namespace)
+
+	stateJSON, err := json.Marshal(state)
+	if err != nil {
+		return fmt.Errorf("failed to marshal state: %w", err)
+	}
+
+	// Write to temp file then move (atomic operation)
+	cmd := []string{"bash", "-c", fmt.Sprintf("echo '%s' > %s.tmp && mv %s.tmp %s",
+		string(stateJSON), stateFile, stateFile, stateFile)}
+
+	if _, err := s.podExecUtil.ExecInPod(ctx, pod, sidecarContainer, cmd, ""); err != nil {
+		return fmt.Errorf("failed to write state file: %w", err)
+	}
+
+	logger.V(1).Info("Wrote registration state",
+		"sidecarRestartCount", state.SidecarRestartCount,
+		"workspaceRestartCount", state.WorkspaceRestartCount)
+	return nil
+}
+
+// setupSidecarContainer handles SSM agent registration via the plugin sidecar
+func (s *AwsSsmPodEventAdapter) setupSidecarContainer(ctx context.Context, pod *corev1.Pod, workspaceName, namespace string, podEventsContext map[string]string, cleanupNeeded bool) error {
+	logger := logf.FromContext(ctx).WithValues("pod", pod.Name, "namespace", namespace, "workspace", workspaceName)
+	noStdin := ""
+	sidecarContainer := ContextKeySidecarContainerName.ResolveStr(podEventsContext)
+
+	// Cleanup old resources if needed
+	if cleanupNeeded {
+		logger.V(1).Info("Cleaning up old SSM resources before registration")
+		if _, err := s.pluginClient.DeregisterNodeAgent(ctx, &pluginapi.DeregisterNodeAgentRequest{
+			PodUID: string(pod.UID),
+		}); err != nil {
+			logger.Error(err, "Failed to cleanup old SSM resources, continuing with registration anyway")
+		}
+	}
+
+	// Register node agent via plugin
+	logger.V(1).Info("Registering node agent via plugin")
+	resp, err := s.registerNodeAgent(ctx, pod, workspaceName, namespace, podEventsContext)
+	if err != nil {
+		return fmt.Errorf("failed to register node agent: %w", err)
+	}
+	logger.Info("Node agent registered", "activationId", resp.ActivationID)
+
+	// Run registration script
+	registrationScript := ContextKeyRegistrationScript.ResolveStr(podEventsContext)
+	logger.V(1).Info("Running SSM registration script in sidecar")
+	// Use stdin to pass only sensitive values securely
+	region := ContextKeyRegion.ResolveStr(podEventsContext)
+	cmd := []string{"bash", "-c", fmt.Sprintf("read ACTIVATION_ID && read ACTIVATION_CODE && env ACTIVATION_ID=\"$ACTIVATION_ID\" ACTIVATION_CODE=\"$ACTIVATION_CODE\" REGION=%s %s", region, registrationScript)}
+	stdinData := fmt.Sprintf("%s\n%s\n", resp.ActivationID, resp.ActivationCode)
+
+	if _, err := s.podExecUtil.ExecInPod(ctx, pod, sidecarContainer, cmd, stdinData); err != nil {
+		return fmt.Errorf("failed to execute SSM registration script: %w", err)
+	}
+	logger.Info("SSM registration completed successfully")
+
+	// TODO: Remove this once all deployments migrate to state-file-based readiness checks
+	markerFile := ContextKeyRegistrationMarkerFile.ResolveStr(podEventsContext)
+	logger.V(1).Info("Creating marker file for backward compatibility")
+	markerCmd := []string{"touch", markerFile}
+	if _, err := s.podExecUtil.ExecInPod(ctx, pod, sidecarContainer, markerCmd, noStdin); err != nil {
+		return fmt.Errorf("failed to create marker file: %w", err)
+	}
+
+	logger.Info("Sidecar container setup completed")
+	return nil
+}
+
+// setupWorkspaceContainer starts the remote access server
+func (s *AwsSsmPodEventAdapter) setupWorkspaceContainer(ctx context.Context, pod *corev1.Pod, podEventsContext map[string]string) error {
+	logger := logf.FromContext(ctx).WithValues("pod", pod.Name, "namespace", pod.Namespace)
+
+	workspaceContainer := ContextKeyWorkspaceContainerName.ResolveStr(podEventsContext)
+
+	// Check workspace is running
+	if !pluginadapters.IsContainerRunning(pod, workspaceContainer) {
+		logger.V(1).Info("Workspace container not running yet, waiting")
+		return nil
+	}
+
+	remoteAccessScript := ContextKeyRemoteAccessServerScript.ResolveStr(podEventsContext)
+	remoteAccessPort := ContextKeyRemoteAccessServerPort.ResolveStr(podEventsContext)
+
+	logger.Info("Starting remote access server in main container")
+	serverCmd := []string{remoteAccessScript, "--port", remoteAccessPort}
+	if _, err := s.podExecUtil.ExecInPod(ctx, pod, workspaceContainer, serverCmd, ""); err != nil {
+		return fmt.Errorf("failed to start remote access server: %w", err)
+	}
+
+	logger.Info("Workspace container setup completed")
+	return nil
+}
+
+// registerNodeAgent delegates activation creation to the plugin sidecar
+func (s *AwsSsmPodEventAdapter) registerNodeAgent(ctx context.Context, pod *corev1.Pod, workspaceName, namespace string, podEventsContext map[string]string) (*pluginapi.RegisterNodeAgentResponse, error) {
+	req := &pluginapi.RegisterNodeAgentRequest{
+		PodUID:           string(pod.UID),
+		WorkspaceName:    workspaceName,
+		Namespace:        namespace,
+		PodEventsContext: podEventsContext,
+	}
+
+	return s.pluginClient.RegisterNodeAgent(ctx, req)
+}

--- a/internal/awsadapter/ssm_pod_event_adapter_test.go
+++ b/internal/awsadapter/ssm_pod_event_adapter_test.go
@@ -1,0 +1,525 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package awsadapter
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	pluginapi "github.com/jupyter-infra/jupyter-k8s/api/plugin/v1alpha1"
+)
+
+const (
+	bashCommand = "bash"
+
+	// Test values for context keys
+	testSidecarContainer         = "ssm-agent-sidecar"
+	testWorkspaceContainer       = "workspace"
+	testRegistrationStateFile    = "/opt/amazon/sagemaker/workspace/.ssm-registration-state.json"
+	testRegistrationMarkerFile   = "/tmp/ssm-registered"
+	testRegistrationScript       = "/usr/local/bin/register-ssm.sh"
+	testRemoteAccessServerScript = "/opt/amazon/sagemaker/workspace/remote-access/start-remote-access-server.sh"
+	testRemoteAccessServerPort   = "2222"
+)
+
+func testPodEventsContext() map[string]string {
+	return map[string]string{
+		ContextKeyPodUID.Key:                   "test-pod-uid-123",
+		ContextKeySsmManagedNodeRole.Key:       "arn:aws:iam::123456789012:role/SSMManagedInstanceCore",
+		ContextKeySidecarContainerName.Key:     testSidecarContainer,
+		ContextKeyWorkspaceContainerName.Key:   testWorkspaceContainer,
+		ContextKeyRegistrationStateFile.Key:    testRegistrationStateFile,
+		ContextKeyRegistrationMarkerFile.Key:   testRegistrationMarkerFile,
+		ContextKeyRegistrationScript.Key:       testRegistrationScript,
+		ContextKeyRemoteAccessServerScript.Key: testRemoteAccessServerScript,
+		ContextKeyRemoteAccessServerPort.Key:   testRemoteAccessServerPort,
+		ContextKeyRegion.Key:                   "us-west-2",
+	}
+}
+
+// Test helper functions for common mocking patterns
+
+// mockReadStateFile mocks reading the state file from the sidecar container
+func mockReadStateFile(mockPodExec *MockPodExecUtil, state *RegistrationState) {
+	if state == nil {
+		// File doesn't exist
+		mockPodExec.On("ExecInPod",
+			mock.Anything,
+			mock.Anything,
+			testSidecarContainer,
+			[]string{"cat", testRegistrationStateFile},
+			"",
+		).Return("", errors.New("file not found")).Once()
+	} else {
+		// File exists with state
+		stateJSON, _ := json.Marshal(state)
+		mockPodExec.On("ExecInPod",
+			mock.Anything,
+			mock.Anything,
+			testSidecarContainer,
+			[]string{"cat", testRegistrationStateFile},
+			"",
+		).Return(string(stateJSON), nil).Once()
+	}
+}
+
+// mockWriteStateFile mocks writing the state file to the sidecar container
+func mockWriteStateFile(mockPodExec *MockPodExecUtil, expectedState *RegistrationState) {
+	mockPodExec.On("ExecInPod",
+		mock.Anything,
+		mock.Anything,
+		testSidecarContainer,
+		mock.MatchedBy(func(cmd []string) bool {
+			if len(cmd) != 3 || cmd[0] != bashCommand || cmd[1] != "-c" {
+				return false
+			}
+			if !strings.Contains(cmd[2], "echo") || !strings.Contains(cmd[2], testRegistrationStateFile) {
+				return false
+			}
+			// Extract and verify JSON
+			if strings.Contains(cmd[2], "echo '") {
+				start := strings.Index(cmd[2], "echo '") + 6
+				end := strings.Index(cmd[2][start:], "'")
+				if end > 0 {
+					jsonStr := cmd[2][start : start+end]
+					var state RegistrationState
+					if err := json.Unmarshal([]byte(jsonStr), &state); err != nil {
+						return false
+					}
+					return state.SidecarRestartCount == expectedState.SidecarRestartCount &&
+						state.WorkspaceRestartCount == expectedState.WorkspaceRestartCount &&
+						state.SetupInProgress == expectedState.SetupInProgress
+				}
+			}
+			return false
+		}),
+		"",
+	).Return("", nil).Once()
+}
+
+// mockCleanup mocks plugin deregister-node-agent
+func mockCleanup(mockPluginClient *MockPluginRemoteAccessClient) {
+	mockPluginClient.On("DeregisterNodeAgent", mock.Anything, mock.Anything).Return(&pluginapi.DeregisterNodeAgentResponse{}, nil).Once()
+}
+
+// mockSSMRegistration mocks SSM agent registration in sidecar
+func mockSSMRegistration(mockPodExec *MockPodExecUtil) {
+	mockPodExec.On("ExecInPod",
+		mock.Anything,
+		mock.Anything,
+		testSidecarContainer,
+		mock.MatchedBy(func(cmd []string) bool {
+			return len(cmd) == 3 && cmd[0] == "bash" && cmd[1] == "-c" &&
+				strings.Contains(cmd[2], "register-ssm.sh")
+		}),
+		mock.MatchedBy(func(stdin string) bool {
+			return strings.Contains(stdin, "test-activation-id")
+		}),
+	).Return("", nil).Once()
+}
+
+// mockMarkerFile mocks marker file creation for backward compatibility
+func mockMarkerFile(mockPodExec *MockPodExecUtil) {
+	mockPodExec.On("ExecInPod",
+		mock.Anything,
+		mock.Anything,
+		testSidecarContainer,
+		[]string{"touch", testRegistrationMarkerFile},
+		"",
+	).Return("", nil).Once()
+}
+
+// mockWorkspaceSetup mocks starting the remote access server in workspace container
+func mockWorkspaceSetup(mockPodExec *MockPodExecUtil) {
+	mockPodExec.On("ExecInPod",
+		mock.Anything,
+		mock.Anything,
+		testWorkspaceContainer,
+		[]string{testRemoteAccessServerScript, "--port", testRemoteAccessServerPort},
+		"",
+	).Return("", nil).Once()
+}
+
+// mockRegisterNodeAgent mocks plugin register-node-agent
+func mockRegisterNodeAgent(mockPluginClient *MockPluginRemoteAccessClient) {
+	mockPluginClient.On("RegisterNodeAgent",
+		mock.Anything, mock.Anything,
+	).Return(&pluginapi.RegisterNodeAgentResponse{
+		ActivationID:   "test-activation-id",
+		ActivationCode: "test-activation-code",
+	}, nil).Once()
+}
+
+// Mock implementations for testing
+
+// MockPluginRemoteAccessClient implements plugin.RemoteAccessPluginApis for testing
+type MockPluginRemoteAccessClient struct {
+	mock.Mock
+}
+
+func (m *MockPluginRemoteAccessClient) Initialize(ctx context.Context, req *pluginapi.InitializeRequest) (*pluginapi.InitializeResponse, error) {
+	args := m.Called(ctx, req)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*pluginapi.InitializeResponse), args.Error(1)
+}
+
+func (m *MockPluginRemoteAccessClient) RegisterNodeAgent(ctx context.Context, req *pluginapi.RegisterNodeAgentRequest) (*pluginapi.RegisterNodeAgentResponse, error) {
+	args := m.Called(ctx, req)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*pluginapi.RegisterNodeAgentResponse), args.Error(1)
+}
+
+func (m *MockPluginRemoteAccessClient) DeregisterNodeAgent(ctx context.Context, req *pluginapi.DeregisterNodeAgentRequest) (*pluginapi.DeregisterNodeAgentResponse, error) {
+	args := m.Called(ctx, req)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*pluginapi.DeregisterNodeAgentResponse), args.Error(1)
+}
+
+func (m *MockPluginRemoteAccessClient) CreateSession(ctx context.Context, req *pluginapi.CreateSessionRequest) (*pluginapi.CreateSessionResponse, error) {
+	args := m.Called(ctx, req)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*pluginapi.CreateSessionResponse), args.Error(1)
+}
+
+// MockPodExecUtil implements PodExecInterface for testing
+type MockPodExecUtil struct {
+	mock.Mock
+}
+
+func (m *MockPodExecUtil) ExecInPod(ctx context.Context, pod *corev1.Pod, containerName string, cmd []string, stdin string) (string, error) {
+	args := m.Called(ctx, pod, containerName, cmd, stdin)
+	return args.String(0), args.Error(1)
+}
+
+func TestNewAwsSsmPodEventAdapter(t *testing.T) {
+	mockPluginClient := &MockPluginRemoteAccessClient{}
+	mockPodExecUtil := &MockPodExecUtil{}
+
+	handler, err := NewAwsSsmPodEventAdapter(mockPluginClient, mockPodExecUtil)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, handler)
+	assert.Equal(t, mockPluginClient, handler.pluginClient)
+	assert.Equal(t, mockPodExecUtil, handler.podExecUtil)
+}
+
+func TestNewAwsSsmPodEventAdapter_NilPodExec(t *testing.T) {
+	mockPluginClient := &MockPluginRemoteAccessClient{}
+
+	_, err := NewAwsSsmPodEventAdapter(mockPluginClient, nil)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "podExecUtil is required")
+}
+
+// Test helper functions for creating test objects
+
+func createTestPod(containerStatuses []corev1.ContainerStatus) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "test-namespace",
+			UID:       "test-pod-uid-123",
+		},
+		Status: corev1.PodStatus{
+			ContainerStatuses: containerStatuses,
+		},
+	}
+}
+
+// HandlePodRunning Tests
+
+func TestHandlePodRunning_FirstTimeSetup_NoStateFile(t *testing.T) {
+	mockPodExecUtil := &MockPodExecUtil{}
+	mockPluginClient := &MockPluginRemoteAccessClient{}
+
+	// Mock 1: Read state file - doesn't exist
+	mockReadStateFile(mockPodExecUtil, nil)
+
+	// Mock 2: Write state - mark in progress
+	inProgressState := &RegistrationState{
+		SidecarRestartCount:   0,
+		WorkspaceRestartCount: 0,
+		SetupInProgress:       true,
+	}
+	mockWriteStateFile(mockPodExecUtil, inProgressState)
+
+	// Mock 3: Plugin register-node-agent and registration
+	mockRegisterNodeAgent(mockPluginClient)
+	mockSSMRegistration(mockPodExecUtil)
+	mockMarkerFile(mockPodExecUtil)
+
+	// Mock 4: Workspace setup
+	mockWorkspaceSetup(mockPodExecUtil)
+
+	// Mock 5: Write state - mark complete
+	completeState := &RegistrationState{
+		SidecarRestartCount:   0,
+		WorkspaceRestartCount: 0,
+		SetupInProgress:       false,
+	}
+	mockWriteStateFile(mockPodExecUtil, completeState)
+
+	handler, err := NewAwsSsmPodEventAdapter(mockPluginClient, mockPodExecUtil)
+	assert.NoError(t, err)
+
+	// Create pod with running containers (restart count = 0)
+	containerStatuses := []corev1.ContainerStatus{
+		{
+			Name:         testSidecarContainer,
+			State:        corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+			Ready:        true,
+			RestartCount: 0,
+		},
+		{
+			Name:         testWorkspaceContainer,
+			State:        corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+			Ready:        true,
+			RestartCount: 0,
+		},
+	}
+	pod := createTestPod(containerStatuses)
+	err = handler.HandlePodRunning(context.Background(), pod, "test-workspace", "test-namespace", testPodEventsContext())
+
+	assert.NoError(t, err)
+	mockPodExecUtil.AssertExpectations(t)
+	mockPluginClient.AssertExpectations(t)
+}
+
+func TestHandlePodRunning_SidecarContainerRestart(t *testing.T) {
+	mockPodExecUtil := &MockPodExecUtil{}
+	mockPluginClient := &MockPluginRemoteAccessClient{}
+
+	// Mock 1: Read existing state (sidecar restart count = 1)
+	existingState := &RegistrationState{
+		SidecarRestartCount:   1,
+		WorkspaceRestartCount: 0,
+		SetupInProgress:       false,
+	}
+	mockReadStateFile(mockPodExecUtil, existingState)
+
+	// Mock 2: Cleanup (because sidecar restarted)
+	mockCleanup(mockPluginClient)
+
+	// Mock 3: Write state - mark in progress
+	inProgressState := &RegistrationState{
+		SidecarRestartCount:   2,
+		WorkspaceRestartCount: 0,
+		SetupInProgress:       true,
+	}
+	mockWriteStateFile(mockPodExecUtil, inProgressState)
+
+	// Mock 4: Setup sidecar only (no workspace setup)
+	mockRegisterNodeAgent(mockPluginClient)
+	mockSSMRegistration(mockPodExecUtil)
+	mockMarkerFile(mockPodExecUtil)
+
+	// Mock 5: Write state - mark complete
+	completeState := &RegistrationState{
+		SidecarRestartCount:   2,
+		WorkspaceRestartCount: 0,
+		SetupInProgress:       false,
+	}
+	mockWriteStateFile(mockPodExecUtil, completeState)
+
+	handler, err := NewAwsSsmPodEventAdapter(mockPluginClient, mockPodExecUtil)
+	assert.NoError(t, err)
+
+	// Create pod with sidecar restarted (count = 2)
+	containerStatuses := []corev1.ContainerStatus{
+		{
+			Name:         testSidecarContainer,
+			State:        corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+			Ready:        true,
+			RestartCount: 2, // Sidecar restarted
+		},
+		{
+			Name:         testWorkspaceContainer,
+			State:        corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+			Ready:        true,
+			RestartCount: 0, // Workspace not restarted
+		},
+	}
+	pod := createTestPod(containerStatuses)
+	err = handler.HandlePodRunning(context.Background(), pod, "test-workspace", "test-namespace", testPodEventsContext())
+
+	assert.NoError(t, err)
+	mockPodExecUtil.AssertExpectations(t)
+	mockPluginClient.AssertExpectations(t)
+}
+
+func TestHandlePodRunning_NoRestartDetected_AlreadySetup(t *testing.T) {
+	mockPodExecUtil := &MockPodExecUtil{}
+	mockPluginClient := &MockPluginRemoteAccessClient{}
+
+	// Mock 1: Read existing state - restart counts match current pod status
+	existingState := &RegistrationState{
+		SidecarRestartCount:   0,
+		WorkspaceRestartCount: 0,
+		SetupInProgress:       false,
+	}
+	mockReadStateFile(mockPodExecUtil, existingState)
+
+	handler, err := NewAwsSsmPodEventAdapter(mockPluginClient, mockPodExecUtil)
+	assert.NoError(t, err)
+
+	containerStatuses := []corev1.ContainerStatus{
+		{
+			Name:         testSidecarContainer,
+			State:        corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+			Ready:        true,
+			RestartCount: 0,
+		},
+		{
+			Name:         testWorkspaceContainer,
+			State:        corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+			Ready:        true,
+			RestartCount: 0,
+		},
+	}
+	pod := createTestPod(containerStatuses)
+	err = handler.HandlePodRunning(context.Background(), pod, "test-workspace", "test-namespace", testPodEventsContext())
+
+	assert.NoError(t, err)
+	mockPodExecUtil.AssertExpectations(t)
+	mockPluginClient.AssertExpectations(t)
+}
+
+func TestHandlePodRunning_SidecarNotRunning(t *testing.T) {
+	mockPodExecUtil := &MockPodExecUtil{}
+	mockPluginClient := &MockPluginRemoteAccessClient{}
+
+	handler, err := NewAwsSsmPodEventAdapter(mockPluginClient, mockPodExecUtil)
+	assert.NoError(t, err)
+
+	containerStatuses := []corev1.ContainerStatus{
+		{
+			Name: testSidecarContainer,
+			State: corev1.ContainerState{
+				Running: nil,
+			},
+			Ready:        false,
+			RestartCount: 0,
+		},
+		{
+			Name:         testWorkspaceContainer,
+			State:        corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+			Ready:        true,
+			RestartCount: 0,
+		},
+	}
+	pod := createTestPod(containerStatuses)
+	err = handler.HandlePodRunning(context.Background(), pod, "test-workspace", "test-namespace", testPodEventsContext())
+
+	assert.NoError(t, err)
+	mockPodExecUtil.AssertExpectations(t)
+	mockPluginClient.AssertExpectations(t)
+}
+
+func TestHandlePodRunning_SetupInProgress(t *testing.T) {
+	mockPodExecUtil := &MockPodExecUtil{}
+	mockPluginClient := &MockPluginRemoteAccessClient{}
+
+	existingState := &RegistrationState{
+		SidecarRestartCount:   0,
+		WorkspaceRestartCount: 0,
+		SetupInProgress:       true,
+	}
+	mockReadStateFile(mockPodExecUtil, existingState)
+
+	handler, err := NewAwsSsmPodEventAdapter(mockPluginClient, mockPodExecUtil)
+	assert.NoError(t, err)
+
+	containerStatuses := []corev1.ContainerStatus{
+		{
+			Name:         testSidecarContainer,
+			State:        corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+			Ready:        true,
+			RestartCount: 0,
+		},
+		{
+			Name:         testWorkspaceContainer,
+			State:        corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+			Ready:        true,
+			RestartCount: 0,
+		},
+	}
+	pod := createTestPod(containerStatuses)
+	err = handler.HandlePodRunning(context.Background(), pod, "test-workspace", "test-namespace", testPodEventsContext())
+
+	assert.NoError(t, err)
+	mockPodExecUtil.AssertExpectations(t)
+	mockPluginClient.AssertExpectations(t)
+}
+
+// HandlePodDeleted Tests
+
+func TestHandlePodDeleted_PluginClientNotAvailable(t *testing.T) {
+	mockPodExecUtil := &MockPodExecUtil{}
+	handler := &AwsSsmPodEventAdapter{
+		pluginClient: nil,
+		podExecUtil:  mockPodExecUtil,
+	}
+
+	pod := createTestPod([]corev1.ContainerStatus{})
+
+	err := handler.HandlePodDeleted(context.Background(), pod, testPodEventsContext())
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "plugin client not available")
+}
+
+func TestHandlePodDeleted_Success(t *testing.T) {
+	mockPluginClient := &MockPluginRemoteAccessClient{}
+	mockPodExecUtil := &MockPodExecUtil{}
+
+	mockPluginClient.On("DeregisterNodeAgent", mock.Anything, mock.Anything).Return(&pluginapi.DeregisterNodeAgentResponse{}, nil)
+
+	handler, err := NewAwsSsmPodEventAdapter(mockPluginClient, mockPodExecUtil)
+	assert.NoError(t, err)
+
+	pod := createTestPod([]corev1.ContainerStatus{})
+
+	err = handler.HandlePodDeleted(context.Background(), pod, testPodEventsContext())
+
+	assert.NoError(t, err)
+	mockPluginClient.AssertExpectations(t)
+}
+
+func TestHandlePodDeleted_CleanupFailure(t *testing.T) {
+	mockPluginClient := &MockPluginRemoteAccessClient{}
+	mockPodExecUtil := &MockPodExecUtil{}
+
+	expectedError := errors.New("plugin: deregister failed")
+	mockPluginClient.On("DeregisterNodeAgent", mock.Anything, mock.Anything).Return(nil, expectedError)
+
+	handler, err := NewAwsSsmPodEventAdapter(mockPluginClient, mockPodExecUtil)
+	assert.NoError(t, err)
+
+	pod := createTestPod([]corev1.ContainerStatus{})
+
+	err = handler.HandlePodDeleted(context.Background(), pod, testPodEventsContext())
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "deregister failed")
+	mockPluginClient.AssertExpectations(t)
+}

--- a/internal/controller/idle_detectors.go
+++ b/internal/controller/idle_detectors.go
@@ -12,20 +12,15 @@ import (
 	"strings"
 	"time"
 
+	workspacev1alpha1 "github.com/jupyter-infra/jupyter-k8s/api/v1alpha1"
+	"github.com/jupyter-infra/jupyter-k8s/internal/pluginadapters"
 	corev1 "k8s.io/api/core/v1"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-
-	workspacev1alpha1 "github.com/jupyter-infra/jupyter-k8s/api/v1alpha1"
 )
 
 // EndpointIdleResponse represents the response from /api/idle endpoint
 type EndpointIdleResponse struct {
 	LastActivity string `json:"lastActiveTimestamp"`
-}
-
-// PodExecInterface defines the interface for pod execution
-type PodExecInterface interface {
-	ExecInPod(ctx context.Context, pod *corev1.Pod, containerName string, cmd []string, stdin string) (string, error)
 }
 
 // IdleDetector interface for different detection methods
@@ -47,11 +42,11 @@ var CreateIdleDetector = createIdleDetectorImpl
 
 // HTTPGetDetector implements HTTP endpoint checking
 type HTTPGetDetector struct {
-	execUtil PodExecInterface
+	execUtil pluginadapters.PodExecInterface
 }
 
-// NewHTTPGetDetectorWithExec creates a new HTTPGetDetector with the provided PodExecInterface
-func NewHTTPGetDetectorWithExec(execUtil PodExecInterface) *HTTPGetDetector {
+// NewHTTPGetDetectorWithExec creates a new HTTPGetDetector with the provided pluginadapters.PodExecInterface
+func NewHTTPGetDetectorWithExec(execUtil pluginadapters.PodExecInterface) *HTTPGetDetector {
 	return &HTTPGetDetector{
 		execUtil: execUtil,
 	}

--- a/internal/jwt/handler.go
+++ b/internal/jwt/handler.go
@@ -4,8 +4,6 @@ Distributed under the terms of the MIT license
 */
 
 // Package jwt provides JWT token management with pluggable signing strategies.
-// It supports both standard HMAC signing and AWS KMS-based signing through
-// a common Handler interface.
 package jwt
 
 import (

--- a/internal/jwt/standard_signer_factory.go
+++ b/internal/jwt/standard_signer_factory.go
@@ -12,8 +12,8 @@ import (
 )
 
 // StandardSignerFactory creates JWT signers using a shared StandardSigner backed by K8s Secrets.
-// Unlike AWSSignerFactory which creates per-strategy signers, this factory reuses a single
-// StandardSigner instance since all k8s-native strategies share the same Secret-based keys.
+// This factory reuses a single StandardSigner instance since all strategies share the same
+// Secret-based keys.
 type StandardSignerFactory struct {
 	signer *StandardSigner
 }
@@ -31,8 +31,7 @@ func (f *StandardSignerFactory) Signer() *StandardSigner {
 }
 
 // CreateSigner returns the shared StandardSigner for compatible access strategies.
-// Accepts "" (auto/default) and "k8s-native" handlers. Rejects "aws" since that
-// requires AWSSignerFactory.
+// Accepts "" (auto/default) and "k8s-native" handlers.
 func (f *StandardSignerFactory) CreateSigner(accessStrategy *workspacev1alpha1.WorkspaceAccessStrategy) (Signer, error) {
 	if accessStrategy == nil {
 		return f.signer, nil
@@ -42,8 +41,6 @@ func (f *StandardSignerFactory) CreateSigner(accessStrategy *workspacev1alpha1.W
 	switch handler {
 	case "", "k8s-native":
 		return f.signer, nil
-	case "aws":
-		return nil, fmt.Errorf("access strategy requires \"aws\" handler, but only \"k8s-native\" signing is configured")
 	default:
 		return nil, fmt.Errorf("unsupported connection handler: %s", handler)
 	}

--- a/internal/pluginadapters/constants.go
+++ b/internal/pluginadapters/constants.go
@@ -1,0 +1,13 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package pluginadapters
+
+const (
+	// controllerFuncPrefix is the prefix for dynamic context values resolved by the controller.
+	controllerFuncPrefix = "controller::"
+	// funcPodUID is the function name for resolving the pod UID.
+	funcPodUID = "PodUid()"
+)

--- a/internal/pluginadapters/pod_event_handler.go
+++ b/internal/pluginadapters/pod_event_handler.go
@@ -1,0 +1,61 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+// Package pluginadapters defines interfaces for handling plugin lifecycle events
+// in a plugin-agnostic way. Implementations live in separate packages
+// (e.g., internal/awsadapter/).
+package pluginadapters
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// PodEventPluginAdapter defines the interface for handling pod lifecycle events.
+// Implementations receive a resolved context map (with all dynamic values
+// like controller::PodUid() already substituted).
+type PodEventPluginAdapter interface {
+	HandlePodRunning(ctx context.Context, pod *corev1.Pod, workspaceName, namespace string, podEventsContext map[string]string) error
+	HandlePodDeleted(ctx context.Context, pod *corev1.Pod, podEventsContext map[string]string) error
+}
+
+// ResolvePodContext resolves dynamic values in the pod events context map.
+// Values prefixed with "controller::" are replaced with computed values.
+// Currently supported: "controller::PodUid()" → pod.UID
+func ResolvePodContext(contextMap map[string]string, pod *corev1.Pod) (map[string]string, error) {
+	if len(contextMap) == 0 {
+		return contextMap, nil
+	}
+
+	resolved := make(map[string]string, len(contextMap))
+	for k, v := range contextMap {
+		if strings.HasPrefix(v, controllerFuncPrefix) {
+			funcName := strings.TrimPrefix(v, controllerFuncPrefix)
+			val, err := resolvePodControllerFunc(funcName, pod)
+			if err != nil {
+				return nil, fmt.Errorf("failed to resolve %q for key %q: %w", v, k, err)
+			}
+			resolved[k] = val
+		} else {
+			resolved[k] = v
+		}
+	}
+	return resolved, nil
+}
+
+func resolvePodControllerFunc(funcName string, pod *corev1.Pod) (string, error) {
+	switch funcName {
+	case funcPodUID:
+		if pod == nil {
+			return "", fmt.Errorf("pod is nil, cannot resolve PodUid()")
+		}
+		return string(pod.UID), nil
+	default:
+		return "", fmt.Errorf("unknown controller function: %q", funcName)
+	}
+}

--- a/internal/pluginadapters/pod_event_handler_test.go
+++ b/internal/pluginadapters/pod_event_handler_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package pluginadapters
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func newPodWithUID(uid string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-pod",
+			UID:  types.UID(uid),
+		},
+	}
+}
+
+func TestResolvePodContext_StaticValues(t *testing.T) {
+	ctx := map[string]string{
+		"region":    "us-east-1",
+		"container": "main",
+	}
+	resolved, err := ResolvePodContext(ctx, newPodWithUID("abc-123"))
+	assert.NoError(t, err)
+	assert.Equal(t, "us-east-1", resolved["region"])
+	assert.Equal(t, "main", resolved["container"])
+}
+
+func TestResolvePodContext_ResolvesPodUid(t *testing.T) {
+	ctx := map[string]string{
+		"podUid": "controller::PodUid()",
+		"region": "us-west-2",
+	}
+	resolved, err := ResolvePodContext(ctx, newPodWithUID("pod-uid-456"))
+	assert.NoError(t, err)
+	assert.Equal(t, "pod-uid-456", resolved["podUid"])
+	assert.Equal(t, "us-west-2", resolved["region"])
+}
+
+func TestResolvePodContext_EmptyMap(t *testing.T) {
+	resolved, err := ResolvePodContext(map[string]string{}, newPodWithUID("abc"))
+	assert.NoError(t, err)
+	assert.Empty(t, resolved)
+}
+
+func TestResolvePodContext_NilMap(t *testing.T) {
+	resolved, err := ResolvePodContext(nil, newPodWithUID("abc"))
+	assert.NoError(t, err)
+	assert.Nil(t, resolved)
+}
+
+func TestResolvePodContext_NilPod_ErrorsOnDynamicValue(t *testing.T) {
+	ctx := map[string]string{
+		"podUid": "controller::PodUid()",
+	}
+	_, err := ResolvePodContext(ctx, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "pod is nil")
+}
+
+func TestResolvePodContext_UnknownFunction(t *testing.T) {
+	ctx := map[string]string{
+		"val": "controller::Unknown()",
+	}
+	_, err := ResolvePodContext(ctx, newPodWithUID("abc"))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown controller function")
+}
+
+func TestResolvePodContext_DoesNotMutateInput(t *testing.T) {
+	ctx := map[string]string{
+		"podUid": "controller::PodUid()",
+	}
+	_, err := ResolvePodContext(ctx, newPodWithUID("xyz"))
+	assert.NoError(t, err)
+	assert.Equal(t, "controller::PodUid()", ctx["podUid"])
+}

--- a/internal/pluginadapters/pods.go
+++ b/internal/pluginadapters/pods.go
@@ -1,0 +1,37 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package pluginadapters
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// PodExecInterface defines the interface for executing commands in pods.
+type PodExecInterface interface {
+	ExecInPod(ctx context.Context, pod *corev1.Pod, containerName string, cmd []string, stdin string) (string, error)
+}
+
+// IsContainerRunning checks if a container is in running state.
+func IsContainerRunning(pod *corev1.Pod, containerName string) bool {
+	for _, cs := range pod.Status.ContainerStatuses {
+		if cs.Name == containerName {
+			return cs.State.Running != nil
+		}
+	}
+	return false
+}
+
+// GetContainerRestartCount returns the restart count for a named container.
+func GetContainerRestartCount(pod *corev1.Pod, containerName string) int32 {
+	for _, cs := range pod.Status.ContainerStatuses {
+		if cs.Name == containerName {
+			return cs.RestartCount
+		}
+	}
+	return 0
+}

--- a/internal/pluginadapters/pods_test.go
+++ b/internal/pluginadapters/pods_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package pluginadapters
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func newTestPod(statuses []corev1.ContainerStatus) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pod"},
+		Status:     corev1.PodStatus{ContainerStatuses: statuses},
+	}
+}
+
+func TestIsContainerRunning_Running(t *testing.T) {
+	pod := newTestPod([]corev1.ContainerStatus{
+		{Name: "main", State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
+	})
+	assert.True(t, IsContainerRunning(pod, "main"))
+}
+
+func TestIsContainerRunning_NotRunning(t *testing.T) {
+	pod := newTestPod([]corev1.ContainerStatus{
+		{Name: "main", State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{}}},
+	})
+	assert.False(t, IsContainerRunning(pod, "main"))
+}
+
+func TestIsContainerRunning_NotFound(t *testing.T) {
+	pod := newTestPod([]corev1.ContainerStatus{})
+	assert.False(t, IsContainerRunning(pod, "missing"))
+}
+
+func TestGetContainerRestartCount_Found(t *testing.T) {
+	pod := newTestPod([]corev1.ContainerStatus{
+		{Name: "sidecar", RestartCount: 3},
+	})
+	assert.Equal(t, int32(3), GetContainerRestartCount(pod, "sidecar"))
+}
+
+func TestGetContainerRestartCount_Zero(t *testing.T) {
+	pod := newTestPod([]corev1.ContainerStatus{
+		{Name: "main", RestartCount: 0},
+	})
+	assert.Equal(t, int32(0), GetContainerRestartCount(pod, "main"))
+}
+
+func TestGetContainerRestartCount_NotFound(t *testing.T) {
+	pod := newTestPod([]corev1.ContainerStatus{})
+	assert.Equal(t, int32(0), GetContainerRestartCount(pod, "missing"))
+}
+
+func TestIsContainerRunning_MultipleContainers(t *testing.T) {
+	pod := newTestPod([]corev1.ContainerStatus{
+		{Name: "sidecar", State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{}}},
+		{Name: "main", State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
+	})
+	assert.False(t, IsContainerRunning(pod, "sidecar"))
+	assert.True(t, IsContainerRunning(pod, "main"))
+}


### PR DESCRIPTION
PR 2b of the plugin migration story, which focuses on "adapters". An adapter is a package that handles specific business logic, including k8s operations, and delegate to a plugin to make cloud-provider calls, such as AWS API calls.

The idea is to temporarily keep in the controller the podEvent orchestration logic for SSM activation / registration etc.
We should revisit and simplify this story, and move most of this logic to the sidecar, however it would require new `extensionapi` APIs to retrieve the activation code. In between, we could use a build flag to ignore such packages; the key point is that `adapters` _must not_ add additional dependencies to the controller, ie would not bloat to `go mod` with dependencies like `github.com/aws/aws-sdk-go-v2` (+ all the transitive deps).

### Implementation
1. `internal/pluginadapters` package
    1.1. shared interface `PodEventPluginAdapter` with `HandlePodRunning` and `HandlePodDeleted` methods
    1.2. shared utilities to parse and resolve context from `AccessStrategy.spec.<>Context` ([example](https://github.com/jupyter-infra/jupyter-k8s/blob/cfc59d613ec2672562c75d1649c6d0e72df97b35/api/v1alpha1/workspaceaccessstrategy_types.go#L122))
    1.3. pod exec interface `PodExecInterface`, with shared pod/container utilities
2. `internal/awsadapter` package for an aws-specific adapter
    2.1. `NewAwsSsmPodEventAdapter` concrete implementation of `PodEventPluginAdapter` interface
    2.2. aws-specific context entries w/ defaults
3. minor changes to `internal/controller` to use the refactored `PodEventPluginAdapter` interface
4. remove `aws` handling in `internal/jwt`: codepath no longer used since #347

### Future PRs
- **PR 3: Controller + extension API wiring [BREAKING]** — Connect plugin infra: `cmd/main.go` (plugin-endpoints flag), `internal/controller/` (pod_event_handler adapter dispatch), `internal/extensionapi/` (multi-plugin connection), `internal/authmiddleware/` cleanup, delete `internal/aws/`.
- **PR 4: Helm, charts, e2e [RESTORING]** — Plugin sidecar Helm configuration, Makefile targets, guided-chart updates, sample workspaces, and e2e test fixtures.

### Testing
See #354 