### PR TITLE
feat: hpchart plugin migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -669,6 +669,8 @@ deploy-aws-internal: helm-generate load-images-aws ## Deploy helm chart to remot
 		$(if $(filter aws,$(PLUGINS)),--set controller.plugins[0].image.tag=latest) \
 		$(if $(filter aws,$(PLUGINS)),--set controller.plugins[0].port=8080) \
 		$(if $(filter aws,$(PLUGINS)),--set controller.plugins[0].imagePullPolicy=Always) \
+		$(if $(filter aws,$(PLUGINS)),--set 'controller.plugins[0].healthcheckCommand[0]=/aws-plugin') \
+		$(if $(filter aws,$(PLUGINS)),--set 'controller.plugins[0].healthcheckCommand[1]=--healthcheck') \
 		$(if $(filter aws,$(PLUGINS)),--set controller.plugins[0].env.PLUGIN_PORT=8080) \
 		$(if $(filter aws,$(PLUGINS)),--set controller.plugins[0].env.AWS_REGION=$(AWS_REGION)) \
 		$(if $(filter aws,$(PLUGINS)),--set controller.plugins[0].env.CLUSTER_ID=$(EKS_CONTEXT))

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,7 @@ ifeq ($(CLOUD_PROVIDER),aws)
 	ECR_REPOSITORY := jupyter-k8s
 	ECR_REPOSITORY_AUTH := jupyter-k8s-auth
 	ECR_REPOSITORY_ROTATOR := jupyter-k8s-rotator
+	ECR_REPOSITORY_AWS_PLUGIN := jupyter-k8s-aws-plugin
 	EKS_CONTEXT := arn:aws:eks:$(AWS_REGION):$(AWS_ACCOUNT_ID):cluster/$(EKS_CLUSTER_NAME)
 endif
 
@@ -487,6 +488,11 @@ build-authmiddleware: ## Build authmiddleware image for local testing
 	@echo "Building authmiddleware image..."
 	$(CONTAINER_TOOL) build $(BUILD_OPTS) -t docker.io/library/authmiddleware:local -f images/authmiddleware/Dockerfile .
 
+.PHONY: build-aws-plugin
+build-aws-plugin: ## Build aws-plugin sidecar image for local testing
+	@echo "Building aws-plugin image..."
+	$(CONTAINER_TOOL) build $(BUILD_OPTS) -t docker.io/library/aws-plugin:local -f images/aws-plugin/Dockerfile .
+
 .PHONY: build-rotator
 build-rotator: ## Build rotator image for local testing
 	@echo "Building rotator image..."
@@ -604,6 +610,8 @@ load-images-aws-internal: manifests generate fmt vet ## Build and push container
 		aws ecr create-repository --repository-name $(ECR_REPOSITORY_AUTH) --region $(AWS_REGION)
 	@aws ecr describe-repositories --repository-names $(ECR_REPOSITORY_ROTATOR) --region $(AWS_REGION) > /dev/null 2>&1 || \
 		aws ecr create-repository --repository-name $(ECR_REPOSITORY_ROTATOR) --region $(AWS_REGION)
+	@aws ecr describe-repositories --repository-names $(ECR_REPOSITORY_AWS_PLUGIN) --region $(AWS_REGION) > /dev/null 2>&1 || \
+		aws ecr create-repository --repository-name $(ECR_REPOSITORY_AWS_PLUGIN) --region $(AWS_REGION)
 
 	@echo "Building controller image..."
 	$(CONTAINER_TOOL) build $(BUILD_OPTS) --platform=linux/amd64 -t $(ECR_REGISTRY)/$(ECR_REPOSITORY):latest .
@@ -620,6 +628,11 @@ load-images-aws-internal: manifests generate fmt vet ## Build and push container
 	$(CONTAINER_TOOL) push $(ECR_REGISTRY)/$(ECR_REPOSITORY_ROTATOR):latest
 	@echo "Rotator image built and pushed successfully to $(ECR_REGISTRY)/$(ECR_REPOSITORY_ROTATOR):latest"
 
