### PR TITLE
feat: hpchart cookie refresh

### DIFF
--- a/.github/workflows/test-chart-aws-traefik-dex.yml
+++ b/.github/workflows/test-chart-aws-traefik-dex.yml
@@ -46,3 +46,40 @@ jobs:
 
       - name: Run AWS Traefik Dex Helm Tests
         run: make helm-test-aws-traefik-dex
+
+  test-chart-aws-hyperpod:
+    name: Chart (AWS HyperPod)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install Helm
+        run: |
+          curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+
+      - name: Verify Helm installation
+        run: helm version
+
+      - name: Install kubebuilder
+        run: |
+          mkdir -p /tmp/kubebuilder
+          curl -L "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v4.8.0/kubebuilder_$(go env GOOS)_$(go env GOARCH)" -o /tmp/kubebuilder/kubebuilder
+          chmod +x /tmp/kubebuilder/kubebuilder
+          sudo mv /tmp/kubebuilder/kubebuilder /usr/local/bin/
+          rm -rf /tmp/kubebuilder
+          kubebuilder version
+
+      - name: Generate Helm Chart
+        run: make helm-generate
+
+      - name: Lint Helm Chart
+        run: make helm-lint
+
+      - name: Run AWS HyperPod Helm Tests
+        run: make helm-test-aws-hyperpod

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,10 @@ All AWS make targets read `AWS_REGION` and `EKS_CLUSTER_NAME` from `.env`, comma
 - call `make kubectl-aws` to switch kubectl context
 All subsequent make targets use the `.env` values.
 
+**Detailed testing strategies for guided charts:**
+- HyperPod (plugin sidecar, SSM remote access, web UI): [`guided-charts/aws-hyperpod/AGENT.md`](guided-charts/aws-hyperpod/AGENT.md)
+- Traefik-Dex (OSS routing, GitHub OAuth, bearer auth): [`guided-charts/aws-traefik-dex/AGENT.md`](guided-charts/aws-traefik-dex/AGENT.md)
+
 ### Clean up
 Ask user before running.
 - `make teardown-kind`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,29 @@ The auth middleware component provides authentication and authorization for work
 
 - `/health`: System health check endpoint for monitoring
 
+### Plugin Architecture
+**Code:** `internal/plugin`, `internal/pluginclient`, `internal/pluginserver`, `internal/pluginadapters`, `internal/awsadapter`, `internal/awsplugin`
+
+Cloud-provider operations are decoupled from the core operator via an HTTP sidecar plugin pattern.
+The controller is the HTTP client; the plugin runs as a sidecar on `localhost` in the same pod.
+
+- **`internal/plugin/`**: Shared interfaces (`RemoteAccessPluginApis`, `JwtPluginApis`) and utilities (`ParseHandlerRef`) used by both client and server sides
+- **`internal/pluginclient/`**: `PluginClient` — HTTP client that implements the plugin interfaces by calling sidecar endpoints
+- **`internal/pluginserver/`**: HTTP server framework that routes requests to handler implementations
+- **`internal/pluginadapters/`**: Controller-side adapter interfaces (`PodEventPluginAdapter`) for pod lifecycle orchestration (pod exec, state files, restart detection)
+- **`internal/awsadapter/`**: AWS-specific adapter (`AwsSsmPodEventAdapter`) — orchestrates SSM registration using `pluginclient` for SDK calls and pod exec for k8s operations
+- **`internal/awsplugin/`**: AWS SDK handler implementations (SSM client, remote access routes), compiled into `cmd/aws-plugin/`
+
+Plugin routing is driven by `AccessStrategy` fields: `PodEventsHandler` (e.g. `"aws:ssm-remote-access"`) and `CreateConnectionHandlerMap` (e.g. `vscode-remote: "aws:createSession"`).
+The controller parses the `plugin:action` format and dispatches to the matching `PluginClient`.
+
+### JWT Key Rotator
+**Code:** `internal/rotator/`
+
+Deployed as a CronJob to rotate the HMAC signing keys stored in a Kubernetes secret.
+- Used by both `extensionapi` and `authmiddleware`.
+- Each has its own CronJob and Kubernetes secret; deployed by different charts and may live in different namespaces.
+
 ### Deployment Modes
 
 1. **Guided Mode**: Helm chart creates all required resources:

--- a/Makefile
+++ b/Makefile
@@ -268,6 +268,7 @@ helm-generate: manifests
 helm-package: helm-generate ## Package the Helm chart
 	helm package dist/chart -d dist
 	helm package guided-charts/aws-traefik-dex -d dist
+	helm package guided-charts/aws-hyperpod -d dist
 
 .PHONY: helm-lint
 helm-lint: ## Lint the Helm chart
@@ -283,6 +284,16 @@ helm-lint: ## Lint the Helm chart
 		--set githubRbac.orgs[0].name=some-org \
 		--set githubRbac.orgs[0].teams[0]=ace-devs \
 		--set oauth2Proxy.cookieSecret=$(OAUTH2P_COOKIE_SECRET)
+	helm lint guided-charts/aws-hyperpod \
+		--set clusterWebUI.enabled=true \
+		--set clusterWebUI.domain=test.example.com \
+		--set clusterWebUI.awsCertificateArn=arn:aws:acm:us-east-1:123456789:certificate/abc \
+		--set aws.region=us-east-1 \
+		--set remoteAccess.enabled=true \
+		--set remoteAccess.ssmManagedNodeRole=arn:aws:iam::123456789:role/SageMakerRole \
+		--set remoteAccess.ssmSidecarImage.containerRegistry=123456789.dkr.ecr.us-east-1.amazonaws.com \
+		--set remoteAccess.ssmSidecarImage.repository=ssm-sidecar \
+		--set remoteAccess.ssmSidecarImage.tag=latest
 
 .PHONY: helm-test
 helm-test: ## Test the Helm chart with helm template

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ OAUTH2P_COOKIE_SECRET := $(shell openssl rand -base64 32 | tr -- '+/' '-_')
 all: build
 
 .PHONY: release
-release: helm-generate build lint-fix lint-fix-e2e test helm-lint helm-test helm-test-aws-traefik-dex ## Run all checks required before PR submission (excluding e2e tests)
+release: helm-generate build lint-fix lint-fix-e2e test helm-lint helm-test helm-test-aws-traefik-dex helm-test-aws-hyperpod ## Run all checks required before PR submission (excluding e2e tests)
 
 ##@ General
 
@@ -298,11 +298,11 @@ helm-test: ## Test the Helm chart with helm template
 
 .PHONY: helm-test-aws-traefik-dex
 helm-test-aws-traefik-dex: ## Test the Helm chart with guided mode (aws-traefik-dex)
-	rm -rf dist/test-output-guided
+	rm -rf dist/test-output-guided/aws-traefik-dex
 	rm -rf /tmp/helm-test-chart
 	cp -r guided-charts/aws-traefik-dex /tmp/helm-test-chart
 	cd /tmp/helm-test-chart && helm dependency build
-	helm template jk8s /tmp/helm-test-chart --output-dir dist/test-output-guided \
+	helm template jk8s /tmp/helm-test-chart --output-dir dist/test-output-guided/aws-traefik-dex \
 		--set domain=a.fine.example.com \
 		--set certManager.email=admin@example.com \
 		--set storageClass.efs.parameters.fileSystemId=fs-00001111222233334 \
@@ -318,6 +318,28 @@ helm-test-aws-traefik-dex: ## Test the Helm chart with guided mode (aws-traefik-
 	rm -rf /tmp/helm-test-chart
 	# Run helm tests to verify resources
 	go test ./test/helm/guided-aws-traefik-dex -v
+
+.PHONY: helm-test-aws-hyperpod
+helm-test-aws-hyperpod: ## Test the Helm chart with guided mode (aws-hyperpod)
+	rm -rf dist/test-output-guided/aws-hyperpod
+	rm -rf /tmp/helm-test-chart
+	cp -r guided-charts/aws-hyperpod /tmp/helm-test-chart
+	cd /tmp/helm-test-chart && helm dependency build
+	helm template jk8s /tmp/helm-test-chart --output-dir dist/test-output-guided/aws-hyperpod \
+		--set clusterWebUI.enabled=true \
+		--set clusterWebUI.domain=test.example.com \
+		--set clusterWebUI.awsCertificateArn=arn:aws:acm:us-east-1:123456789:certificate/abc \
+		--set aws.region=us-east-1 \
+		--set remoteAccess.enabled=true \
+		--set remoteAccess.ssmManagedNodeRole=arn:aws:iam::123456789:role/SageMakerRole \
+		--set remoteAccess.ssmSidecarImage.containerRegistry=123456789.dkr.ecr.us-east-1.amazonaws.com \
+		--set remoteAccess.ssmSidecarImage.repository=ssm-sidecar \
+		--set remoteAccess.ssmSidecarImage.tag=latest \
+		--set clusterWebUI.auth.enableBearerAuth=true
+	# Clean up temporary chart directory
+	rm -rf /tmp/helm-test-chart
+	# Run helm tests to verify resources
+	go test ./test/helm/guided-aws-hyperpod -v
 
 
 ##@ Deployment

