### PR TITLE
feat: add `workingDir` to container spec

### DIFF
--- a/api/v1alpha1/workspace_types.go
+++ b/api/v1alpha1/workspace_types.go
@@ -187,6 +187,12 @@ type WorkspaceSpec struct {
 	// Overrides template defaults when specified
 	// +optional
 	ContainerSecurityContext *corev1.SecurityContext `json:"containerSecurityContext,omitempty"`
+
+	// WorkingDir specifies the container's working directory
+	// Controls where applications like JupyterLab open their file browser by default
+	// Must be an absolute path (e.g., "/home/jovyan/projects")
+	// +optional
+	WorkingDir string `json:"workingDir,omitempty"`
 }
 
 // AccessResourceStatus defines the status of a resource created from a template

--- a/api/v1alpha1/workspacetemplate_types.go
+++ b/api/v1alpha1/workspacetemplate_types.go
@@ -141,6 +141,12 @@ type WorkspaceTemplateSpec struct {
 	// AppType specifies the application type for workspaces using this template
 	// +optional
 	AppType string `json:"appType,omitempty"`
+
+	// DefaultWorkingDir specifies the default working directory for workspaces using this template
+	// Controls where applications like JupyterLab open their file browser by default
+	// Must be an absolute path (e.g., "/home/jovyan/projects")
+	// +optional
+	DefaultWorkingDir string `json:"defaultWorkingDir,omitempty"`
 }
 
 // TemplateLabel defines a label key-value pair to add to workspaces

--- a/config/crd/bases/workspace.jupyter.org_workspaces.yaml
+++ b/config/crd/bases/workspace.jupyter.org_workspaces.yaml
@@ -2097,6 +2097,12 @@ spec:
                 x-kubernetes-validations:
                 - message: volume name 'workspace-storage' is reserved
                   rule: '!self.exists(v, v.name == ''workspace-storage'')'
+              workingDir:
+                description: |-
+                  WorkingDir specifies the container's working directory
+                  Controls where applications like JupyterLab open their file browser by default
+                  Must be an absolute path (e.g., "/home/jovyan/projects")
+                type: string
             required:
             - displayName
             type: object

--- a/config/crd/bases/workspace.jupyter.org_workspacetemplates.yaml
+++ b/config/crd/bases/workspace.jupyter.org_workspacetemplates.yaml
@@ -2052,6 +2052,12 @@ spec:
                       type: string
                   type: object
                 type: array
+              defaultWorkingDir:
+                description: |-
+                  DefaultWorkingDir specifies the default working directory for workspaces using this template
+                  Controls where applications like JupyterLab open their file browser by default
+                  Must be an absolute path (e.g., "/home/jovyan/projects")
+                type: string
               description:
                 description: Description provides additional information about this
                   template

--- a/dist/chart/templates/crd/workspace.jupyter.org_workspaces.yaml
+++ b/dist/chart/templates/crd/workspace.jupyter.org_workspaces.yaml
@@ -2103,6 +2103,12 @@ spec:
                 x-kubernetes-validations:
                 - message: volume name 'workspace-storage' is reserved
                   rule: '!self.exists(v, v.name == ''workspace-storage'')'
+              workingDir:
+                description: |-
+                  WorkingDir specifies the container's working directory
+                  Controls where applications like JupyterLab open their file browser by default
+                  Must be an absolute path (e.g., "/home/jovyan/projects")
+                type: string
             required:
             - displayName
             type: object

--- a/dist/chart/templates/crd/workspace.jupyter.org_workspacetemplates.yaml
+++ b/dist/chart/templates/crd/workspace.jupyter.org_workspacetemplates.yaml
@@ -2058,6 +2058,12 @@ spec:
                       type: string
                   type: object
                 type: array
+              defaultWorkingDir:
+                description: |-
+                  DefaultWorkingDir specifies the default working directory for workspaces using this template
+                  Controls where applications like JupyterLab open their file browser by default
+                  Must be an absolute path (e.g., "/home/jovyan/projects")
+                type: string
               description:
                 description: Description provides additional information about this
                   template