+	@echo "Building aws-plugin image..."
+	$(CONTAINER_TOOL) build $(BUILD_OPTS) --platform=linux/amd64 -t $(ECR_REGISTRY)/$(ECR_REPOSITORY_AWS_PLUGIN):latest -f images/aws-plugin/Dockerfile .
+	$(CONTAINER_TOOL) push $(ECR_REGISTRY)/$(ECR_REPOSITORY_AWS_PLUGIN):latest
+	@echo "AWS plugin image built and pushed successfully to $(ECR_REGISTRY)/$(ECR_REPOSITORY_AWS_PLUGIN):latest"
+
 	@echo "Building application images..."
 	$(MAKE) -C images push-all-aws CLOUD_PROVIDER=aws CONTAINER_TOOL=$(CONTAINER_TOOL)
 	@echo "All images built and pushed successfully to $(ECR_REGISTRY)"
@@ -628,8 +641,9 @@ load-images-aws-internal: manifests generate fmt vet ## Build and push container
 load-images-aws:
 	$(MAKE) load-images-aws-internal CLOUD_PROVIDER=aws
 
-# Optional traefik access resources parameter
+# Optional deploy parameters
 ENABLE_TRAEFIK_ACCESS_RESOURCES ?= true
+PLUGINS ?=
 
 deploy-aws-internal: helm-generate load-images-aws ## Deploy helm chart to remote cluster
 	@echo "Deploying jupyter-k8s CRD and controller with Helm chart to remote AWS cluster..."
@@ -641,7 +655,6 @@ deploy-aws-internal: helm-generate load-images-aws ## Deploy helm chart to remot
 		--set controllerManager.container.imagePullPolicy=Always \
 		--set controllerManager.container.image.repository=$(ECR_REGISTRY)/$(ECR_REPOSITORY) \
 		--set controllerManager.container.image.tag=latest \
-		--set controllerManager.container.env.CLUSTER_ID="$(EKS_CONTEXT)" \
 		--set application.imagesPullPolicy=Always \
 		--set application.imagesRegistry=$(ECR_REGISTRY) \
 		$(if $(filter true,$(ENABLE_TRAEFIK_ACCESS_RESOURCES)),--set accessResources.traefik.enable=true) \
@@ -650,7 +663,15 @@ deploy-aws-internal: helm-generate load-images-aws ## Deploy helm chart to remot
 		--set extensionApi.jwtSecret.enable=true \
 		--set extensionApi.jwtSecret.rotator.repository=$(ECR_REGISTRY) \
 		--set extensionApi.jwtSecret.rotator.imageName=$(ECR_REPOSITORY_ROTATOR) \
-		--set workspaceTemplates.defaultNamespace=jupyter-k8s-system # guided charts deploy templates here
+		--set workspaceTemplates.defaultNamespace=jupyter-k8s-system \
+		$(if $(filter aws,$(PLUGINS)),--set controller.plugins[0].name=aws) \
+		$(if $(filter aws,$(PLUGINS)),--set controller.plugins[0].image.repository=$(ECR_REGISTRY)/$(ECR_REPOSITORY_AWS_PLUGIN)) \
+		$(if $(filter aws,$(PLUGINS)),--set controller.plugins[0].image.tag=latest) \
+		$(if $(filter aws,$(PLUGINS)),--set controller.plugins[0].port=8080) \
+		$(if $(filter aws,$(PLUGINS)),--set controller.plugins[0].imagePullPolicy=Always) \
+		$(if $(filter aws,$(PLUGINS)),--set controller.plugins[0].env.PLUGIN_PORT=8080) \
+		$(if $(filter aws,$(PLUGINS)),--set controller.plugins[0].env.AWS_REGION=$(AWS_REGION)) \
+		$(if $(filter aws,$(PLUGINS)),--set controller.plugins[0].env.CLUSTER_ID=$(EKS_CONTEXT))
 	@echo "Helm chart jupyter-k8s deployed successfully to remote AWS cluster"
 	@echo "Restarting deployments to use new images..."
 	kubectl rollout restart deployment -n jupyter-k8s-system jupyter-k8s-controller-manager
@@ -663,6 +684,10 @@ deploy-aws:
 .PHONY: deploy-aws-with-traefik
 deploy-aws-with-traefik:
 	$(MAKE) deploy-aws-internal CLOUD_PROVIDER=aws ENABLE_TRAEFIK_ACCESS_RESOURCES=true
+
+.PHONY: deploy-aws-with-plugin
+deploy-aws-with-plugin: ## Deploy controller with AWS plugin sidecar
+	$(MAKE) deploy-aws-internal CLOUD_PROVIDER=aws PLUGINS=aws
 
 # Load environment variables from .env file for guided deployment
 deploy-aws-traefik-dex-internal:
@@ -757,7 +782,8 @@ deploy-aws-hyperpod-internal:
 			exit 1; \
 		fi; \
 		echo "Deploying AWS HyperPod helm chart (domain=$$HP_DOMAIN)"; \