--- a/cmd/aws-plugin/main.go
+++ b/cmd/aws-plugin/main.go
@@ -24,9 +24,13 @@ import (
 )
 
 func main() {
-	// Health check mode: used by Kubernetes exec probes to check the server is alive.
-	// The plugin binds to 127.0.0.1 (not reachable by kubelet HTTP probes),
-	// so we use an exec probe that runs the same binary with --healthcheck.
+	// Health check mode for Kubernetes exec probes.
+	// The plugin server binds to 127.0.0.1 so that only the co-located manager
+	// container can reach it. This means kubelet HTTP/TCP probes cannot reach it
+	// (they connect from the node network). Instead, the helm chart configures an
+	// exec probe: kubelet runs ["/aws-plugin", "--healthcheck"] inside this container,
+	// which creates an HTTP client that hits the server's /healthz endpoint on
+	// localhost — this works because the probe process shares the pod's network.
 	if len(os.Args) > 1 && os.Args[1] == "--healthcheck" {
 		port := os.Getenv("PLUGIN_PORT")
 		if port == "" {

--- a/guided-charts/aws-hyperpod/AGENT.md
+++ b/guided-charts/aws-hyperpod/AGENT.md
@@ -1,0 +1,170 @@
+# Testing: aws-hyperpod Guided Chart
+
+This chart deploys the HyperPod access strategy with optional cluster web UI (Traefik + authmiddleware)
+and SSM remote access. It requires the operator chart (`jk8s`) to be deployed first.
+
+## Prerequisites
+
+- An EKS cluster with Pod Identity / IRSA configured
+- `.env` file with `AWS_REGION`, `EKS_CLUSTER_NAME`, and HyperPod-specific values (see `.env.example`)
+- kubectl context pointing at the target cluster
+
+```bash
+make setup-aws                        # configure kubectl context from .env
+```
+
+## Clean Slate
+
+If there's an existing deployment, tear it down in dependency order (workspaces first,
+so the controller can process finalizers):
+
+```bash
+kubectl delete workspaces --all --all-namespaces --wait
+helm uninstall aws-hyperpod -n jupyter-k8s-system
+helm uninstall jk8s -n jupyter-k8s-system
+kubectl delete crd workspaces.workspace.jupyter.org \
+  workspaceaccessstrategies.workspace.jupyter.org \
+  workspacetemplates.workspace.jupyter.org 2>/dev/null; true
+```
+
+Verify nothing remains:
+
+```bash
+kubectl get all -n jupyter-k8s-system
+kubectl get crd | grep jupyter
+```
+
+## Build and Generate
+
+```bash
+make build                            # compile Go binaries
+make helm-generate                    # generate dist/chart from config/
+make helm-lint                        # lint all charts (operator + guided)
+```
+
+## Deploy
+
+### Stack 1: Operator Only (no plugin, backward compatibility)
+
+Tests that the controller works without `--plugin-endpoints`. No AWS plugin sidecar,
+no remote access features — only k8s-native paths.
+
+```bash
+make deploy-aws                       # deploys WITHOUT PLUGINS=aws
+```
+
+**Checks:**
+
+1. Controller pod has 1 container (`manager`, no `plugin-aws`):
+   ```bash
+   kubectl get pods -n jupyter-k8s-system -l control-plane=controller-manager \
+     -o jsonpath='{.items[0].spec.containers[*].name}'
+   ```
+2. No `--plugin-endpoints` in manager args:
+   ```bash
+   kubectl describe pod -n jupyter-k8s-system -l control-plane=controller-manager | grep plugin-endpoints
+   ```
+3. Manager logs show no plugin-related errors.
+
+### Stack 2: Operator with Plugin + HyperPod Chart
+
+Tests full plugin sidecar deployment with AWS remote access.
+
+```bash
+make deploy-aws-with-plugin           # deploys WITH PLUGINS=aws (builds & pushes aws-plugin image)
+make deploy-aws-hyperpod              # deploys the hyperpod guided chart
+```
+
+**Checks:**
+
+1. **Controller pod has 2 containers** (manager + plugin-aws):
+   ```bash
+   kubectl get pods -n jupyter-k8s-system -l control-plane=controller-manager \
+     -o jsonpath='{.items[0].spec.containers[*].name}'
+   ```
+   Expected: `manager plugin-aws`
+
+2. **Plugin sidecar is healthy**:
+   ```bash
+   kubectl logs -n jupyter-k8s-system -l control-plane=controller-manager -c plugin-aws --tail=5
+   ```
+   Look for: healthz 200s, no errors.
+
+3. **Manager has correct flag**:
+   ```bash
+   kubectl get pods -n jupyter-k8s-system -l control-plane=controller-manager \
+     -o jsonpath='{.items[0].spec.containers[0].args}' | tr ',' '\n' | grep plugin
+   ```
+   Expected: `--plugin-endpoints=aws=http://localhost:8080`
+
+4. **AccessStrategy rendered correctly**:
+   ```bash
+   kubectl get workspaceaccessstrategy hyperpod-access-strategy -n jupyter-k8s-system -o yaml
+   ```
+   - `podEventsHandler: "aws:ssm-remote-access"`
+   - `createConnectionHandlerMap.vscode-remote: "aws:createSession"`
+   - `podEventsContext` has all keys (ssmManagedNodeRole, sidecarContainerName, etc.)
+   - `createConnectionContext` has podUid, ssmDocumentName, port
+
+5. **Authmiddleware and Traefik running** (when `clusterWebUI.enabled=true`):
+   ```bash
+   kubectl get pods -n jupyter-k8s-system
+   ```
+   Expect: `workspace-auth-middleware` replicas + `workspace-traefik-router` replicas.
+
+## Create and Test Workspaces
+
+```bash
+make apply-sample-hyperpod WS_USER=<your-user>
+kubectl wait --for=condition=Available workspaces --all -n default --timeout=300s
+```
+
+### Verify SSM Registration Flow
+
+Controller logs should show pod events dispatched to the AWS adapter:
+```bash
+kubectl logs -n jupyter-k8s-system -l control-plane=controller-manager -c manager \
+  | grep -i "ssm\|remote\|adapter\|plugin"
+```
+
+Plugin sidecar logs should show incoming HTTP calls (register-node-agent):
+```bash
+kubectl logs -n jupyter-k8s-system -l control-plane=controller-manager -c plugin-aws --tail=20
+```
+
+### Verify Web-UI Connection (bearer token flow)
+
+```bash
+make bearer-token WS_NAME=<workspace-name>
+```
+
+Should return a URL with a JWT token. Open in browser (or via `make port-forward`) to
+verify the authmiddleware cookie flow works.
+
+### Verify VSCode Remote Connection
+
+```bash
+make vscode-token WS_NAME=<workspace-name>
+```
+
+Should route through `aws:createSession` -> plugin sidecar -> SSM `StartSession` and
+return a `vscode://` connection URL.
+
+## Cleanup
+
+```bash
+make delete-sample-hyperpod WS_USER=<your-user>
+```
+
+Controller logs should show `HandlePodDeleted` dispatched to AWS adapter.
+Plugin sidecar logs should show SSM deregistration calls.
+
+## Failure Modes
+
+| Symptom | Likely cause |
+|---------|-------------|
+| Plugin sidecar CrashLoopBackOff | Missing env vars (PLUGIN_PORT, AWS_REGION, CLUSTER_ID) or IAM role not reaching sidecar |
+| "Pod event adapter not available" in manager logs | `--plugin-endpoints` flag not set or parsed incorrectly |
+| "no plugin endpoint configured for handler" on connection create | `pluginClients` map empty in extensionapi |
+| SSM registration fails | IRSA/PodIdentity not shared to sidecar (both containers share the pod's SA) |
+| `CLUSTER_ID` empty in sidecar | Check Makefile passes `$(EKS_CONTEXT)` correctly |

--- a/guided-charts/aws-hyperpod/templates/validations.tpl
+++ b/guided-charts/aws-hyperpod/templates/validations.tpl
@@ -23,5 +23,111 @@
 {{- fail "remoteAccess.ssmSidecarImage.tag is required when remoteAccess.enabled is true" }}
 {{- end }}
 
+{{/* Validate rotator and JWT configuration when clusterWebUI is enabled */}}
+{{- if .Values.clusterWebUI.enabled }}
+
+{{/* Parse jwtExpiration to minutes */}}
+{{- $jwtExpirationMinutes := 0 }}
+{{- if hasSuffix "h" .Values.clusterWebUI.auth.jwtExpiration }}
+{{- $jwtExpirationMinutes = (trimSuffix "h" .Values.clusterWebUI.auth.jwtExpiration | int | mul 60) }}
+{{- else if hasSuffix "m" .Values.clusterWebUI.auth.jwtExpiration }}
+{{- $jwtExpirationMinutes = (trimSuffix "m" .Values.clusterWebUI.auth.jwtExpiration | int) }}
+{{- else }}
+{{- fail "clusterWebUI.auth.jwtExpiration must end with 'm' (minutes) or 'h' (hours)" }}
+{{- end }}
+
+{{/* Parse jwtExpiration to seconds (for sub-minute comparisons) */}}
+{{- $jwtExpirationSeconds := (mul $jwtExpirationMinutes 60) }}
+
+{{/* Parse jwtRefreshWindow to seconds */}}
+{{- $jwtRefreshWindowSeconds := 0 }}
+{{- if hasSuffix "h" .Values.clusterWebUI.auth.jwtRefreshWindow }}
+{{- $jwtRefreshWindowSeconds = (trimSuffix "h" .Values.clusterWebUI.auth.jwtRefreshWindow | int | mul 3600) }}
+{{- else if hasSuffix "m" .Values.clusterWebUI.auth.jwtRefreshWindow }}
+{{- $jwtRefreshWindowSeconds = (trimSuffix "m" .Values.clusterWebUI.auth.jwtRefreshWindow | int | mul 60) }}
+{{- else if hasSuffix "s" .Values.clusterWebUI.auth.jwtRefreshWindow }}
+{{- $jwtRefreshWindowSeconds = (trimSuffix "s" .Values.clusterWebUI.auth.jwtRefreshWindow | int) }}
+{{- else }}
+{{- fail "clusterWebUI.auth.jwtRefreshWindow must end with 's', 'm', or 'h'" }}
+{{- end }}
+
+{{/* Validate: jwtRefreshWindow <= jwtExpiration */}}
+{{- if gt $jwtRefreshWindowSeconds $jwtExpirationSeconds }}
+{{- fail (printf "clusterWebUI.auth.jwtRefreshWindow (%s) must be less than or equal to jwtExpiration (%s)" .Values.clusterWebUI.auth.jwtRefreshWindow .Values.clusterWebUI.auth.jwtExpiration) }}
+{{- end }}
+
+{{/* Parse jwtRefreshHorizon to seconds */}}
+{{- $jwtRefreshHorizonSeconds := 0 }}
+{{- if hasSuffix "h" .Values.clusterWebUI.auth.jwtRefreshHorizon }}
+{{- $jwtRefreshHorizonSeconds = (trimSuffix "h" .Values.clusterWebUI.auth.jwtRefreshHorizon | int | mul 3600) }}
+{{- else if hasSuffix "m" .Values.clusterWebUI.auth.jwtRefreshHorizon }}
+{{- $jwtRefreshHorizonSeconds = (trimSuffix "m" .Values.clusterWebUI.auth.jwtRefreshHorizon | int | mul 60) }}
+{{- else }}
+{{- fail "clusterWebUI.auth.jwtRefreshHorizon must end with 'm' (minutes) or 'h' (hours)" }}
+{{- end }}
+
+{{/* Validate: jwtRefreshHorizon >= jwtExpiration */}}
+{{- if lt $jwtRefreshHorizonSeconds $jwtExpirationSeconds }}
+{{- fail (printf "clusterWebUI.auth.jwtRefreshHorizon (%s) must be greater than or equal to jwtExpiration (%s)" .Values.clusterWebUI.auth.jwtRefreshHorizon .Values.clusterWebUI.auth.jwtExpiration) }}
+{{- end }}
+
+{{/* Validate rotator configuration */}}
+{{- if .Values.clusterWebUI.rotator.enabled }}
+{{- if not .Values.clusterWebUI.rotator.rotationInterval }}
+{{- fail "clusterWebUI.rotator.rotationInterval is required when rotator is enabled" }}
+{{- end }}
+{{- if not (or (hasSuffix "m" .Values.clusterWebUI.rotator.rotationInterval) (hasSuffix "h" .Values.clusterWebUI.rotator.rotationInterval)) }}
+{{- fail "clusterWebUI.rotator.rotationInterval must end with 'm' (minutes) or 'h' (hours)" }}
+{{- end }}
+{{- if not .Values.clusterWebUI.rotator.numberOfKeys }}
+{{- fail "clusterWebUI.rotator.numberOfKeys is required when rotator is enabled" }}
+{{- end }}
+{{- if lt (.Values.clusterWebUI.rotator.numberOfKeys | int) 1 }}
+{{- fail "clusterWebUI.rotator.numberOfKeys must be at least 1" }}
+{{- end }}
+
+{{/* Parse rotationInterval to minutes */}}
+{{- $rotationIntervalMinutes := 0 }}
+{{- if hasSuffix "h" .Values.clusterWebUI.rotator.rotationInterval }}
+{{- $rotationIntervalMinutes = (trimSuffix "h" .Values.clusterWebUI.rotator.rotationInterval | int | mul 60) }}
+{{- else if hasSuffix "m" .Values.clusterWebUI.rotator.rotationInterval }}
+{{- $rotationIntervalMinutes = (trimSuffix "m" .Values.clusterWebUI.rotator.rotationInterval | int) }}
+{{- end }}
+
+{{/* Validate key retention: numberOfKeys * rotationInterval >= jwtExpiration + 30min buffer */}}
+{{- $retentionMinutes := (mul (.Values.clusterWebUI.rotator.numberOfKeys | int) $rotationIntervalMinutes) }}
+{{- $requiredRetentionMinutes := (add $jwtExpirationMinutes 30) }}
+{{- if lt $retentionMinutes $requiredRetentionMinutes }}
+{{- fail (printf "Key retention (%d min) must be >= JWT expiration + 30min buffer (%d min). Increase numberOfKeys or rotationInterval." $retentionMinutes $requiredRetentionMinutes) }}
+{{- end }}
+
+{{/* Parse jwtNewKeyUseDelay to seconds */}}
+{{- $newKeyUseDelaySeconds := 0 }}
+{{- if hasSuffix "h" .Values.clusterWebUI.auth.jwtNewKeyUseDelay }}
+{{- $newKeyUseDelaySeconds = (trimSuffix "h" .Values.clusterWebUI.auth.jwtNewKeyUseDelay | int | mul 3600) }}
+{{- else if hasSuffix "m" .Values.clusterWebUI.auth.jwtNewKeyUseDelay }}
+{{- $newKeyUseDelaySeconds = (trimSuffix "m" .Values.clusterWebUI.auth.jwtNewKeyUseDelay | int | mul 60) }}
+{{- else if hasSuffix "s" .Values.clusterWebUI.auth.jwtNewKeyUseDelay }}
+{{- $newKeyUseDelaySeconds = (trimSuffix "s" .Values.clusterWebUI.auth.jwtNewKeyUseDelay | int) }}
+{{- else }}
+{{- fail "clusterWebUI.auth.jwtNewKeyUseDelay must end with 's' (seconds), 'm' (minutes), or 'h' (hours)" }}
+{{- end }}
+
+{{/* Validate: jwtNewKeyUseDelay < jwtExpiration */}}
+{{- if ge $newKeyUseDelaySeconds $jwtExpirationSeconds }}
+{{- fail (printf "clusterWebUI.auth.jwtNewKeyUseDelay (%s = %d sec) must be less than jwtExpiration (%s = %d sec)" .Values.clusterWebUI.auth.jwtNewKeyUseDelay $newKeyUseDelaySeconds .Values.clusterWebUI.auth.jwtExpiration $jwtExpirationSeconds) }}
+{{- end }}
+
+{{/* Convert rotationInterval to seconds */}}
+{{- $rotationIntervalSeconds := (mul $rotationIntervalMinutes 60) }}
+
+{{/* Validate: jwtNewKeyUseDelay < rotationInterval */}}
+{{- if ge $newKeyUseDelaySeconds $rotationIntervalSeconds }}
+{{- fail (printf "clusterWebUI.auth.jwtNewKeyUseDelay (%s = %d sec) must be less than rotator.rotationInterval (%s = %d sec)" .Values.clusterWebUI.auth.jwtNewKeyUseDelay $newKeyUseDelaySeconds .Values.clusterWebUI.rotator.rotationInterval $rotationIntervalSeconds) }}
+{{- end }}
+{{- end }}{{/* end rotator.enabled */}}
+
+{{- end }}{{/* end clusterWebUI.enabled */}}
+
 # This file intentionally does not produce any Kubernetes resources
 # It only validates and sets default values

--- a/guided-charts/aws-hyperpod/values.yaml
+++ b/guided-charts/aws-hyperpod/values.yaml
@@ -60,7 +60,7 @@ clusterWebUI:
         memory: 256Mi
     jwtIssuer: "jupyter-k8s-auth"
     jwtAudience: "workspace-users"
-    jwtExpiration: "3h"
+    jwtExpiration: "1h"
     jwtRefreshEnable: "true"
     jwtRefreshWindow: "15m"
     jwtRefreshHorizon: "12h"
@@ -96,8 +96,8 @@ clusterWebUI:
     rotationInterval: "15m"
     # Number of keys to keep (older keys are pruned after rotation)
     # Must satisfy: numberOfKeys * rotationInterval >= jwtExpiration + buffer
-    # 14 keys * 15m rotation = 3.5h retention >= 3h expiration
-    numberOfKeys: 14
+    # 6 keys * 15m rotation = 90m retention >= 1h expiration + 30m buffer
+    numberOfKeys: 6
     resources:
       limits:
         cpu: 100m

--- a/guided-charts/aws-traefik-dex/AGENT.md
+++ b/guided-charts/aws-traefik-dex/AGENT.md
@@ -1,0 +1,140 @@
+# Testing: aws-traefik-dex Guided Chart
+
+This chart deploys the OSS routing stack: Traefik reverse proxy, Dex OIDC provider with GitHub OAuth,
+OAuth2-proxy, authmiddleware, and JWT key rotation. It does NOT use `--plugin-endpoints` — there are
+no plugins. It exercises the k8s-native bearer token path (HMAC JWT via Kubernetes Secret).
+
+## Prerequisites
+
+- An EKS cluster (the OSS chart does not require Pod Identity / IRSA)
+- `.env` file with `AWS_REGION`, `EKS_CLUSTER_NAME`, domain, GitHub OAuth, and EFS values (see `.env.example`)
+- kubectl context pointing at the target cluster
+- A domain with DNS pointing to the cluster (for Traefik ingress + Let's Encrypt)
+
+```bash
+make setup-aws                        # configure kubectl context from .env
+```
+
+**Default cluster:** `jupyter-k8s-cluster` in `us-west-2` (`.env` defaults).
+If switching from another cluster (e.g. parker in us-east-2), update `.env` and run:
+
+```bash
+make kubectl-aws                      # switch kubectl context
+```
+
+## Clean Slate
+
+If there's an existing deployment, tear it down in dependency order:
+
+```bash
+kubectl delete workspaces --all --all-namespaces --wait
+helm uninstall aws-traefik-dex -n jupyter-k8s-system 2>/dev/null; true
+helm uninstall jk8s -n jupyter-k8s-system
+kubectl delete crd workspaces.workspace.jupyter.org \
+  workspaceaccessstrategies.workspace.jupyter.org \
+  workspacetemplates.workspace.jupyter.org 2>/dev/null; true
+```
+
+## Build and Generate
+
+```bash
+make build                            # compile Go binaries
+make helm-generate                    # generate dist/chart from config/
+make helm-lint                        # lint all charts (operator + guided)
+```
+
+## Deploy
+
+The OSS chart is deployed without plugins:
+
+```bash
+make deploy-aws                       # operator chart WITHOUT PLUGINS=aws
+make deploy-aws-traefik-dex           # OSS guided chart (reads .env for domain, GitHub, EFS)
+```
+
+**Checks:**
+
+1. **Controller pod has 1 container** (no sidecar):
+   ```bash
+   kubectl get pods -n jupyter-k8s-system -l control-plane=controller-manager \
+     -o jsonpath='{.items[0].spec.containers[*].name}'
+   ```
+   Expected: `manager` (no `plugin-aws`)
+
+2. **No `--plugin-endpoints` in manager args**:
+   ```bash
+   kubectl describe pod -n jupyter-k8s-system -l control-plane=controller-manager | grep plugin-endpoints
+   ```
+   Expected: empty
+
+3. **Manager logs** show no plugin-related errors:
+   ```bash
+   kubectl logs -n jupyter-k8s-system -l control-plane=controller-manager -c manager --tail=20
+   ```
+
+4. **AccessStrategy uses k8s-native only** (no `createConnectionHandlerMap`, no `podEventsContext`):
+   ```bash
+   kubectl get workspaceaccessstrategy -n jupyter-k8s-system -o yaml
+   ```
+   - `createConnectionHandler: "k8s-native"`
+   - No `podEventsHandler`, `createConnectionHandlerMap`, or `podEventsContext` fields
+
+5. **Full routing stack is running**:
+   ```bash
+   kubectl get pods -n jupyter-k8s-system
+   ```
+   Expect: controller, authmiddleware replicas, traefik replicas, and completed rotator jobs.
+
+## Create and Test Workspaces
+
+```bash
+make apply-sample-routing WS_USER=<your-user>
+kubectl get workspaces -n default
+kubectl wait --for=condition=Available workspaces --all -n default --timeout=300s
+```
+
+### Verify Bearer Token Flow (Web UI)
+
+```bash
+make bearer-token WS_NAME=<workspace-name>
+```
+
+Should return a URL with a JWT token. Open in browser — the bearer auth middleware creates
+a session JWT and sets a cookie, then routes through Traefik to the workspace.
+
+Alternatively, test via port-forward:
+```bash
+make port-forward
+```
+
+### Verify GitHub OAuth Flow
+
+Access a workspace URL directly in browser (without bearer token):
+- Should redirect to Dex -> GitHub login -> workspace
+- Only users in the configured GitHub org/team should be granted access
+
+### Verify JWT Key Rotation
+
+Check that the rotator CronJob is running and the secret has multiple keys:
+```bash
+kubectl get cronjob -n jupyter-k8s-system
+kubectl get secret authmiddleware-secrets -n jupyter-k8s-system -o jsonpath='{.data}' | jq 'keys'
+```
+
+## Cleanup
+
+```bash
+make delete-sample-routing
+```
+
+No errors should appear in controller logs.
+
+## Failure Modes
+
+| Symptom | Likely cause |
+|---------|-------------|
+| Authmiddleware CrashLoopBackOff | JWT secret not found — check `secretName` matches between auth deployment and rotator |
+| Certificate not issued | cert-manager not installed, or DNS not pointing to cluster |
+| OAuth redirect fails | GitHub OAuth app callback URL mismatch with domain, or Dex configmap has wrong issuer URL |
+| Bearer token returns 403 | `enableBearerAuth` not set to true, or RBAC missing for `bearertokenreviews` |
+| Rotator job fails | ServiceAccount missing RBAC to update the JWT secret |

--- a/guided-charts/aws-traefik-dex/templates/validations.tpl
+++ b/guided-charts/aws-traefik-dex/templates/validations.tpl
@@ -33,6 +33,44 @@
 {{- fail "oauth2Proxy.cookieSecret is required" }}
 {{- end }}
 
+{{/* Validate JWT refresh settings */}}
+{{- $jwtRefreshWindowSeconds := 0 }}
+{{- if hasSuffix "h" .Values.authmiddleware.jwtRefreshWindow }}
+{{- $jwtRefreshWindowSeconds = (trimSuffix "h" .Values.authmiddleware.jwtRefreshWindow | int | mul 3600) }}
+{{- else if hasSuffix "m" .Values.authmiddleware.jwtRefreshWindow }}
+{{- $jwtRefreshWindowSeconds = (trimSuffix "m" .Values.authmiddleware.jwtRefreshWindow | int | mul 60) }}
+{{- else if hasSuffix "s" .Values.authmiddleware.jwtRefreshWindow }}
+{{- $jwtRefreshWindowSeconds = (trimSuffix "s" .Values.authmiddleware.jwtRefreshWindow | int) }}
+{{- else }}
+{{- fail "authmiddleware.jwtRefreshWindow must end with 's', 'm', or 'h'" }}
+{{- end }}
+
+{{- $jwtExpirationSecondsForRefresh := 0 }}
+{{- if hasSuffix "h" .Values.authmiddleware.jwtExpiration }}
+{{- $jwtExpirationSecondsForRefresh = (trimSuffix "h" .Values.authmiddleware.jwtExpiration | int | mul 3600) }}
+{{- else if hasSuffix "m" .Values.authmiddleware.jwtExpiration }}
+{{- $jwtExpirationSecondsForRefresh = (trimSuffix "m" .Values.authmiddleware.jwtExpiration | int | mul 60) }}
+{{- end }}
+
+{{/* Validate: jwtRefreshWindow <= jwtExpiration */}}
+{{- if gt $jwtRefreshWindowSeconds $jwtExpirationSecondsForRefresh }}
+{{- fail (printf "authmiddleware.jwtRefreshWindow (%s) must be less than or equal to jwtExpiration (%s)" .Values.authmiddleware.jwtRefreshWindow .Values.authmiddleware.jwtExpiration) }}
+{{- end }}
+
+{{- $jwtRefreshHorizonSeconds := 0 }}
+{{- if hasSuffix "h" .Values.authmiddleware.jwtRefreshHorizon }}
+{{- $jwtRefreshHorizonSeconds = (trimSuffix "h" .Values.authmiddleware.jwtRefreshHorizon | int | mul 3600) }}
+{{- else if hasSuffix "m" .Values.authmiddleware.jwtRefreshHorizon }}
+{{- $jwtRefreshHorizonSeconds = (trimSuffix "m" .Values.authmiddleware.jwtRefreshHorizon | int | mul 60) }}
+{{- else }}
+{{- fail "authmiddleware.jwtRefreshHorizon must end with 'm' (minutes) or 'h' (hours)" }}
+{{- end }}
+
+{{/* Validate: jwtRefreshHorizon >= jwtExpiration */}}
+{{- if lt $jwtRefreshHorizonSeconds $jwtExpirationSecondsForRefresh }}
+{{- fail (printf "authmiddleware.jwtRefreshHorizon (%s) must be greater than or equal to jwtExpiration (%s)" .Values.authmiddleware.jwtRefreshHorizon .Values.authmiddleware.jwtExpiration) }}
+{{- end }}
+
 {{/* Validate rotator configuration if enabled */}}
 {{- if .Values.rotator.enabled }}
 {{- if not .Values.rotator.rotationInterval }}

--- a/internal/authmiddleware/serverroute_verify.go
+++ b/internal/authmiddleware/serverroute_verify.go
@@ -79,7 +79,7 @@ func (s *Server) handleVerify(w http.ResponseWriter, r *http.Request) {
 
 		// UNHAPPY CASE 1: we can't check authZ for some reason, stop attempting to refresh
 		if accessErr != nil {
-			s.logger.Warn("Failed to retrieve the accessReview for cookie refresh", "error", err)
+			s.logger.Warn("Failed to retrieve the accessReview for cookie refresh", "error", accessErr)
 			newToken, err := s.jwtManager.UpdateSkipRefreshToken(claims)
 			if err != nil {
 				s.logger.Warn("Failed to update token to skip", "error", err)

--- a/internal/extensionapi/serverroute_connection.go
+++ b/internal/extensionapi/serverroute_connection.go
@@ -139,8 +139,10 @@ func (s *ExtensionServer) generateBearerTokenURL(r *http.Request, ws *workspacev
 		}
 	}
 
-	// Generate JWT token with domain and path using access strategy-specific signer
-	token, err := signer.GenerateToken(user, []string{}, user, map[string][]string{}, path, domain, jwt.TokenTypeBootstrap)
+	// Generate JWT token with domain and path using access strategy-specific signer.
+	// skipRefresh=true: bootstrap tokens are exchanged immediately for session tokens
+	// via /bearer-auth, so refresh is not applicable.
+	token, err := signer.GenerateToken(user, []string{}, user, map[string][]string{}, path, domain, jwt.TokenTypeBootstrap, true)
 	if err != nil {
 		return "", fmt.Errorf("failed to generate JWT token: %w", err)
 	}

--- a/internal/extensionapi/serverroute_connection.go
+++ b/internal/extensionapi/serverroute_connection.go
@@ -102,6 +102,8 @@ func (s *ExtensionServer) generateBearerTokenURL(r *http.Request, ws *workspacev
 	if user == "" {
 		return "", fmt.Errorf("user information not found in request headers")
 	}
+	groups := GetGroups(r)
+	extra := GetExtra(r)
 
 	if accessStrategy == nil {
 		return "", fmt.Errorf("no AccessStrategy configured for workspace")
@@ -142,7 +144,7 @@ func (s *ExtensionServer) generateBearerTokenURL(r *http.Request, ws *workspacev
 	// Generate JWT token with domain and path using access strategy-specific signer.
 	// skipRefresh=true: bootstrap tokens are exchanged immediately for session tokens
 	// via /bearer-auth, so refresh is not applicable.
-	token, err := signer.GenerateToken(user, []string{}, user, map[string][]string{}, path, domain, jwt.TokenTypeBootstrap, true)
+	token, err := signer.GenerateToken(user, groups, user, extra, path, domain, jwt.TokenTypeBootstrap, true)
 	if err != nil {
 		return "", fmt.Errorf("failed to generate JWT token: %w", err)
 	}

--- a/internal/extensionapi/serverroute_connection_test.go
+++ b/internal/extensionapi/serverroute_connection_test.go
@@ -44,7 +44,11 @@ type mockSigner struct {
 	token string
 }
 
-func (m *mockSigner) GenerateToken(user string, groups []string, uid string, extra map[string][]string, path string, domain string, tokenType string) (string, error) {
+func (m *mockSigner) GenerateToken(user string, groups []string, uid string, extra map[string][]string, path string, domain string, tokenType string, skipRefresh bool) (string, error) {
+	return m.token, nil
+}
+
+func (m *mockSigner) GenerateRefreshToken(claims *jwt.Claims) (string, error) {
 	return m.token, nil
 }
 

--- a/internal/extensionapi/serverroute_connection_test.go
+++ b/internal/extensionapi/serverroute_connection_test.go
@@ -23,6 +23,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/endpoints/request"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -42,9 +44,14 @@ func (m *mockSignerFactory) CreateSigner(accessStrategy *workspacev1alpha1.Works
 // mockSigner for testing
 type mockSigner struct {
 	token string
+	// captured args from last GenerateToken call
+	lastGroups []string
+	lastExtra  map[string][]string
 }
 
-func (m *mockSigner) GenerateToken(user string, groups []string, uid string, extra map[string][]string, path string, domain string, tokenType string, skipRefresh bool) (string, error) {
+func (m *mockSigner) GenerateToken(username string, groups []string, uid string, extra map[string][]string, path string, domain string, tokenType string, skipRefresh bool) (string, error) {
+	m.lastGroups = groups
+	m.lastExtra = extra
 	return m.token, nil
 }
 
@@ -155,6 +162,113 @@ func TestGenerateBearerTokenURL_SubdomainRouting(t *testing.T) {
 	expected := "https://myworkspace-mrswmylvnr2a.example.com/bearer-auth?token=test-token"
 	if url != expected {
 		t.Errorf("expected %s, got %s", expected, url)
+	}
+}
+
+func TestGenerateBearerTokenURL_PassesGroupsAndExtra(t *testing.T) {
+	workspace := &workspacev1alpha1.Workspace{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
+		Spec: workspacev1alpha1.WorkspaceSpec{
+			AccessStrategy: &workspacev1alpha1.AccessStrategyRef{Name: "test-strategy"},
+		},
+	}
+
+	accessStrategy := &workspacev1alpha1.WorkspaceAccessStrategy{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-strategy", Namespace: "default"},
+		Spec: workspacev1alpha1.WorkspaceAccessStrategySpec{
+			BearerAuthURLTemplate: "https://test.com/bearer-auth",
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	_ = workspacev1alpha1.AddToScheme(scheme)
+	fakeClient := ctrlclient.NewClientBuilder().WithScheme(scheme).WithObjects(workspace, accessStrategy).Build()
+
+	signer := &mockSigner{token: "test-token"}
+	server := &ExtensionServer{
+		config:        &ExtensionConfig{},
+		signerFactory: &mockSignerFactory{signer: signer},
+		k8sClient:     fakeClient,
+	}
+
+	req := httptest.NewRequest("POST", "/test", nil)
+	userInfo := &user.DefaultInfo{
+		Name:   testUser,
+		Groups: []string{"cluster-workspace-admin", "system:authenticated"},
+		Extra: map[string][]string{
+			"arn":          {"arn:aws:sts::123456:assumed-role/Admin/session"},
+			"canonicalarn": {"arn:aws:iam::123456:role/Admin"},
+		},
+	}
+	ctx := request.WithUser(req.Context(), userInfo)
+	req = req.WithContext(ctx)
+
+	_, err := server.generateBearerTokenURL(req, workspace, accessStrategy)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify groups were passed to the signer
+	if len(signer.lastGroups) != 2 {
+		t.Fatalf("expected 2 groups, got %d: %v", len(signer.lastGroups), signer.lastGroups)
+	}
+	if signer.lastGroups[0] != "cluster-workspace-admin" || signer.lastGroups[1] != "system:authenticated" {
+		t.Errorf("unexpected groups: %v", signer.lastGroups)
+	}
+
+	// Verify extra was passed to the signer
+	if len(signer.lastExtra) != 2 {
+		t.Fatalf("expected 2 extra keys, got %d: %v", len(signer.lastExtra), signer.lastExtra)
+	}
+	if signer.lastExtra["arn"][0] != "arn:aws:sts::123456:assumed-role/Admin/session" {
+		t.Errorf("unexpected extra arn: %v", signer.lastExtra["arn"])
+	}
+	if signer.lastExtra["canonicalarn"][0] != "arn:aws:iam::123456:role/Admin" {
+		t.Errorf("unexpected extra canonicalarn: %v", signer.lastExtra["canonicalarn"])
+	}
+}
+
+func TestGenerateBearerTokenURL_NoContextFallsBackToEmptyGroupsAndExtra(t *testing.T) {
+	workspace := &workspacev1alpha1.Workspace{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
+		Spec: workspacev1alpha1.WorkspaceSpec{
+			AccessStrategy: &workspacev1alpha1.AccessStrategyRef{Name: "test-strategy"},
+		},
+	}
+
+	accessStrategy := &workspacev1alpha1.WorkspaceAccessStrategy{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-strategy", Namespace: "default"},
+		Spec: workspacev1alpha1.WorkspaceAccessStrategySpec{
+			BearerAuthURLTemplate: "https://test.com/bearer-auth",
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	_ = workspacev1alpha1.AddToScheme(scheme)
+	fakeClient := ctrlclient.NewClientBuilder().WithScheme(scheme).WithObjects(workspace, accessStrategy).Build()
+
+	signer := &mockSigner{token: "test-token"}
+	server := &ExtensionServer{
+		config:        &ExtensionConfig{},
+		signerFactory: &mockSignerFactory{signer: signer},
+		k8sClient:     fakeClient,
+	}
+
+	// Request with header-based user, no Kubernetes context
+	req := httptest.NewRequest("POST", "/test", nil)
+	req.Header.Set("X-Remote-User", testUser)
+
+	_, err := server.generateBearerTokenURL(req, workspace, accessStrategy)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Groups and extra should be nil when no k8s context
+	if signer.lastGroups != nil {
+		t.Errorf("expected nil groups, got %v", signer.lastGroups)
+	}
+	if signer.lastExtra != nil {
+		t.Errorf("expected nil extra, got %v", signer.lastExtra)
 	}
 }
 
@@ -809,9 +923,9 @@ func TestGetUserFromHeaders(t *testing.T) {
 	req := httptest.NewRequest("GET", "/test", nil)
 	req.Header.Set("X-Remote-User", testUser)
 
-	user := GetUser(req)
-	if user != testUser {
-		t.Errorf("expected %s, got %s", testUser, user)
+	username := GetUser(req)
+	if username != testUser {
+		t.Errorf("expected %s, got %s", testUser, username)
 	}
 }
 

--- a/internal/extensionapi/utils.go
+++ b/internal/extensionapi/utils.go
@@ -67,3 +67,31 @@ func GetUser(r *http.Request) string {
 
 	return ""
 }
+
+// GetGroups extracts the user's groups from the Kubernetes request context
+func GetGroups(r *http.Request) []string {
+	if userInfo, ok := request.UserFrom(r.Context()); ok {
+		if userInfo != nil {
+			return userInfo.GetGroups()
+		}
+	}
+	return nil
+}
+
+// GetExtra extracts the user's extra info from the Kubernetes request context
+func GetExtra(r *http.Request) map[string][]string {
+	if userInfo, ok := request.UserFrom(r.Context()); ok {
+		if userInfo != nil {
+			kubeExtra := userInfo.GetExtra()
+			if len(kubeExtra) == 0 {
+				return nil
+			}
+			extra := make(map[string][]string, len(kubeExtra))
+			for k, v := range kubeExtra {
+				extra[k] = v
+			}
+			return extra
+		}
+	}
+	return nil
+}

--- a/internal/jwt/composite_signer_factory_test.go
+++ b/internal/jwt/composite_signer_factory_test.go
@@ -106,7 +106,7 @@ func TestCompositeSignerFactory_ValidateToken_Success(t *testing.T) {
 	}, factory)
 
 	// Generate a token using the signer
-	token, err := factory.Signer().GenerateToken("alice", []string{"team-a"}, "alice-uid", nil, "/workspaces/default/ws", "example.com", TokenTypeBootstrap)
+	token, err := factory.Signer().GenerateToken("alice", []string{"team-a"}, "alice-uid", nil, "/workspaces/default/ws", "example.com", TokenTypeBootstrap, false)
 	require.NoError(t, err)
 
 	// Validate through composite
@@ -146,7 +146,7 @@ func TestCompositeSignerFactory_ValidateToken_MultipleFactories(t *testing.T) {
 		"second": factory2,
 	}, factory1)
 
-	token, err := factory2.Signer().GenerateToken("bob", nil, "bob", nil, "/ws", "test.com", TokenTypeBootstrap)
+	token, err := factory2.Signer().GenerateToken("bob", nil, "bob", nil, "/ws", "test.com", TokenTypeBootstrap, false)
 	require.NoError(t, err)
 
 	claims, err := composite.ValidateToken(token)
@@ -169,7 +169,7 @@ func TestCompositeSignerFactory_ValidateToken_CreateSignerError(t *testing.T) {
 		"good":   goodFactory,
 	}, goodFactory)
 
-	token, err := goodFactory.Signer().GenerateToken("alice", nil, "uid", nil, "/ws", "d.com", TokenTypeBootstrap)
+	token, err := goodFactory.Signer().GenerateToken("alice", nil, "uid", nil, "/ws", "d.com", TokenTypeBootstrap, false)
 	require.NoError(t, err)
 
 	claims, err := composite.ValidateToken(token)

--- a/internal/jwt/handler.go
+++ b/internal/jwt/handler.go
@@ -8,6 +8,7 @@ package jwt
 
 import (
 	"errors"
+	"fmt"
 	"time"
 )
 
@@ -48,7 +49,7 @@ func (m *Manager) GenerateToken(
 	domain string,
 	tokenType string,
 ) (string, error) {
-	return m.signer.GenerateToken(user, groups, uid, extra, path, domain, tokenType)
+	return m.signer.GenerateToken(user, groups, uid, extra, path, domain, tokenType, false)
 }
 
 // ValidateToken delegates to the signer
@@ -56,42 +57,42 @@ func (m *Manager) ValidateToken(tokenString string) (*Claims, error) {
 	return m.signer.ValidateToken(tokenString)
 }
 
-// RefreshToken creates a new token with the same claims
+// RefreshToken creates a new token preserving the original IssuedAt for horizon tracking.
+// Returns an error if the token is beyond the refresh horizon, forcing re-authentication.
 func (m *Manager) RefreshToken(claims *Claims) (string, error) {
 	if claims == nil {
 		return "", errors.New("claims cannot be nil")
 	}
 
-	return m.signer.GenerateToken(
-		claims.User,
-		claims.Groups,
-		claims.UID,
-		claims.Extra,
-		claims.Path,
-		claims.Domain,
-		claims.TokenType,
-	)
+	now := time.Now().UTC()
+	timeSinceOriginalIssuance := now.Sub(claims.IssuedAt.Time)
+
+	if timeSinceOriginalIssuance >= m.refreshHorizon {
+		return "", fmt.Errorf("token beyond refresh horizon (%v since issuance, limit %v)", timeSinceOriginalIssuance, m.refreshHorizon)
+	}
+
+	// Within horizon: refresh preserving the original IssuedAt
+	return m.signer.GenerateRefreshToken(claims)
 }
 
-// UpdateSkipRefreshToken creates a new token with skipRefresh=true
+// UpdateSkipRefreshToken creates a new token with skipRefresh=true.
+// Used when the access review fails during refresh — stops further refresh attempts.
 func (m *Manager) UpdateSkipRefreshToken(claims *Claims) (string, error) {
 	if claims == nil {
 		return "", errors.New("claims cannot be nil")
 	}
 
-	claims.SkipRefresh = true
 	return m.signer.GenerateToken(
-		claims.User,
-		claims.Groups,
-		claims.UID,
-		claims.Extra,
-		claims.Path,
-		claims.Domain,
-		claims.TokenType,
+		claims.User, claims.Groups, claims.UID, claims.Extra,
+		claims.Path, claims.Domain, claims.TokenType, true,
 	)
 }
 
-// ShouldRefreshToken determines if a token should be refreshed
+// ShouldRefreshToken determines if a token should be refreshed.
+// Returns true when the token is within the refresh window (approaching expiry)
+// and not already marked as skip-refresh.
+// The refresh horizon is enforced by RefreshToken, not here — so tokens beyond the
+// horizon still get one final refresh with SkipRefresh=true.
 func (m *Manager) ShouldRefreshToken(claims *Claims) bool {
 	if !m.enableRefresh {
 		return false
@@ -105,16 +106,5 @@ func (m *Manager) ShouldRefreshToken(claims *Claims) bool {
 	expiryTime := claims.ExpiresAt.Time
 	remainingTime := expiryTime.Sub(now)
 
-	if remainingTime <= 0 {
-		return false
-	}
-
-	if remainingTime > m.refreshWindow {
-		return false
-	}
-
-	originalIssueTime := claims.IssuedAt.Time
-	timeSinceOriginalIssuance := now.Sub(originalIssueTime)
-
-	return timeSinceOriginalIssuance < m.refreshHorizon
+	return remainingTime > 0 && remainingTime <= m.refreshWindow
 }

--- a/internal/jwt/handler_test.go
+++ b/internal/jwt/handler_test.go
@@ -6,6 +6,7 @@ Distributed under the terms of the MIT license
 package jwt
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -16,13 +17,21 @@ const mockTokenValue = "mock-token"
 
 // mockSigner implements Signer for testing
 type mockSigner struct {
-	generateFunc func(user string, groups []string, uid string, extra map[string][]string, path string, domain string, tokenType string) (string, error)
-	validateFunc func(tokenString string) (*Claims, error)
+	generateFunc     func(user string, groups []string, uid string, extra map[string][]string, path string, domain string, tokenType string, skipRefresh bool) (string, error)
+	validateFunc     func(tokenString string) (*Claims, error)
+	refreshTokenFunc func(claims *Claims) (string, error)
 }
 
-func (m *mockSigner) GenerateToken(user string, groups []string, uid string, extra map[string][]string, path string, domain string, tokenType string) (string, error) {
+func (m *mockSigner) GenerateToken(user string, groups []string, uid string, extra map[string][]string, path string, domain string, tokenType string, skipRefresh bool) (string, error) {
 	if m.generateFunc != nil {
-		return m.generateFunc(user, groups, uid, extra, path, domain, tokenType)
+		return m.generateFunc(user, groups, uid, extra, path, domain, tokenType, skipRefresh)
+	}
+	return mockTokenValue, nil
+}
+
+func (m *mockSigner) GenerateRefreshToken(claims *Claims) (string, error) {
+	if m.refreshTokenFunc != nil {
+		return m.refreshTokenFunc(claims)
 	}
 	return mockTokenValue, nil
 }
@@ -193,9 +202,6 @@ func TestManager_UpdateSkipRefreshToken_Success(t *testing.T) {
 	if token != mockTokenValue {
 		t.Fatalf("Expected '%s', got %s", mockTokenValue, token)
 	}
-	if !claims.SkipRefresh {
-		t.Fatal("Expected SkipRefresh to be set to true")
-	}
 }
 
 func TestManager_UpdateSkipRefreshToken_NilClaims(t *testing.T) {
@@ -228,7 +234,7 @@ func TestManager_ShouldRefreshToken_AlreadyExpired(t *testing.T) {
 	}
 }
 
-func TestManager_ShouldRefreshToken_BeyondHorizon(t *testing.T) {
+func TestManager_ShouldRefreshToken_BeyondHorizon_StillReturnsTrue(t *testing.T) {
 	signer := &mockSigner{}
 	manager := NewManager(signer, true, 10*time.Minute, time.Hour)
 
@@ -240,8 +246,8 @@ func TestManager_ShouldRefreshToken_BeyondHorizon(t *testing.T) {
 		},
 	}
 
-	if manager.ShouldRefreshToken(claims) {
-		t.Fatal("Expected no refresh when beyond refresh horizon")
+	if !manager.ShouldRefreshToken(claims) {
+		t.Fatal("Expected token to need refresh (horizon is enforced in RefreshToken, not ShouldRefreshToken)")
 	}
 }
 
@@ -276,5 +282,92 @@ func TestManager_ShouldRefreshToken_NilIssuedAt(t *testing.T) {
 	// This should not panic and should return false
 	if manager.ShouldRefreshToken(claims) {
 		t.Fatal("Expected no refresh when IssuedAt is nil")
+	}
+}
+
+func TestManager_RefreshToken_PreservesIssuedAt(t *testing.T) {
+	originalIssuedAt := time.Now().UTC().Add(-30 * time.Minute)
+	refreshCalled := false
+
+	signer := &mockSigner{
+		refreshTokenFunc: func(claims *Claims) (string, error) {
+			refreshCalled = true
+			// Verify the claims passed have the original IssuedAt
+			if claims.IssuedAt.Unix() != originalIssuedAt.Unix() {
+				t.Errorf("Expected IssuedAt %v, got %v", originalIssuedAt, claims.IssuedAt.Time)
+			}
+			return mockTokenValue, nil
+		},
+	}
+	manager := NewManager(signer, true, time.Minute, time.Hour)
+
+	claims := &Claims{
+		RegisteredClaims: jwt5.RegisteredClaims{
+			ExpiresAt: jwt5.NewNumericDate(time.Now().UTC().Add(time.Hour)),
+			IssuedAt:  jwt5.NewNumericDate(originalIssuedAt),
+		},
+		User:   "testuser",
+		Groups: []string{"group1"},
+	}
+
+	token, err := manager.RefreshToken(claims)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if token != mockTokenValue {
+		t.Fatalf("Expected '%s', got %s", mockTokenValue, token)
+	}
+	if !refreshCalled {
+		t.Fatal("Expected GenerateRefreshToken to be called")
+	}
+}
+
+func TestManager_RefreshToken_BeyondHorizon_ReturnsError(t *testing.T) {
+	signer := &mockSigner{}
+	manager := NewManager(signer, true, time.Minute, time.Hour) // 1 hour horizon
+
+	claims := &Claims{
+		RegisteredClaims: jwt5.RegisteredClaims{
+			ExpiresAt: jwt5.NewNumericDate(time.Now().UTC().Add(time.Hour)),
+			IssuedAt:  jwt5.NewNumericDate(time.Now().UTC().Add(-2 * time.Hour)), // 2 hours ago, beyond 1h horizon
+		},
+		User:   "testuser",
+		Groups: []string{"group1"},
+	}
+
+	_, err := manager.RefreshToken(claims)
+	if err == nil {
+		t.Fatal("Expected error when beyond refresh horizon")
+	}
+	if !strings.Contains(err.Error(), "beyond refresh horizon") {
+		t.Fatalf("Expected horizon error, got: %v", err)
+	}
+}
+
+func TestManager_UpdateSkipRefreshToken_SetsSkipRefreshTrue(t *testing.T) {
+	skipRefreshValue := false
+	signer := &mockSigner{
+		generateFunc: func(user string, groups []string, uid string, extra map[string][]string, path string, domain string, tokenType string, skipRefresh bool) (string, error) {
+			skipRefreshValue = skipRefresh
+			return mockTokenValue, nil
+		},
+	}
+	manager := NewManager(signer, true, time.Minute, time.Hour)
+
+	claims := &Claims{
+		RegisteredClaims: jwt5.RegisteredClaims{
+			ExpiresAt: jwt5.NewNumericDate(time.Now().UTC().Add(time.Hour)),
+			IssuedAt:  jwt5.NewNumericDate(time.Now().UTC()),
+		},
+		User:   "testuser",
+		Groups: []string{"group1"},
+	}
+
+	_, err := manager.UpdateSkipRefreshToken(claims)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if !skipRefreshValue {
+		t.Fatal("Expected GenerateToken to be called with skipRefresh=true")
 	}
 }

--- a/internal/jwt/signer.go
+++ b/internal/jwt/signer.go
@@ -7,6 +7,7 @@ package jwt
 
 // Signer handles core JWT operations - encryption-specific
 type Signer interface {
-	GenerateToken(user string, groups []string, uid string, extra map[string][]string, path string, domain string, tokenType string) (string, error)
+	GenerateToken(user string, groups []string, uid string, extra map[string][]string, path string, domain string, tokenType string, skipRefresh bool) (string, error)
+	GenerateRefreshToken(claims *Claims) (string, error)
 	ValidateToken(tokenString string) (*Claims, error)
 }

--- a/internal/jwt/standard_signer.go
+++ b/internal/jwt/standard_signer.go
@@ -82,7 +82,40 @@ func (s *StandardSigner) GenerateToken(
 	extra map[string][]string,
 	path string,
 	domain string,
-	tokenType string) (string, error) {
+	tokenType string,
+	skipRefresh bool) (string, error) {
+	now := time.Now().UTC()
+	return s.generateTokenWithIssuedAt(username, groups, uid, extra, path, domain, tokenType, skipRefresh, now)
+}
+
+// GenerateRefreshToken creates a new JWT token preserving the original IssuedAt
+// from the provided claims. This allows the refresh horizon check to work correctly
+// across multiple refresh cycles.
+func (s *StandardSigner) GenerateRefreshToken(claims *Claims) (string, error) {
+	if claims == nil {
+		return "", fmt.Errorf("claims cannot be nil")
+	}
+	if claims.IssuedAt == nil {
+		return "", fmt.Errorf("claims.IssuedAt cannot be nil")
+	}
+	return s.generateTokenWithIssuedAt(
+		claims.User, claims.Groups, claims.UID, claims.Extra,
+		claims.Path, claims.Domain, claims.TokenType, false, claims.IssuedAt.Time,
+	)
+}
+
+// generateTokenWithIssuedAt is the internal token generation method that accepts
+// both skipRefresh and issuedAt parameters.
+func (s *StandardSigner) generateTokenWithIssuedAt(
+	username string,
+	groups []string,
+	uid string,
+	extra map[string][]string,
+	path string,
+	domain string,
+	tokenType string,
+	skipRefresh bool,
+	issuedAt time.Time) (string, error) {
 	usableKid, signingKey := s.getLatestKidAndKeyWithCoolOff()
 	if usableKid == "" || signingKey == nil {
 		return "", fmt.Errorf("no signing key available beyond cooloff period (%v)", s.newKeyUseDelay)
@@ -92,7 +125,7 @@ func (s *StandardSigner) GenerateToken(
 	claims := &Claims{
 		RegisteredClaims: jwt5.RegisteredClaims{
 			ExpiresAt: jwt5.NewNumericDate(now.Add(s.expiration)),
-			IssuedAt:  jwt5.NewNumericDate(now),
+			IssuedAt:  jwt5.NewNumericDate(issuedAt),
 			NotBefore: jwt5.NewNumericDate(now),
 			Issuer:    s.issuer,
 			Audience:  []string{s.audience},
@@ -105,7 +138,7 @@ func (s *StandardSigner) GenerateToken(
 		Path:        path,
 		Domain:      domain,
 		TokenType:   tokenType,
-		SkipRefresh: false,
+		SkipRefresh: skipRefresh,
 	}
 
 	// Use HS384 and add kid to header

--- a/internal/jwt/standard_signer_factory_test.go
+++ b/internal/jwt/standard_signer_factory_test.go
@@ -113,7 +113,7 @@ func TestStandardSignerFactory_CreateSigner_GenerateValidateRoundTrip(t *testing
 	signer, err := factory.CreateSigner(accessStrategy)
 	require.NoError(t, err)
 
-	token, err := signer.GenerateToken("testuser", []string{"group1"}, "uid1", nil, "/path", "example.com", TokenTypeBootstrap)
+	token, err := signer.GenerateToken("testuser", []string{"group1"}, "uid1", nil, "/path", "example.com", TokenTypeBootstrap, false)
 	require.NoError(t, err)
 	assert.NotEmpty(t, token)
 

--- a/internal/jwt/standard_signer_test.go
+++ b/internal/jwt/standard_signer_test.go
@@ -38,7 +38,7 @@ func TestStandardSigner_GenerateValidateRoundtrip(t *testing.T) {
 	signer := createTestSigner("test-signing-key-32-characters-long", "test-issuer", "test-audience", time.Hour)
 
 	// Generate token
-	token, err := signer.GenerateToken(testUser, []string{"group1", "group2"}, "uid123", nil, "/path", "domain.com", TokenTypeSession)
+	token, err := signer.GenerateToken(testUser, []string{"group1", "group2"}, "uid123", nil, "/path", "domain.com", TokenTypeSession, false)
 	if err != nil {
 		t.Fatalf("Failed to generate token: %v", err)
 	}
@@ -74,7 +74,7 @@ func TestStandardSigner_ValidateToken_ExpiredToken(t *testing.T) {
 	signer := createTestSigner("test-signing-key-32-characters-long", "test-issuer", "test-audience", -time.Hour) // Negative expiration
 
 	// Generate expired token
-	token, err := signer.GenerateToken(testUser, []string{}, "uid", nil, "", "", "")
+	token, err := signer.GenerateToken(testUser, []string{}, "uid", nil, "", "", "", false)
 	if err != nil {
 		t.Fatalf("Failed to generate token: %v", err)
 	}
@@ -94,7 +94,7 @@ func TestStandardSigner_ValidateToken_InvalidSignature(t *testing.T) {
 	signer2 := createTestSigner("key2-32-characters-long-enough", "test-issuer", "test-audience", time.Hour)
 
 	// Generate token with signer1
-	token, err := signer1.GenerateToken(testUser, []string{}, "uid", nil, "", "", "")
+	token, err := signer1.GenerateToken(testUser, []string{}, "uid", nil, "", "", "", false)
 	if err != nil {
 		t.Fatalf("Failed to generate token: %v", err)
 	}
@@ -114,7 +114,7 @@ func TestStandardSigner_ValidateToken_WrongIssuer(t *testing.T) {
 	signer2 := createTestSigner("test-signing-key-32-characters-long", "issuer2", "test-audience", time.Hour)
 
 	// Generate token with signer1
-	token, err := signer1.GenerateToken(testUser, []string{}, "uid", nil, "", "", "")
+	token, err := signer1.GenerateToken(testUser, []string{}, "uid", nil, "", "", "", false)
 	if err != nil {
 		t.Fatalf("Failed to generate token: %v", err)
 	}
@@ -135,7 +135,7 @@ func TestStandardSigner_ValidateToken_WrongAudience(t *testing.T) {
 	signer2 := createTestSigner("test-signing-key-32-characters-long", "test-issuer", "audience2", time.Hour)
 
 	// Generate token with signer1
-	token, err := signer1.GenerateToken(testUser, []string{}, "uid", nil, "", "", "")
+	token, err := signer1.GenerateToken(testUser, []string{}, "uid", nil, "", "", "", false)
 	if err != nil {
 		t.Fatalf("Failed to generate token: %v", err)
 	}
@@ -214,7 +214,7 @@ func TestStandardSigner_MultipleKeys_Validation(t *testing.T) {
 	_ = signer.UpdateKeys(signingKeys, latestKid)
 
 	// Generate token (should use latest key)
-	token, err := signer.GenerateToken(testUser, []string{"group1"}, "uid123", nil, "/path", "domain.com", TokenTypeSession)
+	token, err := signer.GenerateToken(testUser, []string{"group1"}, "uid123", nil, "/path", "domain.com", TokenTypeSession, false)
 	if err != nil {
 		t.Fatalf("Failed to generate token: %v", err)
 	}
@@ -239,7 +239,7 @@ func TestStandardSigner_UpdateKeys_HotReload(t *testing.T) {
 	_ = signer.UpdateKeys(initialKeys, "1000")
 
 	// Generate token with initial key
-	token, err := signer.GenerateToken(testUser, []string{}, "uid", nil, "", "", "")
+	token, err := signer.GenerateToken(testUser, []string{}, "uid", nil, "", "", "", false)
 	if err != nil {
 		t.Fatalf("Failed to generate token: %v", err)
 	}
@@ -263,7 +263,7 @@ func TestStandardSigner_UpdateKeys_HotReload(t *testing.T) {
 	}
 
 	// New tokens should use the new latest key
-	newToken, err := signer.GenerateToken("newuser", []string{}, "uid2", nil, "", "", "")
+	newToken, err := signer.GenerateToken("newuser", []string{}, "uid2", nil, "", "", "", false)
 	if err != nil {
 		t.Fatalf("Failed to generate new token: %v", err)
 	}
@@ -292,7 +292,7 @@ func TestStandardSigner_UpdateKeys_KeyRemoval(t *testing.T) {
 		map[string][]byte{"1000": []byte("old-key-32-characters-long-here")},
 		"1000",
 	)
-	oldToken, err := oldKeySigner.GenerateToken(testUser, []string{}, "uid", nil, "", "", "")
+	oldToken, err := oldKeySigner.GenerateToken(testUser, []string{}, "uid", nil, "", "", "", false)
 	if err != nil {
 		t.Fatalf("Failed to generate old token: %v", err)
 	}
@@ -373,7 +373,7 @@ func TestStandardSigner_ValidateToken_UnknownKid(t *testing.T) {
 	)
 
 	// Generate token with unknown kid
-	token, err := otherSigner.GenerateToken(testUser, []string{}, "uid", nil, "", "", "")
+	token, err := otherSigner.GenerateToken(testUser, []string{}, "uid", nil, "", "", "", false)
 	if err != nil {
 		t.Fatalf("Failed to generate token: %v", err)
 	}
@@ -396,7 +396,7 @@ func TestStandardSigner_HS384Algorithm(t *testing.T) {
 	_ = signer.UpdateKeys(signingKeys, "1000")
 
 	// Generate token
-	token, err := signer.GenerateToken(testUser, []string{}, "uid", nil, "", "", "")
+	token, err := signer.GenerateToken(testUser, []string{}, "uid", nil, "", "", "", false)
 	if err != nil {
 		t.Fatalf("Failed to generate token: %v", err)
 	}
@@ -460,7 +460,7 @@ func TestStandardSigner_CoolOffKeySelection(t *testing.T) {
 		signer.mu.Unlock()
 
 		// Should fail to generate token since all keys are within cooloff
-		_, err := signer.GenerateToken(testUser, []string{}, "uid", nil, "", "", "")
+		_, err := signer.GenerateToken(testUser, []string{}, "uid", nil, "", "", "", false)
 		if err == nil {
 			t.Error("Expected error when all keys within cooloff, got nil")
 		}
@@ -485,7 +485,7 @@ func TestStandardSigner_CoolOffKeySelection(t *testing.T) {
 		}
 		signer.mu.Unlock()
 
-		token, err := signer.GenerateToken(testUser, []string{}, "uid", nil, "", "", "")
+		token, err := signer.GenerateToken(testUser, []string{}, "uid", nil, "", "", "", false)
 		if err != nil {
 			t.Fatalf("Expected token generation to succeed, got error: %v", err)
 		}
@@ -515,7 +515,7 @@ func TestStandardSigner_CoolOffKeySelection(t *testing.T) {
 		}
 		signer.mu.Unlock()
 
-		token, err := signer.GenerateToken(testUser, []string{}, "uid", nil, "", "", "")
+		token, err := signer.GenerateToken(testUser, []string{}, "uid", nil, "", "", "", false)
 		if err != nil {
 			t.Fatalf("Expected token generation to succeed, got error: %v", err)
 		}
@@ -545,7 +545,7 @@ func TestStandardSigner_CoolOffKeySelection(t *testing.T) {
 		}
 		signer.mu.Unlock()
 
-		token, err := signer.GenerateToken(testUser, []string{}, "uid", nil, "", "", "")
+		token, err := signer.GenerateToken(testUser, []string{}, "uid", nil, "", "", "", false)
 		if err != nil {
 			t.Fatalf("Expected token generation to succeed with zero cooloff, got error: %v", err)
 		}
@@ -575,7 +575,7 @@ func TestStandardSigner_CoolOffKeySelection(t *testing.T) {
 		}
 		signer.mu.Unlock()
 
-		token, err := signer.GenerateToken(testUser, []string{}, "uid", nil, "", "", "")
+		token, err := signer.GenerateToken(testUser, []string{}, "uid", nil, "", "", "", false)
 		if err != nil {
 			t.Fatalf("Expected token generation to succeed, got error: %v", err)
 		}
@@ -603,7 +603,7 @@ func TestStandardSigner_CoolOffKeySelection(t *testing.T) {
 		signer.mu.Unlock()
 
 		// Generate token and validate it can be verified (proving the key was correctly retrieved)
-		token, err := signer.GenerateToken(testUser, []string{}, "uid", nil, "", "", "")
+		token, err := signer.GenerateToken(testUser, []string{}, "uid", nil, "", "", "", false)
 		if err != nil {
 			t.Fatalf("Expected token generation to succeed, got error: %v", err)
 		}
@@ -633,7 +633,7 @@ func TestStandardSigner_NewKeyUseDelay(t *testing.T) {
 	signer.mu.Unlock()
 
 	// Generate token with initial key (should work immediately since key was added at creation)
-	token1, err := signer.GenerateToken(testUser, []string{}, "uid", nil, "", "", "")
+	token1, err := signer.GenerateToken(testUser, []string{}, "uid", nil, "", "", "", false)
 	if err != nil {
 		t.Fatalf("Failed to generate token with initial key: %v", err)
 	}
@@ -654,7 +654,7 @@ func TestStandardSigner_NewKeyUseDelay(t *testing.T) {
 	}
 
 	// Immediately try to generate token - should still use old key "1000" due to cooloff
-	token2, err := signer.GenerateToken(testUser, []string{}, "uid", nil, "", "", "")
+	token2, err := signer.GenerateToken(testUser, []string{}, "uid", nil, "", "", "", false)
 	if err != nil {
 		t.Fatalf("Failed to generate token immediately after update: %v", err)
 	}
@@ -668,7 +668,7 @@ func TestStandardSigner_NewKeyUseDelay(t *testing.T) {
 	time.Sleep(2100 * time.Millisecond)
 
 	// Now token should use the new key "2000"
-	token3, err := signer.GenerateToken(testUser, []string{}, "uid", nil, "", "", "")
+	token3, err := signer.GenerateToken(testUser, []string{}, "uid", nil, "", "", "", false)
 	if err != nil {
 		t.Fatalf("Failed to generate token after cooloff: %v", err)
 	}
@@ -698,7 +698,7 @@ func TestStandardSigner_ConcurrentAccess(t *testing.T) {
 	_ = signer.UpdateKeys(signingKeys, "1000")
 
 	// Generate initial token
-	token, err := signer.GenerateToken(testUser, []string{}, "uid", nil, "", "", "")
+	token, err := signer.GenerateToken(testUser, []string{}, "uid", nil, "", "", "", false)
 	if err != nil {
 		t.Fatalf("Failed to generate initial token: %v", err)
 	}
@@ -708,7 +708,7 @@ func TestStandardSigner_ConcurrentAccess(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		// Concurrent token generation
 		go func() {
-			_, err := signer.GenerateToken("user", []string{}, "uid", nil, "", "", "")
+			_, err := signer.GenerateToken("user", []string{}, "uid", nil, "", "", "", false)
 			if err != nil {
 				t.Errorf("Concurrent GenerateToken failed: %v", err)
 			}
@@ -769,7 +769,7 @@ func TestStandardSigner_RetrieveInitialSecret_Success(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify keys were loaded — signer should be able to generate and validate tokens
-	token, err := signer.GenerateToken("user", nil, "uid", nil, "/path", "domain", TokenTypeSession)
+	token, err := signer.GenerateToken("user", nil, "uid", nil, "/path", "domain", TokenTypeSession, false)
 	require.NoError(t, err)
 	assert.NotEmpty(t, token)
 
@@ -817,4 +817,60 @@ func TestStandardSigner_RetrieveInitialSecret_NoSigningKeys(t *testing.T) {
 	err := signer.RetrieveInitialSecret(context.Background(), fakeClient, "jwt-secret", "default")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to parse signing keys")
+}
+
+func TestGenerateToken_WithSkipRefreshTrue(t *testing.T) {
+	signer := createTestSigner("test-signing-key-32-characters-long", "test-issuer", "test-audience", time.Hour)
+	token, err := signer.GenerateToken(testUser, []string{"group1"}, "uid123", nil, "/path", "domain.com", TokenTypeSession, true)
+	require.NoError(t, err)
+
+	claims, err := signer.ValidateToken(token)
+	require.NoError(t, err)
+	assert.True(t, claims.SkipRefresh, "Expected SkipRefresh to be true")
+}
+
+func TestGenerateToken_WithSkipRefreshFalse(t *testing.T) {
+	signer := createTestSigner("test-signing-key-32-characters-long", "test-issuer", "test-audience", time.Hour)
+	token, err := signer.GenerateToken(testUser, []string{"group1"}, "uid123", nil, "/path", "domain.com", TokenTypeSession, false)
+	require.NoError(t, err)
+
+	claims, err := signer.ValidateToken(token)
+	require.NoError(t, err)
+	assert.False(t, claims.SkipRefresh, "Expected SkipRefresh to be false")
+}
+
+func TestGenerateRefreshToken_PreservesIssuedAt(t *testing.T) {
+	signer := createTestSigner("test-signing-key-32-characters-long", "test-issuer", "test-audience", time.Hour)
+
+	// Generate original token
+	originalToken, err := signer.GenerateToken(testUser, []string{"group1"}, "uid123", nil, "/path", "domain.com", TokenTypeSession, false)
+	require.NoError(t, err)
+	originalClaims, err := signer.ValidateToken(originalToken)
+	require.NoError(t, err)
+
+	// Generate refresh token
+	refreshedToken, err := signer.GenerateRefreshToken(originalClaims)
+	require.NoError(t, err)
+	refreshedClaims, err := signer.ValidateToken(refreshedToken)
+	require.NoError(t, err)
+
+	// IssuedAt should be preserved
+	assert.Equal(t, originalClaims.IssuedAt.Unix(), refreshedClaims.IssuedAt.Unix(),
+		"IssuedAt should be preserved from original token")
+	// ExpiresAt should be at least as recent (both use now+expiration, may land in same second)
+	assert.False(t, refreshedClaims.ExpiresAt.Before(originalClaims.ExpiresAt.Time),
+		"ExpiresAt should not be earlier than original")
+	// SkipRefresh should be false
+	assert.False(t, refreshedClaims.SkipRefresh, "SkipRefresh should be false on refreshed token")
+	// User should be preserved
+	assert.Equal(t, originalClaims.User, refreshedClaims.User)
+	assert.Equal(t, originalClaims.Path, refreshedClaims.Path)
+	assert.Equal(t, originalClaims.Domain, refreshedClaims.Domain)
+}
+
+func TestGenerateRefreshToken_NilClaims(t *testing.T) {
+	signer := createTestSigner("test-signing-key-32-characters-long", "test-issuer", "test-audience", time.Hour)
+	_, err := signer.GenerateRefreshToken(nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "claims cannot be nil")
 }

--- a/test/helm/guided-aws-hyperpod/resources_test.go
+++ b/test/helm/guided-aws-hyperpod/resources_test.go
@@ -3,7 +3,7 @@ Copyright (c) Amazon Web Services
 Distributed under the terms of the MIT license
 */
 
-package aws_traefik_dex_test
+package aws_hyperpod_test
 
 import (
 	"os"
@@ -19,97 +19,53 @@ import (
 	"github.com/jupyter-infra/jupyter-k8s/test/helm"
 )
 
-// Test suite for verifying Helm chart resources match config resources
-var _ = Describe("AWS Traefik Dex Resources", func() {
-	It("should include all aws-traefik-dex resources in the Helm chart", func() {
-		// Get project root directory
+var _ = Describe("AWS HyperPod Resources", func() {
+	It("should include all aws-hyperpod resources in the Helm chart", func() {
 		rootDir, err := filepath.Abs("../../..")
 		Expect(err).NotTo(HaveOccurred())
 
 		// Parse resources from source directory
-		configDir := filepath.Join(rootDir, "guided-charts", "aws-traefik-dex", "templates")
+		configDir := filepath.Join(rootDir, "guided-charts", "aws-hyperpod", "templates")
 		configResources, configMap, err := helm.ParseYAMLDirectory(configDir)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(configResources).NotTo(BeEmpty(), "No resources found in guided-charts directory")
 
 		// Parse resources from target directory
 		helmDir := filepath.Join(
-			rootDir, "dist", "test-output-guided", "aws-traefik-dex", "jupyter-k8s-aws-traefik-dex", "templates")
+			rootDir, "dist", "test-output-guided", "aws-hyperpod", "jupyter-k8s-aws-hyperpod", "templates")
 		helmResources, helmMap, err := helm.ParseYAMLDirectory(helmDir)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(helmResources).NotTo(BeEmpty(), "No resources found in output directory")
 
-		// Compare resources using our new helper function
+		// Compare resources
 		missingResources, unmatchedResources, _ := helm.CompareResourceMaps(
 			configResources, configMap, helmResources, helmMap)
 
-		// Check that all source resources exist in rendered output
 		Expect(missingResources).To(BeEmpty(), "Resources from source chart missing in output: %v", missingResources)
 
-		// Filter out resources from traefik-crds dependency chart and show them
-		// For Helm charts, it's normal for template files to produce multiple resources
-		// that don't have direct 1:1 matches with source files
-		filteredUnmatched := []string{}
-		for _, res := range unmatchedResources {
-			// Only add non-dependency resources to the filtered list
-			if !strings.Contains(res, "traefik-crd") {
-				filteredUnmatched = append(filteredUnmatched, res)
-			}
-		}
-
-		if len(filteredUnmatched) > 0 {
+		if len(unmatchedResources) > 0 {
 			GinkgoWriter.Println("Note: Multiple resources generated from template files (expected):")
-			for _, res := range filteredUnmatched {
+			for _, res := range unmatchedResources {
 				GinkgoWriter.Printf("  - %s\n", res)
 			}
 		}
-
-		// Instead of requiring filtered list to be empty, just note that they exist
-		// This is expected for Helm templates where one template file can generate multiple resources
-	})
-
-	It("should find values.yaml references in the templates", func() {
-		// Get project root directory
-		rootDir, err := filepath.Abs("../../..")
-		Expect(err).NotTo(HaveOccurred())
-
-		// Check that values references are valid
-		templatesDir := filepath.Join(rootDir, "guided-charts", "aws-traefik-dex", "templates")
-		valuesPath := filepath.Join(rootDir, "guided-charts", "aws-traefik-dex", "values.yaml")
-
-		// Extract references from templates
-		references, err := helm.ExtractTemplateReferences(templatesDir)
-		Expect(err).NotTo(HaveOccurred())
-
-		// Extract values schema
-		schema, err := helm.ExtractValuesSchema(valuesPath)
-		Expect(err).NotTo(HaveOccurred())
-
-		// Find invalid references
-		invalidRefs := helm.FindInvalidReferences(references, schema)
-
-		Expect(invalidRefs).To(BeEmpty(), "Invalid values references found: %v", invalidRefs)
 	})
 
 	It("should generate JWT signing key with 48 bytes (384 bits) for HS384", func() {
-		// Get project root directory
 		rootDir, err := filepath.Abs("../../..")
 		Expect(err).NotTo(HaveOccurred())
 
-		// Read the rendered secret
 		secretPath := filepath.Join(
-			rootDir, "dist", "test-output-guided", "aws-traefik-dex", "jupyter-k8s-aws-traefik-dex",
+			rootDir, "dist", "test-output-guided", "aws-hyperpod", "jupyter-k8s-aws-hyperpod",
 			"templates", "authmiddleware", "secrets.yaml")
 
 		secretBytes, err := os.ReadFile(secretPath)
 		Expect(err).NotTo(HaveOccurred())
 
-		// Parse the secret
 		var secret corev1.Secret
 		err = yaml.Unmarshal(secretBytes, &secret)
 		Expect(err).NotTo(HaveOccurred())
 
-		// Find the JWT signing key (should have format jwt-signing-key-<timestamp>)
 		var keyValue []byte
 		var keyName string
 		for name, value := range secret.Data {
@@ -121,11 +77,6 @@ var _ = Describe("AWS Traefik Dex Resources", func() {
 		}
 
 		Expect(keyName).NotTo(BeEmpty(), "No JWT signing key found in secret")
-
-		// The value in the secret data field is base64-encoded in the YAML file,
-		// but the YAML parser (sigs.k8s.io/yaml) automatically decodes it when
-		// unmarshaling into a corev1.Secret. So keyValue is already the raw bytes.
-		// Verify the key is exactly 48 bytes (384 bits) as required by RFC 7518 for HS384
 		Expect(keyValue).To(HaveLen(48),
 			"JWT signing key %s should be 48 bytes for HS384, but got %d bytes", keyName, len(keyValue))
 	})
@@ -135,13 +86,13 @@ var _ = Describe("AWS Traefik Dex Resources", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		rbacPath := filepath.Join(
-			rootDir, "dist", "test-output-guided", "aws-traefik-dex", "jupyter-k8s-aws-traefik-dex",
+			rootDir, "dist", "test-output-guided", "aws-hyperpod", "jupyter-k8s-aws-hyperpod",
 			"templates", "authmiddleware", "rbac.yaml")
 
 		rbacBytes, err := os.ReadFile(rbacPath)
 		Expect(err).NotTo(HaveOccurred())
 
-		// The file contains multiple YAML documents; find the ClusterRole
+		// Find the ClusterRole among multiple YAML documents
 		docs := strings.Split(string(rbacBytes), "---")
 		var clusterRole rbacv1.ClusterRole
 		found := false
@@ -161,7 +112,6 @@ var _ = Describe("AWS Traefik Dex Resources", func() {
 		}
 		Expect(found).To(BeTrue(), "ClusterRole not found in authmiddleware rbac.yaml")
 
-		// Verify both extension API resources are present
 		resourceNames := []string{}
 		for _, rule := range clusterRole.Rules {
 			resourceNames = append(resourceNames, rule.Resources...)
@@ -170,5 +120,67 @@ var _ = Describe("AWS Traefik Dex Resources", func() {
 			"ClusterRole should grant access to connectionaccessreviews")
 		Expect(resourceNames).To(ContainElement("bearertokenreviews"),
 			"ClusterRole should grant access to bearertokenreviews when enableBearerAuth=true")
+	})
+
+	It("should render access strategy with correct plugin handler references", func() {
+		rootDir, err := filepath.Abs("../../..")
+		Expect(err).NotTo(HaveOccurred())
+
+		accessStrategyPath := filepath.Join(
+			rootDir, "dist", "test-output-guided", "aws-hyperpod", "jupyter-k8s-aws-hyperpod",
+			"templates", "hyperpod-access-strategy.yaml")
+
+		data, err := os.ReadFile(accessStrategyPath)
+		Expect(err).NotTo(HaveOccurred())
+		content := string(data)
+
+		// Verify plugin handler references
+		Expect(content).To(ContainSubstring("podEventsHandler: \"aws:ssm-remote-access\""),
+			"AccessStrategy should have podEventsHandler referencing aws plugin")
+		Expect(content).To(ContainSubstring("vscode-remote: \"aws:createSession\""),
+			"AccessStrategy should have createConnectionHandlerMap entry for vscode-remote")
+
+		// Verify k8s-native is the default connection handler
+		Expect(content).To(ContainSubstring("createConnectionHandler: \"k8s-native\""),
+			"AccessStrategy should have k8s-native as default createConnectionHandler")
+
+		// Verify podEventsContext has required keys
+		Expect(content).To(ContainSubstring("sidecarContainerName:"),
+			"podEventsContext should include sidecarContainerName")
+		Expect(content).To(ContainSubstring("registrationStateFile:"),
+			"podEventsContext should include registrationStateFile")
+		Expect(content).To(ContainSubstring("controller::PodUid()"),
+			"podEventsContext should use dynamic PodUid resolution")
+
+		// Verify createConnectionContext has required keys
+		Expect(content).To(ContainSubstring("extensionapi::PodUid()"),
+			"createConnectionContext should use dynamic PodUid resolution")
+		Expect(content).To(ContainSubstring("ssmDocumentName:"),
+			"createConnectionContext should include ssmDocumentName")
+	})
+
+	It("should render authmiddleware JWT env vars consistent with values", func() {
+		rootDir, err := filepath.Abs("../../..")
+		Expect(err).NotTo(HaveOccurred())
+
+		deploymentPath := filepath.Join(
+			rootDir, "dist", "test-output-guided", "aws-hyperpod", "jupyter-k8s-aws-hyperpod",
+			"templates", "authmiddleware", "deployment.yaml")
+
+		data, err := os.ReadFile(deploymentPath)
+		Expect(err).NotTo(HaveOccurred())
+		content := string(data)
+
+		// Verify JWT settings are rendered
+		Expect(content).To(ContainSubstring(`value: "1h"`),
+			"JWT_EXPIRATION should be 1h")
+		Expect(content).To(ContainSubstring(`value: "15m"`),
+			"JWT_REFRESH_WINDOW should be 15m")
+		Expect(content).To(ContainSubstring(`value: "12h"`),
+			"JWT_REFRESH_HORIZON should be 12h")
+		Expect(content).To(ContainSubstring(`value: "true"`),
+			"JWT_REFRESH_ENABLE should be true")
+		Expect(content).To(ContainSubstring(`value: "5s"`),
+			"NEW_KEY_USE_DELAY should be 5s")
 	})
 })

--- a/test/helm/guided-aws-hyperpod/suite_test.go
+++ b/test/helm/guided-aws-hyperpod/suite_test.go
@@ -1,0 +1,18 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package aws_hyperpod_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestAwsHyperpod(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "AWS HyperPod Suite")
+}

--- a/test/helm/guided-aws-hyperpod/values_consistency_test.go
+++ b/test/helm/guided-aws-hyperpod/values_consistency_test.go
@@ -1,0 +1,34 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package aws_hyperpod_test
+
+import (
+	"path/filepath"
+
+	"github.com/jupyter-infra/jupyter-k8s/test/helm"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("AWS-HyperPod Values Consistency", func() {
+	It("should have consistent references between aws-hyperpod templates and values.yaml", func() {
+		rootDir, err := filepath.Abs("../../..")
+		Expect(err).NotTo(HaveOccurred())
+
+		valuesPath := filepath.Join(rootDir, "guided-charts/aws-hyperpod/values.yaml")
+		templatesDir := filepath.Join(rootDir, "guided-charts/aws-hyperpod/templates")
+
+		schema, err := helm.ExtractValuesSchema(valuesPath)
+		Expect(err).NotTo(HaveOccurred())
+
+		references, err := helm.ExtractTemplateReferences(templatesDir)
+		Expect(err).NotTo(HaveOccurred())
+
+		invalidRefs := helm.FindInvalidReferences(references, schema)
+
+		Expect(invalidRefs).To(BeEmpty(), "Found template references that don't exist in values.yaml")
+	})
+})

--- a/test/helm/guided-aws-traefik-dex/oidc_consistency_test.go
+++ b/test/helm/guided-aws-traefik-dex/oidc_consistency_test.go
@@ -46,7 +46,8 @@ var _ = Describe("OIDC Configuration Consistency", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// Path to rendered test output
-		testOutputDir = filepath.Join(rootDir, "dist/test-output-guided/aws-traefik-dex/jupyter-k8s-aws-traefik-dex/templates")
+		testOutputDir = filepath.Join(
+			rootDir, "dist/test-output-guided/aws-traefik-dex/jupyter-k8s-aws-traefik-dex/templates")
 
 		// Read the necessary files
 		dexConfigmapPath := filepath.Join(testOutputDir, "dex/configmap.yaml")

--- a/test/helm/guided-aws-traefik-dex/oidc_consistency_test.go
+++ b/test/helm/guided-aws-traefik-dex/oidc_consistency_test.go
@@ -46,7 +46,7 @@ var _ = Describe("OIDC Configuration Consistency", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// Path to rendered test output
-		testOutputDir = filepath.Join(rootDir, "dist/test-output-guided/jupyter-k8s-aws-traefik-dex/templates")
+		testOutputDir = filepath.Join(rootDir, "dist/test-output-guided/aws-traefik-dex/jupyter-k8s-aws-traefik-dex/templates")
 
 		// Read the necessary files
 		dexConfigmapPath := filepath.Join(testOutputDir, "dex/configmap.yaml")


### PR DESCRIPTION
This PR adds a few clean-ups after the migration of the `aws-hyperpod` guided chart to the plugin architecture (#358 ).
- use `1h` expiry for `Authmiddleware` JWT seed
- use `15m` refresh horizon (ie refreshed during `45m-1h` window)
- use `12h` jwt refresh horizon (after which, needs to generate a new `bearer-token` URL)
- fixes refresh logic by holding the `issuedAt` steady in the `claims`

Also in this PR:
- update `CLAUDE.md` for plugin architecture
- add helm chart tests for `aws-hyperpod` chart: use `make helm-test-aws-hyperpod`
- add validator for `aws-hyperpod` helm values

### Testing
- redeployed `aws-traefik`, tested web and remote access