--- a/internal/controller/deployment_builder.go
+++ b/internal/controller/deployment_builder.go
@@ -239,6 +239,7 @@ func (db *DeploymentBuilder) buildPrimaryContainer(workspace *workspacev1alpha1.
 		Args:            args,
 		Lifecycle:       workspace.Spec.Lifecycle,
 		Env:             workspace.Spec.Env,
+		WorkingDir:      workspace.Spec.WorkingDir,
 		Ports: []corev1.ContainerPort{
 			{
 				Name:          "http",

--- a/internal/controller/deployment_builder_test.go
+++ b/internal/controller/deployment_builder_test.go
@@ -154,6 +154,40 @@ var _ = Describe("DeploymentBuilder", func() {
 	})
 
 	Context("Container Configuration", func() {
+		It("should set working directory when specified", func() {
+			workspace := &workspacev1alpha1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-workspace-workingdir",
+					Namespace: "default",
+				},
+				Spec: workspacev1alpha1.WorkspaceSpec{
+					WorkingDir: "/home/jovyan/projects",
+				},
+			}
+
+			deployment, err := deploymentBuilder.BuildDeployment(ctx, workspace)
+			Expect(err).NotTo(HaveOccurred())
+
+			container := deployment.Spec.Template.Spec.Containers[0]
+			Expect(container.WorkingDir).To(Equal("/home/jovyan/projects"))
+		})
+
+		It("should leave working directory empty when not specified", func() {
+			workspace := &workspacev1alpha1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-workspace-no-workingdir",
+					Namespace: "default",
+				},
+				Spec: workspacev1alpha1.WorkspaceSpec{},
+			}
+
+			deployment, err := deploymentBuilder.BuildDeployment(ctx, workspace)
+			Expect(err).NotTo(HaveOccurred())
+
+			container := deployment.Spec.Template.Spec.Containers[0]
+			Expect(container.WorkingDir).To(BeEmpty())
+		})
+
 		It("should set custom command and args", func() {
 			workspace := &workspacev1alpha1.Workspace{
 				ObjectMeta: metav1.ObjectMeta{

--- a/internal/webhook/v1alpha1/core_defaulter.go
+++ b/internal/webhook/v1alpha1/core_defaulter.go
@@ -35,4 +35,9 @@ func applyCoreDefaults(workspace *workspacev1alpha1.Workspace, template *workspa
 	if workspace.Spec.AppType == "" && template.Spec.AppType != "" {
 		workspace.Spec.AppType = template.Spec.AppType
 	}
+
+	// Apply working directory defaults
+	if workspace.Spec.WorkingDir == "" && template.Spec.DefaultWorkingDir != "" {
+		workspace.Spec.WorkingDir = template.Spec.DefaultWorkingDir
+	}
 }

--- a/internal/webhook/v1alpha1/core_defaulter_test.go
+++ b/internal/webhook/v1alpha1/core_defaulter_test.go
@@ -134,5 +134,22 @@ var _ = Describe("CoreDefaulter", func() {
 
 			Expect(workspace.Spec.AppType).To(Equal("vscode"))
 		})
+
+		It("should apply working dir defaults", func() {
+			template.Spec.DefaultWorkingDir = "/home/jovyan/projects"
+
+			applyCoreDefaults(workspace, template)
+
+			Expect(workspace.Spec.WorkingDir).To(Equal("/home/jovyan/projects"))
+		})
+
+		It("should not override existing working dir", func() {
+			workspace.Spec.WorkingDir = "/home/jovyan/work"
+			template.Spec.DefaultWorkingDir = "/home/jovyan/projects"
+
+			applyCoreDefaults(workspace, template)
+
+			Expect(workspace.Spec.WorkingDir).To(Equal("/home/jovyan/work"))
+		})
 	})
 })

--- a/test/e2e/static/storage-base/workspace-custom-workingdir.yaml
+++ b/test/e2e/static/storage-base/workspace-custom-workingdir.yaml
@@ -1,0 +1,18 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: Workspace
+metadata:
+  name: workspace-custom-workingdir
+spec:
+  displayName: "Workspace with Custom Working Dir"
+  image: jk8s-application-jupyter-uv:latest
+  desiredStatus: Running
+  workingDir: /home/jovyan/projects
+  storage:
+    size: 1Gi
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi

--- a/test/e2e/static/storage-base/workspace-workingdir-no-storage.yaml
+++ b/test/e2e/static/storage-base/workspace-workingdir-no-storage.yaml
@@ -1,0 +1,13 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: Workspace
+metadata:
+  name: workspace-workingdir-no-storage
+spec:
+  displayName: "Workspace with Working Dir No Storage"
+  image: jk8s-application-jupyter-uv:latest
+  desiredStatus: Running
+  workingDir: /tmp/work
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi

--- a/test/e2e/workspace_storage_test.go
+++ b/test/e2e/workspace_storage_test.go
@@ -167,6 +167,62 @@ var _ = Describe("Workspace Storage", Ordered, func() {
 				"workspace-storage", "/home/jovyan/data")
 		})
 