-		HELM_ARGS="--set clusterWebUI.enabled=true \
+		HELM_ARGS="--set aws.region=$(AWS_REGION) \
+			--set clusterWebUI.enabled=true \
 			--set clusterWebUI.domain=$$HP_DOMAIN \
 			--set clusterWebUI.auth.repository=$(ECR_REGISTRY) \
 			--set clusterWebUI.auth.imageName=$(ECR_REPOSITORY_AUTH) \

--- a/api/plugin/v1alpha1/remote_access_types.go
+++ b/api/plugin/v1alpha1/remote_access_types.go
@@ -23,6 +23,7 @@ type RegisterNodeAgentRequest struct {
 type RegisterNodeAgentResponse struct {
 	ActivationID   string `json:"activationId"`
 	ActivationCode string `json:"activationCode"`
+	Region         string `json:"region"`
 }
 
 // DeregisterNodeAgentRequest is the request body for POST /v1alpha1/remote-access/deregister-node-agent.

--- a/api/plugin/v1alpha1/remote_access_types.go
+++ b/api/plugin/v1alpha1/remote_access_types.go
@@ -23,7 +23,6 @@ type RegisterNodeAgentRequest struct {
 type RegisterNodeAgentResponse struct {
 	ActivationID   string `json:"activationId"`
 	ActivationCode string `json:"activationCode"`
-	Region         string `json:"region"`
 }
 
 // DeregisterNodeAgentRequest is the request body for POST /v1alpha1/remote-access/deregister-node-agent.

--- a/cmd/aws-plugin/main.go
+++ b/cmd/aws-plugin/main.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/jupyter-infra/jupyter-k8s/internal/awsplugin"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
@@ -23,6 +24,22 @@ import (
 )
 
 func main() {
+	// Health check mode: used by Kubernetes exec probes to check the server is alive.
+	// The plugin binds to 127.0.0.1 (not reachable by kubelet HTTP probes),
+	// so we use an exec probe that runs the same binary with --healthcheck.
+	if len(os.Args) > 1 && os.Args[1] == "--healthcheck" {
+		port := os.Getenv("PLUGIN_PORT")
+		if port == "" {
+			port = "8080"
+		}
+		client := &http.Client{Timeout: 2 * time.Second}
+		resp, err := client.Get(fmt.Sprintf("http://127.0.0.1:%s/healthz", port))
+		if err != nil || resp.StatusCode != http.StatusOK {
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+
 	ctrllog.SetLogger(zap.New(zap.UseDevMode(false)))
 	logger := ctrllog.Log.WithName("aws-plugin")
 

--- a/dist/chart/templates/manager/manager.yaml
+++ b/dist/chart/templates/manager/manager.yaml
@@ -126,6 +126,18 @@ spec:
           ports:
             - containerPort: {{ .port }}
               protocol: TCP
+          {{- if .healthcheckCommand }}
+          livenessProbe:
+            exec:
+              command: {{ .healthcheckCommand | toJson }}
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command: {{ .healthcheckCommand | toJson }}
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          {{- end }}
           {{- if .env }}
           env:
             {{- range $key, $value := .env }}

--- a/dist/chart/templates/manager/manager.yaml
+++ b/dist/chart/templates/manager/manager.yaml
@@ -61,6 +61,9 @@ spec:
             {{- if .Values.workspacePodWatching.enable }}
             - "--enable-workspace-pod-watching"
             {{- end}}
+            {{- if .Values.controller.plugins }}
+            - "--plugin-endpoints={{ range $i, $p := .Values.controller.plugins }}{{ if $i }},{{ end }}{{ $p.name }}=http://localhost:{{ $p.port }}{{ end }}"
+            {{- end}}
           command:
             - /manager
           image: {{ .Values.controllerManager.container.image.repository }}:{{ .Values.controllerManager.container.image.tag }}
@@ -114,6 +117,27 @@ spec:
               readOnly: true
             {{- end }}
           {{- end }}
+        {{- range .Values.controller.plugins }}
+        - name: plugin-{{ .name }}
+          image: "{{ .image.repository }}:{{ .image.tag }}"
+          {{- if .imagePullPolicy }}
+          imagePullPolicy: {{ .imagePullPolicy }}
+          {{- end }}
+          ports:
+            - containerPort: {{ .port }}
+              protocol: TCP
+          {{- if .env }}
+          env:
+            {{- range $key, $value := .env }}
+            - name: {{ $key }}
+              value: "{{ $value }}"
+            {{- end }}
+          {{- end }}
+          {{- if .resources }}
+          resources:
+            {{- toYaml .resources | nindent 12 }}
+          {{- end }}
+        {{- end }}
       securityContext:
         {{- toYaml .Values.controllerManager.securityContext | nindent 8 }}
       serviceAccountName: {{ .Values.controllerManager.serviceAccountName }}

--- a/dist/chart/values.yaml
+++ b/dist/chart/values.yaml
@@ -4,7 +4,6 @@ controllerManager:
   container:
     env:
       CLUSTER_ADMIN_GROUP: "cluster-workspace-admin"
-      CLUSTER_ID: ""
     image:
       repository: controller
       tag: latest
@@ -157,3 +156,20 @@ extensionApi:
         limits:
           cpu: 100m
           memory: 128Mi
+
+# [CONTROLLER]: Controller configuration
+controller:
+  # Plugin sidecars to deploy alongside the controller
+  # Each plugin runs as a sidecar container in the controller pod
+  # Example:
+  #   plugins:
+  #     - name: aws
+  #       image:
+  #         repository: my-registry/jupyter-k8s-aws-plugin
+  #         tag: latest
+  #       port: 8080
+  #       imagePullPolicy: Always
+  #       env:
+  #         PLUGIN_PORT: "8080"
+  #         AWS_REGION: "us-west-2"
+  plugins: []

--- a/dist/chart/values.yaml
+++ b/dist/chart/values.yaml
@@ -169,6 +169,7 @@ controller:
   #         tag: latest
   #       port: 8080
   #       imagePullPolicy: Always
+  #       healthcheckCommand: ["/aws-plugin", "--healthcheck"]
   #       env:
   #         PLUGIN_PORT: "8080"
   #         AWS_REGION: "us-west-2"

--- a/guided-charts/aws-hyperpod/templates/hyperpod-access-strategy.yaml
+++ b/guided-charts/aws-hyperpod/templates/hyperpod-access-strategy.yaml
@@ -61,12 +61,28 @@ spec:
   {{- end }}
 
   createConnectionHandler: "k8s-native"
-  podEventsHandler: "aws"
+  {{- if .Values.remoteAccess.enabled }}
+  createConnectionHandlerMap:
+    vscode-remote: "aws:createSession"
+  {{- end }}
+  podEventsHandler: "aws:ssm-remote-access"
 
   {{- if .Values.remoteAccess.enabled }}
   createConnectionContext:
-    ssmManagedNodeRole: "{{ .Values.remoteAccess.ssmManagedNodeRole }}"
+    podUid: "extensionapi::PodUid()"
     ssmDocumentName: "{{ .Values.remoteAccess.ssmDocumentName }}"
+    port: "2222"
+  podEventsContext:
+    podUid: "controller::PodUid()"
+    region: "{{ .Values.aws.region }}"
+    ssmManagedNodeRole: "{{ .Values.remoteAccess.ssmManagedNodeRole }}"
+    sidecarContainerName: "ssm-agent-sidecar"
+    workspaceContainerName: "workspace"
+    registrationStateFile: "/opt/amazon/sagemaker/workspace/.ssm-registration-state.json"
+    registrationMarkerFile: "/tmp/ssm-registered"
+    registrationScript: "/usr/local/bin/register-ssm.sh"
+    remoteAccessServerScript: "/opt/amazon/sagemaker/workspace/remote-access/start-remote-access-server.sh"
+    remoteAccessServerPort: "2222"
   {{- end }}
 
   # Deployment modifications for SSM remote access

--- a/guided-charts/aws-hyperpod/templates/hyperpod-access-strategy.yaml
+++ b/guided-charts/aws-hyperpod/templates/hyperpod-access-strategy.yaml
@@ -71,18 +71,18 @@ spec:
   createConnectionContext:
     podUid: "extensionapi::PodUid()"
     ssmDocumentName: "{{ .Values.remoteAccess.ssmDocumentName }}"
-    port: "2222"
+    port: "{{ .Values.remoteAccess.remoteAccessServerPort }}"
   podEventsContext:
     podUid: "controller::PodUid()"
-    region: "{{ .Values.aws.region }}"
+    region: "{{ required "aws.region is required when remoteAccess is enabled" .Values.aws.region }}"
     ssmManagedNodeRole: "{{ .Values.remoteAccess.ssmManagedNodeRole }}"
-    sidecarContainerName: "ssm-agent-sidecar"
-    workspaceContainerName: "workspace"
-    registrationStateFile: "/opt/amazon/sagemaker/workspace/.ssm-registration-state.json"
-    registrationMarkerFile: "/tmp/ssm-registered"
-    registrationScript: "/usr/local/bin/register-ssm.sh"
-    remoteAccessServerScript: "/opt/amazon/sagemaker/workspace/remote-access/start-remote-access-server.sh"
-    remoteAccessServerPort: "2222"
+    sidecarContainerName: "{{ .Values.remoteAccess.sidecarContainerName }}"
+    workspaceContainerName: "{{ .Values.remoteAccess.workspaceContainerName }}"
+    registrationStateFile: "{{ .Values.remoteAccess.registrationStateFile }}"
+    registrationMarkerFile: "{{ .Values.remoteAccess.registrationMarkerFile }}"
+    registrationScript: "{{ .Values.remoteAccess.registrationScript }}"
+    remoteAccessServerScript: "{{ .Values.remoteAccess.remoteAccessServerScript }}"
+    remoteAccessServerPort: "{{ .Values.remoteAccess.remoteAccessServerPort }}"
   {{- end }}
 
   # Deployment modifications for SSM remote access
@@ -90,7 +90,7 @@ spec:
     podModifications:
       {{- if .Values.remoteAccess.enabled }}
       additionalContainers:
-        - name: "ssm-agent-sidecar"
+        - name: "{{ .Values.remoteAccess.sidecarContainerName }}"
           image: "{{ .Values.remoteAccess.ssmSidecarImage.containerRegistry }}/{{ .Values.remoteAccess.ssmSidecarImage.repository }}:{{ .Values.remoteAccess.ssmSidecarImage.tag }}"
           command:
             - /opt/amazon/sagemaker/workspace/bin/entrypoint-workspace-sidecar-container
@@ -117,7 +117,7 @@ spec:
             failureThreshold: 6
           readinessProbe:
             exec:
-              command: ["test", "-f", "/tmp/ssm-registered"]
+              command: ["test", "-f", "{{ .Values.remoteAccess.registrationMarkerFile }}"]
             initialDelaySeconds: 2
             periodSeconds: 2
       {{- end }}

--- a/guided-charts/aws-hyperpod/values.yaml
+++ b/guided-charts/aws-hyperpod/values.yaml
@@ -115,6 +115,15 @@ remoteAccess:
     repository: ""
     tag: ""
   ssmDocumentName: "AWS-StartSSHSession"
+  # Container and path configuration shared between podEventsContext and sidecar spec.
+  # Changing these values updates both the controller context and the sidecar container.
+  sidecarContainerName: "ssm-agent-sidecar"
+  workspaceContainerName: "workspace"
+  registrationMarkerFile: "/tmp/ssm-registered"
+  registrationStateFile: "/opt/amazon/sagemaker/workspace/.ssm-registration-state.json"
+  registrationScript: "/usr/local/bin/register-ssm.sh"
+  remoteAccessServerScript: "/opt/amazon/sagemaker/workspace/remote-access/start-remote-access-server.sh"
+  remoteAccessServerPort: "2222"
 
 # [STORAGE] StorageClasses for Workspaces
 storageClass:

--- a/guided-charts/aws-hyperpod/values.yaml
+++ b/guided-charts/aws-hyperpod/values.yaml
@@ -3,6 +3,10 @@
 
 namespace: jupyter-k8s-system
 
+# AWS configuration
+aws:
+  region: ""
+
 # [CLUSTER WEB UI]: Web interface configuration
 clusterWebUI:
   enabled: false

--- a/hack/apply-helm-patches.sh
+++ b/hack/apply-helm-patches.sh
@@ -206,8 +206,7 @@ if [ -f "${PATCHES_DIR}/values.yaml.patch" ]; then
         # Add env section right after container: (macOS compatible)
         sed -i.bak '/container:/a\
     env:\
-      CLUSTER_ADMIN_GROUP: "cluster-workspace-admin"\
-      CLUSTER_ID: ""
+      CLUSTER_ADMIN_GROUP: "cluster-workspace-admin"
 ' "${CHART_DIR}/values.yaml" && rm "${CHART_DIR}/values.yaml.bak"
     fi
 
@@ -336,13 +335,16 @@ if [ -f "${PATCHES_DIR}/manager.yaml.patch" ]; then
             {{- end}}\
             {{- if .Values.workspacePodWatching.enable }}\
             - "--enable-workspace-pod-watching"\
+            {{- end}}\
+            {{- if .Values.controller.plugins }}\
+            - "--plugin-endpoints={{ range \$i, \$p := .Values.controller.plugins }}{{ if \$i }},{{ end }}{{ \$p.name }}=http://localhost:{{ \$p.port }}{{ end }}"\
             {{- end}}
                     }' "${MANAGER_YAML}"
                 else
                     # Linux sed
                     sed -i '/args:/,/command:/ {
                     /command:/!d
-                    i\          args:\n            {{- range .Values.controllerManager.container.args }}\n            - {{ . }}\n            {{- end }}\n            - "--application-images-pull-policy={{ .Values.application.imagesPullPolicy }}"\n            - "--application-images-registry={{ .Values.application.imagesRegistry }}"\n            - "--default-template-namespace={{ .Values.workspaceTemplates.defaultNamespace }}"\n            {{- if .Values.accessResources.traefik.enable }}\n            - "--watch-traefik"\n            {{- end}}\n            {{- if .Values.extensionApi.enable }}\n            - "--enable-extension-api"\n            {{- if .Values.extensionApi.jwtIssuer }}\n            - "--jwt-issuer={{ .Values.extensionApi.jwtIssuer }}"\n            {{- end}}\n            {{- if .Values.extensionApi.jwtAudience }}\n            - "--jwt-audience={{ .Values.extensionApi.jwtAudience }}"\n            {{- end}}\n            {{- end}}\n            {{- if and .Values.extensionApi.enable .Values.extensionApi.jwtSecret.enable }}\n            - "--jwt-secret-name={{ .Values.extensionApi.jwtSecret.secretName }}"\n            {{- if .Values.extensionApi.jwtSecret.tokenTTL }}\n            - "--jwt-ttl={{ .Values.extensionApi.jwtSecret.tokenTTL }}"\n            {{- end}}\n            {{- if .Values.extensionApi.jwtSecret.newKeyUseDelay }}\n            - "--new-key-use-delay={{ .Values.extensionApi.jwtSecret.newKeyUseDelay }}"\n            {{- end}}\n            {{- end}}\n            {{- if .Values.workspacePodWatching.enable }}\n            - "--enable-workspace-pod-watching"\n            {{- end}}
+                    i\          args:\n            {{- range .Values.controllerManager.container.args }}\n            - {{ . }}\n            {{- end }}\n            - "--application-images-pull-policy={{ .Values.application.imagesPullPolicy }}"\n            - "--application-images-registry={{ .Values.application.imagesRegistry }}"\n            - "--default-template-namespace={{ .Values.workspaceTemplates.defaultNamespace }}"\n            {{- if .Values.accessResources.traefik.enable }}\n            - "--watch-traefik"\n            {{- end}}\n            {{- if .Values.extensionApi.enable }}\n            - "--enable-extension-api"\n            {{- if .Values.extensionApi.jwtIssuer }}\n            - "--jwt-issuer={{ .Values.extensionApi.jwtIssuer }}"\n            {{- end}}\n            {{- if .Values.extensionApi.jwtAudience }}\n            - "--jwt-audience={{ .Values.extensionApi.jwtAudience }}"\n            {{- end}}\n            {{- end}}\n            {{- if and .Values.extensionApi.enable .Values.extensionApi.jwtSecret.enable }}\n            - "--jwt-secret-name={{ .Values.extensionApi.jwtSecret.secretName }}"\n            {{- if .Values.extensionApi.jwtSecret.tokenTTL }}\n            - "--jwt-ttl={{ .Values.extensionApi.jwtSecret.tokenTTL }}"\n            {{- end}}\n            {{- if .Values.extensionApi.jwtSecret.newKeyUseDelay }}\n            - "--new-key-use-delay={{ .Values.extensionApi.jwtSecret.newKeyUseDelay }}"\n            {{- end}}\n            {{- end}}\n            {{- if .Values.workspacePodWatching.enable }}\n            - "--enable-workspace-pod-watching"\n            {{- end}}\n            {{- if .Values.controller.plugins }}\n            - "--plugin-endpoints={{ range $i, $p := .Values.controller.plugins }}{{ if $i }},{{ end }}{{ $p.name }}=http://localhost:{{ $p.port }}{{ end }}"\n            {{- end}}
                 }' "${MANAGER_YAML}"
                 fi
                 # Also add extension API volume mount if not already present
@@ -443,6 +445,44 @@ if [ -f "${PATCHES_DIR}/manager.yaml.patch" ]; then
         # in the args block above, so no env var injection needed here.
     else
         echo "Warning: manager.yaml not found at ${MANAGER_YAML}"
+    fi
+fi
+
+# Add plugin sidecar containers to manager.yaml
+MANAGER_YAML="${CHART_DIR}/templates/manager/manager.yaml"
+if [ -f "${MANAGER_YAML}" ]; then
+    if ! grep -q "plugin-{{ .name }}" "${MANAGER_YAML}"; then
+        echo "Adding plugin sidecar container support to manager.yaml..."
+        # Insert plugin sidecar containers block before securityContext (pod-level)
+        # We target the pod-level securityContext that comes after the manager container's closing volumeMounts
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+            sed -i '' '/^      securityContext:$/i\
+        {{- range .Values.controller.plugins }}\
+        - name: plugin-{{ .name }}\
+          image: "{{ .image.repository }}:{{ .image.tag }}"\
+          {{- if .imagePullPolicy }}\
+          imagePullPolicy: {{ .imagePullPolicy }}\
+          {{- end }}\
+          ports:\
+            - containerPort: {{ .port }}\
+              protocol: TCP\
+          {{- if .env }}\
+          env:\
+            {{- range \$key, \$value := .env }}\
+            - name: {{ \$key }}\
+              value: "{{ \$value }}"\
+            {{- end }}\
+          {{- end }}\
+          {{- if .resources }}\
+          resources:\
+            {{- toYaml .resources | nindent 12 }}\
+          {{- end }}\
+        {{- end }}
+' "${MANAGER_YAML}"
+        else
+            sed -i '/^      securityContext:$/i\        {{- range .Values.controller.plugins }}\n        - name: plugin-{{ .name }}\n          image: "{{ .image.repository }}:{{ .image.tag }}"\n          {{- if .imagePullPolicy }}\n          imagePullPolicy: {{ .imagePullPolicy }}\n          {{- end }}\n          ports:\n            - containerPort: {{ .port }}\n              protocol: TCP\n          {{- if .env }}\n          env:\n            {{- range $key, $value := .env }}\n            - name: {{ $key }}\n              value: "{{ $value }}"\n            {{- end }}\n          {{- end }}\n          {{- if .resources }}\n          resources:\n            {{- toYaml .resources | nindent 12 }}\n          {{- end }}\n        {{- end }}' "${MANAGER_YAML}"
+        fi
+        echo "Added plugin sidecar container support"
     fi
 fi
 

--- a/hack/apply-helm-patches.sh
+++ b/hack/apply-helm-patches.sh
@@ -466,6 +466,18 @@ if [ -f "${MANAGER_YAML}" ]; then
           ports:\
             - containerPort: {{ .port }}\
               protocol: TCP\
+          {{- if .healthcheckCommand }}\
+          livenessProbe:\
+            exec:\
+              command: {{ .healthcheckCommand | toJson }}\
+            initialDelaySeconds: 5\
+            periodSeconds: 10\
+          readinessProbe:\
+            exec:\
+              command: {{ .healthcheckCommand | toJson }}\
+            initialDelaySeconds: 2\
+            periodSeconds: 5\
+          {{- end }}\
           {{- if .env }}\
           env:\
             {{- range \$key, \$value := .env }}\
@@ -480,7 +492,7 @@ if [ -f "${MANAGER_YAML}" ]; then
         {{- end }}
 ' "${MANAGER_YAML}"
         else
-            sed -i '/^      securityContext:$/i\        {{- range .Values.controller.plugins }}\n        - name: plugin-{{ .name }}\n          image: "{{ .image.repository }}:{{ .image.tag }}"\n          {{- if .imagePullPolicy }}\n          imagePullPolicy: {{ .imagePullPolicy }}\n          {{- end }}\n          ports:\n            - containerPort: {{ .port }}\n              protocol: TCP\n          {{- if .env }}\n          env:\n            {{- range $key, $value := .env }}\n            - name: {{ $key }}\n              value: "{{ $value }}"\n            {{- end }}\n          {{- end }}\n          {{- if .resources }}\n          resources:\n            {{- toYaml .resources | nindent 12 }}\n          {{- end }}\n        {{- end }}' "${MANAGER_YAML}"
+            sed -i '/^      securityContext:$/i\        {{- range .Values.controller.plugins }}\n        - name: plugin-{{ .name }}\n          image: "{{ .image.repository }}:{{ .image.tag }}"\n          {{- if .imagePullPolicy }}\n          imagePullPolicy: {{ .imagePullPolicy }}\n          {{- end }}\n          ports:\n            - containerPort: {{ .port }}\n              protocol: TCP\n          {{- if .healthcheckCommand }}\n          livenessProbe:\n            exec:\n              command: {{ .healthcheckCommand | toJson }}\n            initialDelaySeconds: 5\n            periodSeconds: 10\n          readinessProbe:\n            exec:\n              command: {{ .healthcheckCommand | toJson }}\n            initialDelaySeconds: 2\n            periodSeconds: 5\n          {{- end }}\n          {{- if .env }}\n          env:\n            {{- range $key, $value := .env }}\n            - name: {{ $key }}\n              value: "{{ $value }}"\n            {{- end }}\n          {{- end }}\n          {{- if .resources }}\n          resources:\n            {{- toYaml .resources | nindent 12 }}\n          {{- end }}\n        {{- end }}' "${MANAGER_YAML}"
         fi
         echo "Added plugin sidecar container support"
     fi

--- a/hack/helm-patches/manager.yaml.patch
+++ b/hack/helm-patches/manager.yaml.patch
@@ -14,3 +14,6 @@
             {{- if .Values.workspacePodWatching.enable }}
             - --enable-workspace-pod-watching
             {{- end}}
+            {{- if .Values.controller.plugins }}
+            - "--plugin-endpoints={{ range $i, $p := .Values.controller.plugins }}{{ if $i }},{{ end }}{{ $p.name }}=http://localhost:{{ $p.port }}{{ end }}"
+            {{- end}}

--- a/hack/helm-patches/values.yaml.patch
+++ b/hack/helm-patches/values.yaml.patch
@@ -55,3 +55,20 @@ extensionApi:
         limits:
           cpu: 100m
           memory: 128Mi
+
+# [CONTROLLER]: Controller configuration
+controller:
+  # Plugin sidecars to deploy alongside the controller
+  # Each plugin runs as a sidecar container in the controller pod
+  # Example:
+  #   plugins:
+  #     - name: aws
+  #       image:
+  #         repository: my-registry/jupyter-k8s-aws-plugin
+  #         tag: latest
+  #       port: 8080
+  #       imagePullPolicy: Always
+  #       env:
+  #         PLUGIN_PORT: "8080"
+  #         AWS_REGION: "us-west-2"
+  plugins: []

--- a/hack/helm-patches/values.yaml.patch
+++ b/hack/helm-patches/values.yaml.patch
@@ -68,6 +68,7 @@ controller:
   #         tag: latest
   #       port: 8080
   #       imagePullPolicy: Always
+  #       healthcheckCommand: ["/aws-plugin", "--healthcheck"]
   #       env:
   #         PLUGIN_PORT: "8080"
   #         AWS_REGION: "us-west-2"


### PR DESCRIPTION
This PR 4 of the plugin migration story, which provides configuration for the `aws-hyperpod` guided chart, along with `Makefile` methods to deploy, create sample workspaces, and generate bearer token URLs for both jupyterlab and code editor IDEs against an `aws-hyperpod` deployment.

### Implementation
1. update `dist/chart/template` after generation to add the plugin configuration
    1.1. expose a `controller: plugin: []` in `values.yaml`
3. update `hack` to handle the plugins
4. update `Makefile` methods:
    3.1. create the ecr repo for the aws plugin image if missing
    3.2. build & publish the aws plugin to ecr
    3.3. parametrize `deploy-aws-internal` method to pass the `plugin` config to helm

### Testing
- deployed the updated operator, including `controller`, `extensionapi` and `aws-plugin` to an hyperpod cluster
- used `make apply-sample-hyperpod WS_USER=admin` to create
    - public `jupyterlab` workspace
    - private `jupyterlab` workspace
    - public `code-editor` workspace
    - private `code-editor` workspace
- used `make bearer-token WS_NAME=<>` to generate URL, and verify access on webbrowser
- used `make vscode-token WS_NAME=<>` to generate VS Code URL, and verify access on my desktop
- switched users (ie used different iam role), then used `make apply-sample-hyperpod WS_USER=parkeruser1`
- verified access (webbrowser and VS Code remote access) on own workspaces
- verified access denied on `make bearer-token WS_NAME=<>` and `make vscode-token WS_NAME=<>` for private workspaces owned by `admin` user
- verified access (webbrowser and VS Code remote access) on admin public workspaces