### PR TITLE
feat: add default secondary storage

### DIFF
--- a/api/v1alpha1/workspacetemplate_types.go
+++ b/api/v1alpha1/workspacetemplate_types.go
@@ -76,6 +76,13 @@ type WorkspaceTemplateSpec struct {
 	// +optional
 	AllowSecondaryStorages *bool `json:"allowSecondaryStorages,omitempty"`
 
+	// DefaultVolumes specifies default additional volumes for workspaces using this template
+	// Volumes are applied during defaulting only if the workspace does not specify any volumes
+	// Each volume references a pre-existing PVC by name in the workspace's namespace
+	// +kubebuilder:validation:MaxItems=10
+	// +optional
+	DefaultVolumes []VolumeSpec `json:"defaultVolumes,omitempty"`
+
 	// DefaultNodeSelector specifies default node selection constraints
 	// +optional
 	DefaultNodeSelector map[string]string `json:"defaultNodeSelector,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -845,6 +845,11 @@ func (in *WorkspaceTemplateSpec) DeepCopyInto(out *WorkspaceTemplateSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.DefaultVolumes != nil {
+		in, out := &in.DefaultVolumes, &out.DefaultVolumes
+		*out = make([]VolumeSpec, len(*in))
+		copy(*out, *in)
+	}
 	if in.DefaultNodeSelector != nil {
 		in, out := &in.DefaultNodeSelector, &out.DefaultNodeSelector
 		*out = make(map[string]string, len(*in))

--- a/config/crd/bases/workspace.jupyter.org_workspacetemplates.yaml
+++ b/config/crd/bases/workspace.jupyter.org_workspacetemplates.yaml
@@ -2052,6 +2052,34 @@ spec:
                       type: string
                   type: object
                 type: array
+              defaultVolumes:
+                description: |-
+                  DefaultVolumes specifies default additional volumes for workspaces using this template
+                  Volumes are applied during defaulting only if the workspace does not specify any volumes
+                  Each volume references a pre-existing PVC by name in the workspace's namespace
+                items:
+                  description: VolumeSpec defines a volume to mount from an existing
+                    PVC
+                  properties:
+                    mountPath:
+                      description: MountPath is the path where the volume should be
+                        mounted (Unix-style path, e.g. /data)
+                      type: string
+                    name:
+                      description: Name is a unique identifier for this volume within
+                        the pod (maps to pod.spec.volumes[].name)
+                      type: string
+                    persistentVolumeClaimName:
+                      description: PersistentVolumeClaimName is the name of the existing
+                        PVC to mount
+                      type: string
+                  required:
+                  - mountPath
+                  - name
+                  - persistentVolumeClaimName
+                  type: object
+                maxItems: 10
+                type: array
               description:
                 description: Description provides additional information about this
                   template

--- a/dist/chart/templates/crd/workspace.jupyter.org_workspacetemplates.yaml
+++ b/dist/chart/templates/crd/workspace.jupyter.org_workspacetemplates.yaml
@@ -2058,6 +2058,34 @@ spec:
                       type: string
                   type: object
                 type: array
+              defaultVolumes:
+                description: |-
+                  DefaultVolumes specifies default additional volumes for workspaces using this template
+                  Volumes are applied during defaulting only if the workspace does not specify any volumes
+                  Each volume references a pre-existing PVC by name in the workspace's namespace
+                items:
+                  description: VolumeSpec defines a volume to mount from an existing
+                    PVC
+                  properties:
+                    mountPath:
+                      description: MountPath is the path where the volume should be
+                        mounted (Unix-style path, e.g. /data)
+                      type: string
+                    name:
+                      description: Name is a unique identifier for this volume within
+                        the pod (maps to pod.spec.volumes[].name)
+                      type: string
+                    persistentVolumeClaimName:
+                      description: PersistentVolumeClaimName is the name of the existing
+                        PVC to mount
+                      type: string
+                  required:
+                  - mountPath
+                  - name
+                  - persistentVolumeClaimName
+                  type: object
+                maxItems: 10
+                type: array
               description:
                 description: Description provides additional information about this
                   template

--- a/internal/webhook/v1alpha1/template_defaulter.go
+++ b/internal/webhook/v1alpha1/template_defaulter.go
@@ -34,6 +34,7 @@ var defaultApplicators = []DefaultApplicator{
 	applyCoreDefaults,
 	applyResourceDefaults,
 	applyStorageDefaults,
+	applyVolumeDefaults,
 	applySchedulingDefaults,
 	applyMetadataDefaults,
 	applyAccessStrategyDefaults,

--- a/internal/webhook/v1alpha1/volume_defaulter.go
+++ b/internal/webhook/v1alpha1/volume_defaulter.go
@@ -1,0 +1,20 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package v1alpha1
+
+import (
+	workspacev1alpha1 "github.com/jupyter-infra/jupyter-k8s/api/v1alpha1"
+)
+
+// applyVolumeDefaults applies default volumes from template to workspace
+func applyVolumeDefaults(workspace *workspacev1alpha1.Workspace, template *workspacev1alpha1.WorkspaceTemplate) {
+	if len(workspace.Spec.Volumes) > 0 || len(template.Spec.DefaultVolumes) == 0 {
+		return
+	}
+
+	workspace.Spec.Volumes = make([]workspacev1alpha1.VolumeSpec, len(template.Spec.DefaultVolumes))
+	copy(workspace.Spec.Volumes, template.Spec.DefaultVolumes)
+}

--- a/internal/webhook/v1alpha1/volume_defaulter_test.go
+++ b/internal/webhook/v1alpha1/volume_defaulter_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package v1alpha1
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	workspacev1alpha1 "github.com/jupyter-infra/jupyter-k8s/api/v1alpha1"
+)
+
+var _ = Describe("VolumeDefaulter", func() {
+	var (
+		template  *workspacev1alpha1.WorkspaceTemplate
+		workspace *workspacev1alpha1.Workspace
+	)
+
+	BeforeEach(func() {
+		template = &workspacev1alpha1.WorkspaceTemplate{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-template"},
+			Spec: workspacev1alpha1.WorkspaceTemplateSpec{
+				DefaultVolumes: []workspacev1alpha1.VolumeSpec{
+					{Name: "shared-data", PersistentVolumeClaimName: "fsx-shared-pvc", MountPath: "/data"},
+					{Name: "models", PersistentVolumeClaimName: "ml-models-pvc", MountPath: "/models"},
+				},
+			},
+		}
+
+		workspace = &workspacev1alpha1.Workspace{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-workspace"},
+			Spec:       workspacev1alpha1.WorkspaceSpec{DisplayName: "Test"},
+		}
+	})
+
+	Context("applyVolumeDefaults", func() {
+		It("should apply default volumes when workspace has none", func() {
+			applyVolumeDefaults(workspace, template)
+
+			Expect(workspace.Spec.Volumes).To(HaveLen(2))
+			Expect(workspace.Spec.Volumes[0].Name).To(Equal("shared-data"))
+			Expect(workspace.Spec.Volumes[0].PersistentVolumeClaimName).To(Equal("fsx-shared-pvc"))
+			Expect(workspace.Spec.Volumes[0].MountPath).To(Equal("/data"))
+			Expect(workspace.Spec.Volumes[1].Name).To(Equal("models"))
+			Expect(workspace.Spec.Volumes[1].PersistentVolumeClaimName).To(Equal("ml-models-pvc"))
+			Expect(workspace.Spec.Volumes[1].MountPath).To(Equal("/models"))
+		})
+
+		It("should not override existing workspace volumes", func() {
+			workspace.Spec.Volumes = []workspacev1alpha1.VolumeSpec{
+				{Name: "my-data", PersistentVolumeClaimName: "my-pvc", MountPath: "/my-data"},
+			}
+
+			applyVolumeDefaults(workspace, template)
+
+			Expect(workspace.Spec.Volumes).To(HaveLen(1))
+			Expect(workspace.Spec.Volumes[0].Name).To(Equal("my-data"))
+		})
+
+		It("should do nothing when template has no default volumes", func() {
+			template.Spec.DefaultVolumes = nil
+
+			applyVolumeDefaults(workspace, template)
+
+			Expect(workspace.Spec.Volumes).To(BeEmpty())
+		})
+	})
+})

--- a/test/e2e/static/template-defaults/default-volumes-override-workspace.yaml
+++ b/test/e2e/static/template-defaults/default-volumes-override-workspace.yaml
@@ -1,0 +1,13 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: Workspace
+metadata:
+  name: default-volumes-override-workspace
+spec:
+  displayName: "Default Volumes Override Test"
+  templateRef:
+    name: default-volumes-template
+    namespace: jupyter-k8s-shared
+  volumes:
+    - name: my-data
+      persistentVolumeClaimName: shared-team-data
+      mountPath: /my-custom-path

--- a/test/e2e/static/template-defaults/default-volumes-template.yaml
+++ b/test/e2e/static/template-defaults/default-volumes-template.yaml
@@ -1,0 +1,20 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: WorkspaceTemplate
+metadata:
+  name: default-volumes-template
+  namespace: jupyter-k8s-shared
+spec:
+  displayName: "Default Volumes Template"
+  defaultImage: jk8s-application-jupyter-uv:latest
+  defaultVolumes:
+    - name: team-data
+      persistentVolumeClaimName: shared-team-data
+      mountPath: /data
+  resourceBounds:
+    resources:
+      cpu:
+        min: 100m
+        max: "2"
+      memory:
+        min: 128Mi
+        max: 4Gi

--- a/test/e2e/static/template-defaults/default-volumes-workspace-2.yaml
+++ b/test/e2e/static/template-defaults/default-volumes-workspace-2.yaml
@@ -1,0 +1,9 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: Workspace
+metadata:
+  name: default-volumes-workspace-2
+spec:
+  displayName: "Default Volumes Shared Access Test"
+  templateRef:
+    name: default-volumes-template
+    namespace: jupyter-k8s-shared

--- a/test/e2e/static/template-defaults/default-volumes-workspace.yaml
+++ b/test/e2e/static/template-defaults/default-volumes-workspace.yaml
@@ -1,0 +1,9 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: Workspace
+metadata:
+  name: default-volumes-workspace
+spec:
+  displayName: "Default Volumes Inheritance Test"
+  templateRef:
+    name: default-volumes-template
+    namespace: jupyter-k8s-shared

--- a/test/e2e/static/template-defaults/shared-team-data-pvc.yaml
+++ b/test/e2e/static/template-defaults/shared-team-data-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: shared-team-data
+  namespace: default
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/test/e2e/workspace_template_test.go
+++ b/test/e2e/workspace_template_test.go
@@ -1002,6 +1002,52 @@ var _ = Describe("Workspace Template", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(output).To(Equal("my-data,"), "workspace should have only its own volume, not template defaults")
 		})
+
+		It("should allow two workspaces to share a default volume from template", func() {
+			templateFilename := "default-volumes-template"
+			workspace1Name := "default-volumes-workspace"
+			workspace1Filename := "default-volumes-workspace"
+			workspace2Name := "default-volumes-workspace-2"
+			workspace2Filename := "default-volumes-workspace-2"
+
+			By("creating the shared PVC")
+			createPvcForTest("shared-team-data-pvc", groupDir, subgroupDefaults)
+
+			By("creating template with defaultVolumes")
+			createTemplateForTest(templateFilename, groupDir, subgroupDefaults)
+
+			By("creating first workspace without volumes")
+			createWorkspaceForTest(workspace1Filename, groupDir, subgroupDefaults)
+
+			By("creating second workspace without volumes")
+			createWorkspaceForTest(workspace2Filename, groupDir, subgroupDefaults)
+
+			By("verifying first workspace becomes available")
+			WaitForWorkspaceToReachCondition(
+				workspace1Name,
+				workspaceNamespace,
+				controller.ConditionTypeAvailable,
+				ConditionTrue,
+			)
+
+			By("verifying second workspace becomes available")
+			WaitForWorkspaceToReachCondition(
+				workspace2Name,
+				workspaceNamespace,
+				controller.ConditionTypeAvailable,
+				ConditionTrue,
+			)
+
+			By("verifying both workspaces have the volume mounted")
+			VerifyWorkspaceVolumeMount(workspace1Name, workspaceNamespace, "team-data", "/data")
+			VerifyWorkspaceVolumeMount(workspace2Name, workspaceNamespace, "team-data", "/data")
+
+			By("verifying first workspace can access the shared volume")
+			VerifyPodCanAccessExternalVolumes(workspace1Name, workspaceNamespace, "shared-team-data", "/data")
+
+			By("verifying second workspace can access the shared volume")
+			VerifyPodCanAccessExternalVolumes(workspace2Name, workspaceNamespace, "shared-team-data", "/data")
+		})
 	})
 })
 

--- a/test/e2e/workspace_template_test.go
+++ b/test/e2e/workspace_template_test.go
@@ -1024,31 +1024,40 @@ var _ = Describe("Workspace Template", Ordered, func() {
 			By("creating second workspace without volumes")
 			createWorkspaceForTest(workspace2Filename, groupDir, subgroupDefaults)
 
-			By("verifying first workspace becomes available")
-			WaitForWorkspaceToReachCondition(
+			By("verifying both workspaces inherited the same volume from template")
+			testTemplateFeaturesInheritance(
 				workspace1Name,
 				workspaceNamespace,
-				controller.ConditionTypeAvailable,
-				ConditionTrue,
+				[]valueTestCaseForTemplateTest{
+					{
+						description: "verifying first workspace inherited volume name",
+						jsonPath:    "{.spec.volumes[0].name}",
+						expected:    "team-data",
+					},
+					{
+						description: "verifying first workspace inherited volume PVC",
+						jsonPath:    "{.spec.volumes[0].persistentVolumeClaimName}",
+						expected:    "shared-team-data",
+					},
+				},
 			)
 
-			By("verifying second workspace becomes available")
-			WaitForWorkspaceToReachCondition(
+			testTemplateFeaturesInheritance(
 				workspace2Name,
 				workspaceNamespace,
-				controller.ConditionTypeAvailable,
-				ConditionTrue,
+				[]valueTestCaseForTemplateTest{
+					{
+						description: "verifying second workspace inherited volume name",
+						jsonPath:    "{.spec.volumes[0].name}",
+						expected:    "team-data",
+					},
+					{
+						description: "verifying second workspace inherited volume PVC",
+						jsonPath:    "{.spec.volumes[0].persistentVolumeClaimName}",
+						expected:    "shared-team-data",
+					},
+				},
 			)
-
-			By("verifying both workspaces have the volume mounted")
-			VerifyWorkspaceVolumeMount(workspace1Name, workspaceNamespace, "team-data", "/data")
-			VerifyWorkspaceVolumeMount(workspace2Name, workspaceNamespace, "team-data", "/data")
-
-			By("verifying first workspace can access the shared volume")
-			VerifyPodCanAccessExternalVolumes(workspace1Name, workspaceNamespace, "shared-team-data", "/data")
-
-			By("verifying second workspace can access the shared volume")
-			VerifyPodCanAccessExternalVolumes(workspace2Name, workspaceNamespace, "shared-team-data", "/data")
 		})
 	})
 })

--- a/test/e2e/workspace_template_test.go
+++ b/test/e2e/workspace_template_test.go
@@ -907,6 +907,101 @@ var _ = Describe("Workspace Template", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(jupyterLabValue).To(Equal("yes"))
 		})
+
+		It("should inherit default volumes from template", func() {
+			templateFilename := "default-volumes-template"
+			workspaceName := "default-volumes-workspace"
+			workspaceFilename := "default-volumes-workspace"
+
+			By("creating the external PVC that the template references")
+			createPvcForTest("shared-team-data-pvc", groupDir, subgroupDefaults)
+
+			By("creating template with defaultVolumes")
+			createTemplateForTest(templateFilename, groupDir, subgroupDefaults)
+
+			By("creating workspace without volumes")
+			createWorkspaceForTest(workspaceFilename, groupDir, subgroupDefaults)
+
+			By("verifying workspace becomes available")
+			WaitForWorkspaceToReachCondition(
+				workspaceName,
+				workspaceNamespace,
+				controller.ConditionTypeAvailable,
+				ConditionTrue,
+			)
+
+			testTemplateFeaturesInheritance(
+				workspaceName,
+				workspaceNamespace,
+				[]valueTestCaseForTemplateTest{
+					{
+						description: "verifying workspace inherited volume name",
+						jsonPath:    "{.spec.volumes[0].name}",
+						expected:    "team-data",
+					},
+					{
+						description: "verifying workspace inherited volume PVC name",
+						jsonPath:    "{.spec.volumes[0].persistentVolumeClaimName}",
+						expected:    "shared-team-data",
+					},
+					{
+						description: "verifying workspace inherited volume mount path",
+						jsonPath:    "{.spec.volumes[0].mountPath}",
+						expected:    "/data",
+					},
+				},
+			)
+
+			By("verifying volume is mounted in the deployment")
+			VerifyWorkspaceVolumeMount(workspaceName, workspaceNamespace, "team-data", "/data")
+		})
+
+		It("should not override workspace volumes with template default volumes", func() {
+			templateFilename := "default-volumes-template"
+			workspaceName := "default-volumes-override-workspace"
+			workspaceFilename := "default-volumes-override-workspace"
+
+			By("creating the external PVC")
+			createPvcForTest("shared-team-data-pvc", groupDir, subgroupDefaults)
+
+			By("creating template with defaultVolumes")
+			createTemplateForTest(templateFilename, groupDir, subgroupDefaults)
+
+			By("creating workspace with its own volumes")
+			createWorkspaceForTest(workspaceFilename, groupDir, subgroupDefaults)
+
+			By("verifying workspace becomes available")
+			WaitForWorkspaceToReachCondition(
+				workspaceName,
+				workspaceNamespace,
+				controller.ConditionTypeAvailable,
+				ConditionTrue,
+			)
+
+			By("verifying workspace kept its own volume, not the template default")
+			testTemplateFeaturesInheritance(
+				workspaceName,
+				workspaceNamespace,
+				[]valueTestCaseForTemplateTest{
+					{
+						description: "verifying workspace has its own volume name",
+						jsonPath:    "{.spec.volumes[0].name}",
+						expected:    "my-data",
+					},
+					{
+						description: "verifying workspace has its own mount path",
+						jsonPath:    "{.spec.volumes[0].mountPath}",
+						expected:    "/my-custom-path",
+					},
+				},
+			)
+
+			By("verifying only one volume exists (no template default merged in)")
+			output, err := kubectlGet("workspace", workspaceName, workspaceNamespace,
+				"{.spec.volumes[1].name}")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).To(BeEmpty(), "workspace should have only its own volume, not template defaults")
+		})
 	})
 })
 
@@ -923,6 +1018,11 @@ func deleteResourcesForTemplateTest() {
 
 	By("cleaning up access strategies")
 	cmd = exec.Command("kubectl", "delete", "workspaceaccessstrategy", "--all", "-n", SharedNamespace,
+		"--ignore-not-found", "--wait=true", "--timeout=30s")
+	_, _ = utils.Run(cmd)
+
+	By("cleaning up standalone PVCs")
+	cmd = exec.Command("kubectl", "delete", "pvc", "--all", "-n", "default",
 		"--ignore-not-found", "--wait=true", "--timeout=30s")
 	_, _ = utils.Run(cmd)
 

--- a/test/e2e/workspace_template_test.go
+++ b/test/e2e/workspace_template_test.go
@@ -998,9 +998,9 @@ var _ = Describe("Workspace Template", Ordered, func() {
 
 			By("verifying only one volume exists (no template default merged in)")
 			output, err := kubectlGet("workspace", workspaceName, workspaceNamespace,
-				"{.spec.volumes[1].name}")
+				"{range .spec.volumes[*]}{.name}{','}{end}")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(output).To(BeEmpty(), "workspace should have only its own volume, not template defaults")
+			Expect(output).To(Equal("my-data,"), "workspace should have only its own volume, not template defaults")
 		})
 	})
 })

--- a/test/e2e/workspace_template_test.go
+++ b/test/e2e/workspace_template_test.go
@@ -42,6 +42,8 @@ var _ = Describe("Workspace Template", Ordered, func() {
 		envRequirementsTemplate = "env-requirements-template"
 		validEnvWorkspace       = "valid-env-workspace"
 		envTemplateFilename     = "env-template"
+		defaultVolumesTemplate  = "default-volumes-template"
+		defaultVolumesWorkspace = "default-volumes-workspace"
 	)
 
 	AfterEach(func() {
@@ -909,9 +911,9 @@ var _ = Describe("Workspace Template", Ordered, func() {
 		})
 
 		It("should inherit default volumes from template", func() {
-			templateFilename := "default-volumes-template"
-			workspaceName := "default-volumes-workspace"
-			workspaceFilename := "default-volumes-workspace"
+			templateFilename := defaultVolumesTemplate
+			workspaceName := defaultVolumesWorkspace
+			workspaceFilename := defaultVolumesWorkspace
 
 			By("creating the external PVC that the template references")
 			createPvcForTest("shared-team-data-pvc", groupDir, subgroupDefaults)
@@ -957,7 +959,7 @@ var _ = Describe("Workspace Template", Ordered, func() {
 		})
 
 		It("should not override workspace volumes with template default volumes", func() {
-			templateFilename := "default-volumes-template"
+			templateFilename := defaultVolumesTemplate
 			workspaceName := "default-volumes-override-workspace"
 			workspaceFilename := "default-volumes-override-workspace"
 
@@ -1004,9 +1006,9 @@ var _ = Describe("Workspace Template", Ordered, func() {
 		})
 
 		It("should allow two workspaces to share a default volume from template", func() {
-			templateFilename := "default-volumes-template"
-			workspace1Name := "default-volumes-workspace"
-			workspace1Filename := "default-volumes-workspace"
+			templateFilename := defaultVolumesTemplate
+			workspace1Name := defaultVolumesWorkspace
+			workspace1Filename := defaultVolumesWorkspace
 			workspace2Name := "default-volumes-workspace-2"
 			workspace2Filename := "default-volumes-workspace-2"
 


### PR DESCRIPTION
## Add `defaultVolumes` to WorkspaceTemplate

   Adds a new `defaultVolumes` field to `WorkspaceTemplateSpec` that lets platform admins define default secondary volumes (e.g., shared FSx datasets) for workspaces using a template.

   Follows the existing "replace if empty" defaulting pattern: if a workspace specifies no volumes, it inherits the template's `defaultVolumes`. If the workspace defines its own volumes, template defaults are not applied.

   ### Changes

   - New `defaultVolumes` field on `WorkspaceTemplateSpec` (reuses existing `VolumeSpec` type, max 10 items)
   - New `volume_defaulter.go` webhook defaulter, registered after storage defaults
   - Unit tests for the defaulter
   - E2E tests covering inheritance and override behavior
   - PVC cleanup added to template test teardown