+		It("should set container workingDir when specified", func() {
+			workspaceName := "workspace-custom-workingdir"
+			workspaceFilename := "workspace-custom-workingdir"
+
+			By("creating a workspace with custom working dir")
+			createWorkspaceForTest(workspaceFilename, group, baseSubgroup)
+
+			By("waiting for the workspace to become Available")
+			WaitForWorkspaceToReachCondition(
+				workspaceName,
+				workspaceNamespace,
+				ConditionTypeAvailable,
+				ConditionTrue,
+			)
+
+			By("retrieving deployment name from workspace status")
+			deploymentName, err := kubectlGet("workspace", workspaceName, workspaceNamespace,
+				"{.status.deploymentName}")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(deploymentName).NotTo(BeEmpty())
+
+			By("verifying container workingDir is set correctly")
+			workingDir, err := kubectlGet("deployment", deploymentName, workspaceNamespace,
+				"{.spec.template.spec.containers[0].workingDir}")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(workingDir).To(Equal("/home/jovyan/projects"))
+		})
+
+		It("should set container workingDir without storage", func() {
+			workspaceName := "workspace-workingdir-no-storage"
+			workspaceFilename := "workspace-workingdir-no-storage"
+
+			By("creating a workspace with working dir but no storage")
+			createWorkspaceForTest(workspaceFilename, group, baseSubgroup)
+
+			By("waiting for the workspace to become Available")
+			WaitForWorkspaceToReachCondition(
+				workspaceName,
+				workspaceNamespace,
+				ConditionTypeAvailable,
+				ConditionTrue,
+			)
+
+			By("retrieving deployment name from workspace status")
+			deploymentName, err := kubectlGet("workspace", workspaceName, workspaceNamespace,
+				"{.status.deploymentName}")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(deploymentName).NotTo(BeEmpty())
+
+			By("verifying container workingDir is set correctly")
+			workingDir, err := kubectlGet("deployment", deploymentName, workspaceNamespace,
+				"{.spec.template.spec.containers[0].workingDir}")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(workingDir).To(Equal("/tmp/work"))
+		})
+
 		It("should delete pvc when workspace is deleted", func() {
 			workspaceFilename := baseWorkspaceName
 			workspaceName := baseWorkspaceName


### PR DESCRIPTION
## Add workingDir field to Workspace CRD

Adds a workingDir field to WorkspaceSpec that sets the container's working directory. This controls where applications like JupyterLab open their file browser by default, without changing where volumes are mounted.

For example, a workspace can mount its PVC at /home/jovyan but have JupyterLab open to /home/jovyan/projects by setting workingDir: /home/jovyan/projects.

The field is independent of storage — it works with primary storage, secondary volumes, or no storage at all. It maps directly to Kubernetes container.WorkingDir.

Templates can provide a default via defaultWorkingDir on WorkspaceTemplateSpec, inherited by workspaces that don't specify their own.

### Changes

API types:
- WorkspaceSpec.WorkingDir — optional absolute path (api/v1alpha1/workspace_types.go)
- WorkspaceTemplateSpec.DefaultWorkingDir — template default (api/v1alpha1/workspacetemplate_types.go)

Webhook defaulting:
- core_defaulter.go — copies template.Spec.DefaultWorkingDir to workspace when not set

Controller:
- deployment_builder.go — sets container.WorkingDir from workspace.Spec.WorkingDir

### Tests

- Unit tests for defaulting (core_defaulter_test.go) and deployment building (deployment_builder_test.go)
- E2E tests verifying workingDir reaches the deployment container spec, both with and without storage (workspace_storage_test.go)
