### PR TITLE
feat: add auth session infrastructure for web-app fast path

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,12 @@
 # More info: https://docs.docker.com/engine/reference/builder/#dockerignore-file
 # Ignore build and test binaries.
 bin/
+
+# Git and IDE
+.git/
+.vscode/
+.devcontainer/
+
+# Go test artifacts
+cover.out
+dist/

--- a/Makefile
+++ b/Makefile
@@ -584,6 +584,10 @@ setup-aws-internal: ## Setup connection to remote cluster
 	aws ecr describe-repositories --repository-names $(ECR_REPOSITORY_ROTATOR) --region $(AWS_REGION) > /dev/null || \
 	aws ecr create-repository --repository-name $(ECR_REPOSITORY_ROTATOR) --region $(AWS_REGION)
 
+	@echo "Creating ECR repository for web-app if it doesn't exist..."
+	aws ecr describe-repositories --repository-names $(ECR_REPOSITORY_WEB_APP) --region $(AWS_REGION) > /dev/null || \
+	aws ecr create-repository --repository-name $(ECR_REPOSITORY_WEB_APP) --region $(AWS_REGION)
+
 	@if ! kubectl get namespace cert-manager > /dev/null 2>&1; then \
 		echo "Installing cert-manager"; \
 		helm repo add jetstack https://charts.jetstack.io; \

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ ifeq ($(CLOUD_PROVIDER),aws)
 	ECR_REPOSITORY_AUTH := jupyter-k8s-auth
 	ECR_REPOSITORY_ROTATOR := jupyter-k8s-rotator
 	ECR_REPOSITORY_AWS_PLUGIN := jupyter-k8s-aws-plugin
+	ECR_REPOSITORY_WEB_APP := jk8s-application-web-app
 	EKS_CONTEXT := arn:aws:eks:$(AWS_REGION):$(AWS_ACCOUNT_ID):cluster/$(EKS_CLUSTER_NAME)
 endif
 
@@ -754,7 +755,9 @@ deploy-aws-traefik-dex-internal:
 			--set authmiddleware.imageName=$(ECR_REPOSITORY_AUTH) \
 			--set authmiddleware.enableBearerAuth=true \
 			--set rotator.repository=$(ECR_REGISTRY) \
-			--set rotator.imageName=$(ECR_REPOSITORY_ROTATOR)"; \
+			--set rotator.imageName=$(ECR_REPOSITORY_ROTATOR) \
+			--set webApp.repository=$(ECR_REGISTRY) \
+			--set webApp.imageName=$(ECR_REPOSITORY_WEB_APP)"; \
 		if [ ! -z "$$DEX_OAUTH2_SECRET" ]; then \
 			HELM_ARGS="$$HELM_ARGS --set dex.oauth2ProxyClientSecret=$$DEX_OAUTH2_SECRET"; \
 		fi; \
@@ -763,8 +766,6 @@ deploy-aws-traefik-dex-internal:
 			HELM_ARGS="$$HELM_ARGS --set dex.kubernetesClientSecret=$$DEX_K8S_SECRET"; \
 		fi; \
 		\
-		# Default redirect ports are set in values.yaml (8000, 18000, 9800) \
-		# But allow overriding with env vars \
 		if [ ! -z "$$KUBECTL_REDIRECT_PORTS" ]; then \
 			IFS=',' read -ra PORTS <<< "$$KUBECTL_REDIRECT_PORTS"; \
 			PORT_INDEX=0; \
@@ -774,7 +775,7 @@ deploy-aws-traefik-dex-internal:
 			done; \
 		fi; \
 		\
-		helm upgrade --install jk8-aws-traefik-dex /tmp/jk8s-aws-traefik-dex/aws-traefik-dex \
+		helm upgrade --install jk8-aws-traefik-dex /tmp/jk8s-aws-traefik-dex \
 			-n jupyter-k8s-router \
 			--create-namespace \
 			--force \
@@ -790,8 +791,8 @@ deploy-aws-traefik-dex-internal:
 	)
 	@echo "Restarting deployments to use new images..."
 	kubectl rollout restart deployment -n jupyter-k8s-router \
-		traefik oauth2-proxy dex authmiddleware
-	@echo "All deployments to use new images..."
+		traefik oauth2-proxy dex authmiddleware web-app
+	@echo "All deployments restarted to use new images..."
 	# Clean up temporary chart directory
 	rm -rf /tmp/jk8s-aws-traefik-dex
 	@echo "Bash script for end-users to set their kubeconfig available at: dist/users-scripts"

--- a/cmd/rotator/main.go
+++ b/cmd/rotator/main.go
@@ -87,8 +87,11 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
+	// Check for multi-secret mode
+	secretsConfigJSON := os.Getenv(EnvSecretsConfig)
+
 	// Validate secret exists and has valid keys before rotation (single-secret mode only)
-	if os.Getenv(EnvSecretsConfig) == "" {
+	if secretsConfigJSON == "" {
 		log.Printf("Validating secret %s in namespace %s...", secretName, secretNamespace)
 		if err := rotator.ValidateSecret(ctx, k8sClient, secretName, secretNamespace); err != nil {
 			log.Printf("Warning: secret validation failed (this is OK for first run): %v", err)
@@ -96,9 +99,6 @@ func main() {
 			log.Printf("Secret validation passed")
 		}
 	}
-
-	// Check for multi-secret mode
-	secretsConfigJSON := os.Getenv(EnvSecretsConfig)
 
 	if dryRun {
 		if secretsConfigJSON != "" {
@@ -124,8 +124,8 @@ func main() {
 			log.Fatalf("Failed to rotate secrets: %v", err)
 		}
 	} else {
-		// Single-secret mode (backward compatible)
-		if err := rotator.RotateSecret(ctx, k8sClient, secretName, secretNamespace, numberOfKeys); err != nil {
+		// Single-secret mode
+		if err := rotator.RotateSecret(ctx, k8sClient, secretNamespace, rotator.DefaultJWTConfig(secretName, numberOfKeys)); err != nil {
 			log.Fatalf("Failed to rotate keys: %v", err)
 		}
 	}

--- a/cmd/rotator/main.go
+++ b/cmd/rotator/main.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"log"
 	"math"
 	"os"
@@ -29,6 +30,7 @@ const (
 	EnvDryRun           = "DRY_RUN"
 	EnvTokenTTL         = "TOKEN_TTL"
 	EnvRotationInterval = "ROTATION_INTERVAL"
+	EnvSecretsConfig    = "SECRETS_CONFIG"
 )
 
 // Default values
@@ -85,25 +87,47 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	// Validate secret exists and has valid keys before rotation
-	log.Printf("Validating secret %s in namespace %s...", secretName, secretNamespace)
-	if err := rotator.ValidateSecret(ctx, k8sClient, secretName, secretNamespace); err != nil {
-		log.Printf("Warning: secret validation failed (this is OK for first run): %v", err)
-	} else {
-		log.Printf("Secret validation passed")
+	// Validate secret exists and has valid keys before rotation (single-secret mode only)
+	if os.Getenv(EnvSecretsConfig) == "" {
+		log.Printf("Validating secret %s in namespace %s...", secretName, secretNamespace)
+		if err := rotator.ValidateSecret(ctx, k8sClient, secretName, secretNamespace); err != nil {
+			log.Printf("Warning: secret validation failed (this is OK for first run): %v", err)
+		} else {
+			log.Printf("Secret validation passed")
+		}
 	}
 
+	// Check for multi-secret mode
+	secretsConfigJSON := os.Getenv(EnvSecretsConfig)
+
 	if dryRun {
-		log.Printf("DRY RUN: Would rotate keys in secret %s/%s (numberOfKeys=%d)",
-			secretNamespace, secretName, numberOfKeys)
+		if secretsConfigJSON != "" {
+			log.Printf("DRY RUN: Would rotate multiple secrets in namespace %s", secretNamespace)
+		} else {
+			log.Printf("DRY RUN: Would rotate keys in secret %s/%s (numberOfKeys=%d)",
+				secretNamespace, secretName, numberOfKeys)
+		}
 		log.Printf("DRY RUN: Skipping actual rotation")
 		os.Exit(0)
 	}
 
-	// Perform rotation
 	log.Printf("Rotating keys...")
-	if err := rotator.RotateSecret(ctx, k8sClient, secretName, secretNamespace, numberOfKeys); err != nil {
-		log.Fatalf("Failed to rotate keys: %v", err)
+
+	if secretsConfigJSON != "" {
+		// Multi-secret mode
+		var configs []rotator.SecretConfig
+		if err := json.Unmarshal([]byte(secretsConfigJSON), &configs); err != nil {
+			log.Fatalf("Failed to parse %s: %v", EnvSecretsConfig, err)
+		}
+		log.Printf("Multi-secret mode: rotating %d secrets", len(configs))
+		if err := rotator.RotateSecrets(ctx, k8sClient, secretNamespace, configs); err != nil {
+			log.Fatalf("Failed to rotate secrets: %v", err)
+		}
+	} else {
+		// Single-secret mode (backward compatible)
+		if err := rotator.RotateSecret(ctx, k8sClient, secretName, secretNamespace, numberOfKeys); err != nil {
+			log.Fatalf("Failed to rotate keys: %v", err)
+		}
 	}
 
 	log.Printf("Key rotation completed successfully")

--- a/cmd/rotator/main.go
+++ b/cmd/rotator/main.go
@@ -125,7 +125,8 @@ func main() {
 		}
 	} else {
 		// Single-secret mode
-		if err := rotator.RotateSecret(ctx, k8sClient, secretNamespace, rotator.DefaultJWTConfig(secretName, numberOfKeys)); err != nil {
+		cfg := rotator.DefaultJWTConfig(secretName, numberOfKeys)
+		if err := rotator.RotateSecret(ctx, k8sClient, secretNamespace, cfg); err != nil {
 			log.Fatalf("Failed to rotate keys: %v", err)
 		}
 	}

--- a/guided-charts/aws-traefik-dex/templates/defaulter.tpl
+++ b/guided-charts/aws-traefik-dex/templates/defaulter.tpl
@@ -44,3 +44,49 @@ Examples: "5m" converts to every 5 minutes, "1h" converts to every hour.
   {{- fail (printf "Unsupported rotation interval format: %s (use Xm for minutes or Xh for hours)" $interval) -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Convert a Go-style duration string (e.g. "8h", "30m", "1h30m") to total seconds.
+Supports hours (h) and minutes (m).
+*/}}
+{{- define "defaulter.durationToSeconds" -}}
+{{- $input := . -}}
+{{- $totalSeconds := 0 -}}
+{{- if regexMatch "^[0-9]+h" $input -}}
+  {{- $hours := regexFind "[0-9]+" $input | int -}}
+  {{- $totalSeconds = mul $hours 3600 -}}
+  {{- $input = regexReplaceAll "^[0-9]+h" $input "" -}}
+{{- end -}}
+{{- if regexMatch "^[0-9]+m" $input -}}
+  {{- $minutes := regexFind "[0-9]+" $input | int -}}
+  {{- $totalSeconds = add $totalSeconds (mul $minutes 60) -}}
+{{- end -}}
+{{- $totalSeconds -}}
+{{- end -}}
+
+{{/*
+Compute session cookie max age in seconds.
+75% of OAuth2 Proxy cookie expiry to ensure session expires before the OAuth2 session.
+*/}}
+{{- define "defaulter.sessionCookieMaxAgeSecs" -}}
+{{- $expirySecs := include "defaulter.durationToSeconds" .Values.oauth2Proxy.cookieExpire | int -}}
+{{- div (mul $expirySecs 3) 4 -}}
+{{- end -}}
+
+{{/*
+Compute session max lifetime in seconds.
+Equal to the OAuth2 Proxy cookie expiry (absolute upper bound).
+*/}}
+{{- define "defaulter.sessionMaxLifetimeSecs" -}}
+{{- include "defaulter.durationToSeconds" .Values.oauth2Proxy.cookieExpire -}}
+{{- end -}}
+
+{{/*
+Compute session near-expiry threshold in seconds.
+Stop refreshing the session cookie when the OAuth2 token is within this window of expiry.
+Set to 25% of cookie expiry (i.e. the remaining 25% after cookieMaxAge).
+*/}}
+{{- define "defaulter.sessionNearExpiryThresholdSecs" -}}
+{{- $expirySecs := include "defaulter.durationToSeconds" .Values.oauth2Proxy.cookieExpire | int -}}
+{{- div $expirySecs 4 -}}
+{{- end -}}

--- a/guided-charts/aws-traefik-dex/templates/dex/configmap.yaml
+++ b/guided-charts/aws-traefik-dex/templates/dex/configmap.yaml
@@ -13,22 +13,17 @@ data:
     web:
       http: 0.0.0.0:5556
     staticClients:
-    - id: {{ .Values.dex.oauth2ProxyClientId }}
-      redirectURIs:
-      - https://{{ .Values.domain }}/oauth2/callback
-      name: 'OAuth2 Proxy'
-      secret: {{ include "defaulter.oauth2ProxyClientSecret" . }}
     - id: {{ .Values.dex.kubernetesClientId }}
       redirectURIs:
+      # OAuth2 Proxy web callback
+      - https://{{ .Values.domain }}/oauth2/callback
+      # kubectl CLI callbacks
       {{- range .Values.dex.kubernetesClientRedirectPorts }}
       - http://localhost:{{ . }}
       {{- end }}
       name: 'Kubernetes Cluster'
-      {{- if .Values.dex.kubernetesClientSecret }}
-      secret: {{ .Values.dex.kubernetesClientSecret }}
-      {{- else }}
-      public: true
-      {{- end }}
+      # Use the OAuth2 Proxy secret for web authentication
+      secret: {{ include "defaulter.oauth2ProxyClientSecret" . }}
     connectors:
     - type: github
       id: github

--- a/guided-charts/aws-traefik-dex/templates/dex/configmap.yaml
+++ b/guided-charts/aws-traefik-dex/templates/dex/configmap.yaml
@@ -21,7 +21,7 @@ data:
       {{- range .Values.dex.kubernetesClientRedirectPorts }}
       - http://localhost:{{ . }}
       {{- end }}
-      name: 'Kubernetes Cluster'
+      name: 'OAuth2 Proxy'
       # Use the OAuth2 Proxy secret for web authentication
       secret: {{ include "defaulter.oauth2ProxyClientSecret" . }}
     connectors:

--- a/guided-charts/aws-traefik-dex/templates/oauth2-proxy/cookie-secret.yaml
+++ b/guided-charts/aws-traefik-dex/templates/oauth2-proxy/cookie-secret.yaml
@@ -1,3 +1,4 @@
+{{- $existingSecret := lookup "v1" "Secret" .Values.namespace "oauth2-proxy-cookie" -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -5,4 +6,10 @@ metadata:
   namespace: {{ .Values.namespace }}
 type: Opaque
 data:
+  {{- if .Values.oauth2Proxy.cookieSecret }}
   cookie-secret: {{ .Values.oauth2Proxy.cookieSecret | b64enc }}
+  {{- else if and $existingSecret $existingSecret.data (index $existingSecret.data "cookie-secret") }}
+  cookie-secret: {{ index $existingSecret.data "cookie-secret" }}
+  {{- else }}
+  cookie-secret: {{ randAlphaNum 32 | b64enc }}
+  {{- end }}

--- a/guided-charts/aws-traefik-dex/templates/oauth2-proxy/deployment.yaml
+++ b/guided-charts/aws-traefik-dex/templates/oauth2-proxy/deployment.yaml
@@ -59,8 +59,8 @@ spec:
         - --oidc-issuer-url=https://{{ .Values.domain }}/dex
         - --cookie-secure=true
         - --cookie-samesite=lax
-        - --cookie-refresh=1h
-        - --cookie-expire=8h
+        - --cookie-refresh={{ .Values.oauth2Proxy.cookieRefresh }}
+        - --cookie-expire={{ .Values.oauth2Proxy.cookieExpire }}
         - --cookie-domain={{ .Values.domain }}
         - --cookie-path=/
         - --session-store-type=cookie

--- a/guided-charts/aws-traefik-dex/templates/rotator/cronjob.yaml
+++ b/guided-charts/aws-traefik-dex/templates/rotator/cronjob.yaml
@@ -47,12 +47,17 @@ spec:
               readOnlyRootFilesystem: true
               allowPrivilegeEscalation: false
             env:
-            - name: SECRET_NAME
-              value: "{{ .Values.authmiddleware.secretName }}"
             - name: SECRET_NAMESPACE
               value: "{{ .Values.namespace }}"
-            - name: NUMBER_OF_KEYS
-              value: "{{ .Values.rotator.numberOfKeys }}"
             - name: DRY_RUN
               value: "false"
+            {{- if .Values.webApp.enabled }}
+            - name: SECRETS_CONFIG
+              value: '[{"secretName":"{{ .Values.authmiddleware.secretName }}","keyPrefix":"jwt-signing-key-","keySize":48,"numberOfKeys":{{ .Values.rotator.numberOfKeys }}},{"secretName":"{{ .Values.webApp.session.secretName }}","keyPrefix":"{{ .Values.webApp.session.keyPrefix }}","keySize":{{ .Values.webApp.session.keySizeBytes }},"numberOfKeys":{{ .Values.webApp.session.numberOfKeys }}}]'
+            {{- else }}
+            - name: SECRET_NAME
+              value: "{{ .Values.authmiddleware.secretName }}"
+            - name: NUMBER_OF_KEYS
+              value: "{{ .Values.rotator.numberOfKeys }}"
+            {{- end }}
 {{- end }}

--- a/guided-charts/aws-traefik-dex/templates/rotator/rbac.yaml
+++ b/guided-charts/aws-traefik-dex/templates/rotator/rbac.yaml
@@ -18,7 +18,11 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
-    resourceNames: ["{{ .Values.authmiddleware.secretName }}"]
+    resourceNames:
+      - "{{ .Values.authmiddleware.secretName }}"
+      {{- if .Values.webApp.enabled }}
+      - "{{ .Values.webApp.session.secretName }}"
+      {{- end }}
     verbs: ["get", "update", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/guided-charts/aws-traefik-dex/templates/web-app/deployment.yaml
+++ b/guided-charts/aws-traefik-dex/templates/web-app/deployment.yaml
@@ -1,0 +1,85 @@
+{{- if .Values.webApp.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web-app
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: web-app
+    component: web-app
+spec:
+  replicas: {{ .Values.webApp.replicas }}
+  selector:
+    matchLabels:
+      app: web-app
+  template:
+    metadata:
+      labels:
+        app: web-app
+        component: web-app
+    spec:
+      serviceAccountName: web-app
+      containers:
+      - name: web-app
+        image: {{ .Values.webApp.repository }}/{{ .Values.webApp.imageName }}:{{ .Values.webApp.imageTag }}
+        imagePullPolicy: {{ .Values.webApp.imagePullPolicy }}
+        ports:
+        - containerPort: 8090
+          name: http
+        env:
+        - name: NODE_ENV
+          value: "production"
+        - name: PORT
+          value: "8090"
+        - name: NAMESPACE
+          value: {{ .Values.webApp.namespace | quote }}
+        - name: STATIC_DIR
+          value: "./dist"
+        - name: SESSION_COOKIE_NAME
+          value: {{ .Values.webApp.session.cookieName | quote }}
+        - name: SESSION_COOKIE_PATH
+          value: {{ .Values.webApp.session.cookiePath | quote }}
+        - name: SESSION_COOKIE_MAX_AGE_SECS
+          value: {{ include "defaulter.sessionCookieMaxAgeSecs" . | quote }}
+        - name: SESSION_MAX_LIFETIME_SECS
+          value: {{ include "defaulter.sessionMaxLifetimeSecs" . | quote }}
+        - name: SESSION_NEAR_EXPIRY_THRESHOLD_SECS
+          value: {{ include "defaulter.sessionNearExpiryThresholdSecs" . | quote }}
+        - name: SESSION_SECRET_NAME
+          value: {{ .Values.webApp.session.secretName | quote }}
+        - name: SESSION_SECRET_NAMESPACE
+          value: {{ .Values.namespace | quote }}
+        - name: SESSION_KEY_PREFIX
+          value: {{ .Values.webApp.session.keyPrefix | quote }}
+        - name: SESSION_NEW_KEY_USE_DELAY_SECS
+          value: {{ .Values.webApp.session.newKeyUseDelaySecs | quote }}
+        - name: SESSION_EXPECTED_DOMAIN
+          value: {{ .Values.domain | quote }}
+        resources:
+          {{- toYaml .Values.webApp.resources | nindent 10 }}
+        livenessProbe:
+          httpGet:
+            path: /api/v1/health
+            port: http
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 3
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /api/v1/health
+            port: http
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 3
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 1000
+          capabilities:
+            drop:
+            - ALL
+      securityContext:
+        fsGroup: 1000
+{{- end }}

--- a/guided-charts/aws-traefik-dex/templates/web-app/ingressroute.yaml
+++ b/guided-charts/aws-traefik-dex/templates/web-app/ingressroute.yaml
@@ -1,0 +1,73 @@
+{{- if .Values.webApp.enabled }}
+# Fast path: requests with session cookie bypass OAuth2 Proxy
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: web-app-session
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: web-app
+    component: web-app
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`{{ .Values.domain }}`) && PathPrefix(`/api/`) && HeaderRegexp(`Cookie`, `{{ .Values.webApp.session.cookieName }}=`)
+      priority: 15
+      kind: Rule
+      services:
+        - name: web-app
+          port: 8090
+          namespace: {{ .Values.namespace }}
+  tls: {}
+---
+# Auth path: API requests without session cookie go through OAuth2 Proxy
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: web-app-auth
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: web-app
+    component: web-app
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`{{ .Values.domain }}`) && PathPrefix(`/api/`)
+      priority: 10
+      kind: Rule
+      middlewares:
+        - name: oauth-auth-redirect
+          namespace: {{ .Values.namespace }}
+      services:
+        - name: web-app
+          port: 8090
+          namespace: {{ .Values.namespace }}
+  tls: {}
+---
+# Static/SPA catch-all: always through OAuth2 Proxy
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: web-app
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: web-app
+    component: web-app
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`{{ .Values.domain }}`) && PathPrefix(`/`)
+      priority: 5
+      kind: Rule
+      middlewares:
+        - name: oauth-auth-redirect
+          namespace: {{ .Values.namespace }}
+      services:
+        - name: web-app
+          port: 8090
+          namespace: {{ .Values.namespace }}
+  tls: {}
+{{- end }}

--- a/guided-charts/aws-traefik-dex/templates/web-app/rbac.yaml
+++ b/guided-charts/aws-traefik-dex/templates/web-app/rbac.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.webApp.enabled }}
+# ServiceAccount for the web-app pod
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: web-app
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: web-app
+    component: web-app
+---
+# Role for reading session signing keys (secret watch for key rotation)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: web-app-session-reader
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: web-app
+    component: security
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["{{ .Values.webApp.session.secretName }}"]
+    verbs: ["get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: web-app-session-reader
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: web-app
+    component: security
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: web-app-session-reader
+subjects:
+  - kind: ServiceAccount
+    name: web-app
+    namespace: {{ .Values.namespace }}
+{{- end }}

--- a/guided-charts/aws-traefik-dex/templates/web-app/service.yaml
+++ b/guided-charts/aws-traefik-dex/templates/web-app/service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.webApp.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-app
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: web-app
+    component: web-app
+spec:
+  selector:
+    app: web-app
+  ports:
+    - name: http
+      port: 8090
+      targetPort: http
+      protocol: TCP
+{{- end }}

--- a/guided-charts/aws-traefik-dex/templates/web-app/session-secret.yaml
+++ b/guided-charts/aws-traefik-dex/templates/web-app/session-secret.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.webApp.enabled }}
+{{- $existingSecret := lookup "v1" "Secret" .Values.namespace .Values.webApp.session.secretName -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.webApp.session.secretName }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: web-app
+    component: security
+type: Opaque
+data:
+  {{- if and $existingSecret $existingSecret.data }}
+  {{- range $key, $value := $existingSecret.data }}
+  {{ $key }}: {{ $value }}
+  {{- end }}
+  {{- else }}
+  {{ .Values.webApp.session.keyPrefix }}{{ now | unixEpoch }}: {{ randBytes (int .Values.webApp.session.keySizeBytes) }}
+  {{- end }}
+{{- end }}

--- a/guided-charts/aws-traefik-dex/values.yaml
+++ b/guided-charts/aws-traefik-dex/values.yaml
@@ -74,8 +74,9 @@ dex:
   # Prefix for the k8s groups authenticated through Dex
   oidcGroupPrefix: "github:"
 
-  # Client ID for oauth2-proxy to authenticate with Dex (auto-generated if empty)
-  oauth2ProxyClientId: "oauth2-proxy"
+  # Client ID for oauth2-proxy to authenticate with Dex
+  # Must match the Kubernetes OIDC client ID for tokens to work with K8s API
+  oauth2ProxyClientId: "kubectl-oidc"
   # Client secret for oauth2-proxy to authenticate with Dex (auto-generated if empty)
   # Generate with 'openssl rand -hex 16'
   oauth2ProxyClientSecret: ""
@@ -127,12 +128,67 @@ githubRbac:
 oauth2Proxy:
   # Cookie secret for OAuth2 Proxy (generate with openssl rand -base64 32 | tr -- '+/' '-_')
   cookieSecret: ""
+  # Cookie expiry duration (Go duration string, e.g. "8h", "1h30m")
+  # This is the single source of truth for session timing — web-app session
+  # cookie max age, max lifetime, and near-expiry threshold are derived from this
+  cookieExpire: "8h"
+  # Cookie refresh interval (Go duration string)
+  cookieRefresh: "1h"
   # initContainer config for dex availability checks
   dexCheck:
     # Maximum time to wait for Dex to be available in seconds
     timeout_seconds: 300
   # Skip authentication for certain paths (useful for WebSockets)
   skipAuthRegex: []
+
+# ============================================================================
+# Web App (Self-Service UI) - OPTIONAL
+# ============================================================================
+# Enable this to provide a web-based UI for users to manage their workspaces
+# through a browser instead of using kubectl commands.
+#
+# When enabled:
+#   - Users can access the UI at https://<domain>/
+#   - Create, view, update, and delete workspaces through the web interface
+#   - View workspace templates and their configurations
+#   - Authenticated via GitHub OAuth through Dex
+#
+# When disabled:
+#   - Users must use kubectl to manage workspaces
+#   - All workspace management is done via Kubernetes API
+#   - No web interface is available
+#
+# Set 'enabled: false' if you only want kubectl-based workspace management
+# ============================================================================
+webApp:
+  # Enable or disable the web UI (default: true)
+  enabled: true
+  replicas: 1
+  imagePullPolicy: Always
+  repository: docker.io
+  imageName: jupyter-k8s-web-app
+  imageTag: latest
+  # Kubernetes namespace where workspaces are created and managed
+  # This should match the namespace where your WorkspaceTemplates are deployed
+  namespace: default
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+  # Session cookie configuration for auth fast path
+  # Timing values (cookieMaxAge, maxLifetime, nearExpiryThreshold) are
+  # automatically derived from oauth2Proxy.cookieExpire — no need to set them here
+  session:
+    cookieName: "workspace_console_session"
+    cookiePath: "/api/"
+    secretName: "web-app-session-secret"
+    keyPrefix: "session-key-"
+    keySizeBytes: 32
+    numberOfKeys: 3
+    newKeyUseDelaySecs: 60          # Cooloff before using a newly rotated key
 
 # Authmiddleware configuration
 authmiddleware:

--- a/guided-charts/aws-traefik-dex/values.yaml
+++ b/guided-charts/aws-traefik-dex/values.yaml
@@ -163,7 +163,7 @@ oauth2Proxy:
 webApp:
   # Enable or disable the web UI (default: true)
   enabled: true
-  replicas: 1
+  replicas: 2
   imagePullPolicy: Always
   repository: docker.io
   imageName: jupyter-k8s-web-app

--- a/guided-charts/aws-traefik-dex/values.yaml
+++ b/guided-charts/aws-traefik-dex/values.yaml
@@ -161,8 +161,8 @@ oauth2Proxy:
 # Set 'enabled: false' if you only want kubectl-based workspace management
 # ============================================================================
 webApp:
-  # Enable or disable the web UI (default: true)
-  enabled: true
+  # Enable or disable the web UI (default: false)
+  enabled: false
   replicas: 2
   imagePullPolicy: Always
   repository: docker.io

--- a/guided-charts/aws-traefik-dex/values.yaml
+++ b/guided-charts/aws-traefik-dex/values.yaml
@@ -188,7 +188,7 @@ webApp:
     keyPrefix: "session-key-"
     keySizeBytes: 32
     numberOfKeys: 3
-    newKeyUseDelaySecs: 60          # Cooloff before using a newly rotated key
+    newKeyUseDelaySecs: 5           # Cooloff before using a newly rotated key
 
 # Authmiddleware configuration
 authmiddleware:

--- a/internal/jwt/keys.go
+++ b/internal/jwt/keys.go
@@ -27,13 +27,18 @@ func BuildKeyName(timestamp int64) string {
 	return fmt.Sprintf("%s%d", KeyPrefix, timestamp)
 }
 
-// ParseKeyTimestamp extracts the timestamp from a key name
+// ParseKeyTimestamp extracts the timestamp from a key name using the default KeyPrefix.
 func ParseKeyTimestamp(keyName string) (int64, error) {
-	if !strings.HasPrefix(keyName, KeyPrefix) {
-		return 0, fmt.Errorf("key name %s does not have prefix %s", keyName, KeyPrefix)
+	return ParseKeyTimestampWithPrefix(keyName, KeyPrefix)
+}
+
+// ParseKeyTimestampWithPrefix extracts the timestamp from a key name with a given prefix.
+func ParseKeyTimestampWithPrefix(keyName string, prefix string) (int64, error) {
+	if !strings.HasPrefix(keyName, prefix) {
+		return 0, fmt.Errorf("key name %s does not have prefix %s", keyName, prefix)
 	}
 
-	timestampStr := strings.TrimPrefix(keyName, KeyPrefix)
+	timestampStr := strings.TrimPrefix(keyName, prefix)
 	timestamp, err := strconv.ParseInt(timestampStr, 10, 64)
 	if err != nil {
 		return 0, fmt.Errorf("failed to parse timestamp from %s: %w", keyName, err)

--- a/internal/jwt/keys.go
+++ b/internal/jwt/keys.go
@@ -22,9 +22,14 @@ const (
 	KeySizeBytes = 48
 )
 
-// BuildKeyName creates a key name with the given timestamp
-func BuildKeyName(timestamp int64) string {
-	return fmt.Sprintf("%s%d", KeyPrefix, timestamp)
+// BuildKeyName creates a key name with the given timestamp.
+// An optional prefix can be provided; defaults to KeyPrefix.
+func BuildKeyName(timestamp int64, prefix ...string) string {
+	p := KeyPrefix
+	if len(prefix) > 0 {
+		p = prefix[0]
+	}
+	return fmt.Sprintf("%s%d", p, timestamp)
 }
 
 // ParseKeyTimestamp extracts the timestamp from a key name using the default KeyPrefix.

--- a/internal/jwt/keys_test.go
+++ b/internal/jwt/keys_test.go
@@ -14,12 +14,22 @@ import (
 
 func TestBuildKeyName(t *testing.T) {
 	timestamp := int64(1609459200) // 2021-01-01 00:00:00 UTC
-	expected := "jwt-signing-key-1609459200"
-	result := BuildKeyName(timestamp)
 
-	if result != expected {
-		t.Errorf("Expected %s, got %s", expected, result)
-	}
+	t.Run("default prefix", func(t *testing.T) {
+		result := BuildKeyName(timestamp)
+		expected := "jwt-signing-key-1609459200"
+		if result != expected {
+			t.Errorf("Expected %s, got %s", expected, result)
+		}
+	})
+
+	t.Run("custom prefix", func(t *testing.T) {
+		result := BuildKeyName(timestamp, "session-key-")
+		expected := "session-key-1609459200"
+		if result != expected {
+			t.Errorf("Expected %s, got %s", expected, result)
+		}
+	})
 }
 
 func TestParseKeyTimestamp(t *testing.T) {

--- a/internal/jwt/keys_test.go
+++ b/internal/jwt/keys_test.go
@@ -79,6 +79,59 @@ func TestParseKeyTimestamp(t *testing.T) {
 	}
 }
 
+func TestParseKeyTimestampWithPrefix(t *testing.T) {
+	tests := []struct {
+		name        string
+		keyName     string
+		prefix      string
+		expected    int64
+		expectError bool
+	}{
+		{
+			name:     "session key prefix",
+			keyName:  "session-key-1775604478",
+			prefix:   "session-key-",
+			expected: 1775604478,
+		},
+		{
+			name:     "custom prefix",
+			keyName:  "my-prefix-9999999999",
+			prefix:   "my-prefix-",
+			expected: 9999999999,
+		},
+		{
+			name:        "wrong prefix",
+			keyName:     "session-key-1234",
+			prefix:      "jwt-signing-key-",
+			expectError: true,
+		},
+		{
+			name:        "invalid timestamp",
+			keyName:     "session-key-abc",
+			prefix:      "session-key-",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ParseKeyTimestampWithPrefix(tt.keyName, tt.prefix)
+			if tt.expectError {
+				if err == nil {
+					t.Error("Expected error but got none")
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("Unexpected error: %v", err)
+				}
+				if result != tt.expected {
+					t.Errorf("Expected %d, got %d", tt.expected, result)
+				}
+			}
+		})
+	}
+}
+
 func TestParseSigningKeysFromSecret(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/internal/rotator/rotator.go
+++ b/internal/rotator/rotator.go
@@ -85,6 +85,7 @@ func RotateSecret(ctx context.Context, k8sClient client.Client, namespace string
 		return fmt.Errorf("numberOfKeys must be at least 1, got %d", numberOfKeys)
 	}
 
+	// Get current secret
 	secret := &corev1.Secret{}
 	err := k8sClient.Get(ctx, types.NamespacedName{
 		Name:      secretName,
@@ -107,6 +108,7 @@ func RotateSecret(ctx context.Context, k8sClient client.Client, namespace string
 
 		timestamp, err := jwt.ParseKeyTimestampWithPrefix(name, keyPrefix)
 		if err != nil {
+			// Log warning but continue - don't fail rotation due to malformed key
 			log.Printf("Warning: skipping malformed key %s: %v\n", name, err)
 			continue
 		}
@@ -118,10 +120,12 @@ func RotateSecret(ctx context.Context, k8sClient client.Client, namespace string
 		})
 	}
 
+	// Sort keys by timestamp (oldest first)
 	sort.Slice(keys, func(i, j int) bool {
 		return keys[i].timestamp < keys[j].timestamp
 	})
 
+	// Generate new key
 	newKey, err := GenerateKeyWithSize(keySize)
 	if err != nil {
 		return fmt.Errorf("failed to generate new key: %w", err)
@@ -130,12 +134,14 @@ func RotateSecret(ctx context.Context, k8sClient client.Client, namespace string
 	now := time.Now().UTC().Unix()
 	newKeyName := jwt.BuildKeyName(now, keyPrefix)
 
+	// Check if key with this timestamp already exists (clock skew or very fast rotation)
 	for _, k := range keys {
 		if k.name == newKeyName {
 			return fmt.Errorf("key with timestamp %d already exists, refusing to overwrite", now)
 		}
 	}
 
+	// Add new key
 	secret.Data[newKeyName] = newKey
 	keys = append(keys, keyEntry{
 		name:      newKeyName,
@@ -143,10 +149,12 @@ func RotateSecret(ctx context.Context, k8sClient client.Client, namespace string
 		value:     newKey,
 	})
 
+	// Re-sort after adding new key
 	sort.Slice(keys, func(i, j int) bool {
 		return keys[i].timestamp < keys[j].timestamp
 	})
 
+	// Keep only the latest numberOfKeys keys
 	if len(keys) > numberOfKeys {
 		keysToRemove := keys[:len(keys)-numberOfKeys]
 		for _, k := range keysToRemove {
@@ -155,6 +163,7 @@ func RotateSecret(ctx context.Context, k8sClient client.Client, namespace string
 		log.Printf("Pruned %d old keys: %v\n", len(keysToRemove), getKeyNames(keysToRemove))
 	}
 
+	// Update secret
 	err = k8sClient.Update(ctx, secret)
 	if err != nil {
 		return fmt.Errorf("failed to update secret %s: %w", secretName, err)

--- a/internal/rotator/rotator.go
+++ b/internal/rotator/rotator.go
@@ -21,13 +21,43 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// GenerateKey generates a cryptographically random signing key
+// SecretConfig defines the configuration for rotating a single secret.
+type SecretConfig struct {
+	SecretName   string `json:"secretName"`
+	KeyPrefix    string `json:"keyPrefix"`
+	KeySize      int    `json:"keySize"`
+	NumberOfKeys int    `json:"numberOfKeys"`
+}
+
+// GenerateKey generates a cryptographically random signing key of the default size.
 func GenerateKey() ([]byte, error) {
-	key := make([]byte, jwt.KeySizeBytes)
+	return GenerateKeyWithSize(jwt.KeySizeBytes)
+}
+
+// GenerateKeyWithSize generates a cryptographically random key of the specified size.
+// Minimum key size is 16 bytes (128 bits).
+func GenerateKeyWithSize(size int) ([]byte, error) {
+	if size < 16 {
+		return nil, fmt.Errorf("key size must be at least 16 bytes, got %d", size)
+	}
+	key := make([]byte, size)
 	if _, err := rand.Read(key); err != nil {
 		return nil, fmt.Errorf("failed to generate random key: %w", err)
 	}
 	return key, nil
+}
+
+// RotateSecrets performs key rotation on multiple Kubernetes secrets.
+// Each secret is configured independently with its own key prefix, size, and retention count.
+func RotateSecrets(ctx context.Context, k8sClient client.Client, namespace string, configs []SecretConfig) error {
+	for _, cfg := range configs {
+		log.Printf("Rotating secret %s (prefix=%s, keySize=%d, numberOfKeys=%d)",
+			cfg.SecretName, cfg.KeyPrefix, cfg.KeySize, cfg.NumberOfKeys)
+		if err := rotateSecretWithConfig(ctx, k8sClient, cfg.SecretName, namespace, cfg.KeyPrefix, cfg.KeySize, cfg.NumberOfKeys); err != nil {
+			return fmt.Errorf("failed to rotate secret %s: %w", cfg.SecretName, err)
+		}
+	}
+	return nil
 }
 
 // keyEntry represents a signing key with its timestamp
@@ -37,14 +67,18 @@ type keyEntry struct {
 	value     []byte
 }
 
-// RotateSecret performs key rotation on a Kubernetes secret
-// It generates a new key, adds it to the secret, and prunes old keys beyond numberOfKeys
+// RotateSecret performs key rotation on a Kubernetes secret using the default JWT key prefix and size.
+// Backward compatible — delegates to the generalized rotateSecretWithConfig.
 func RotateSecret(ctx context.Context, k8sClient client.Client, secretName string, namespace string, numberOfKeys int) error {
+	return rotateSecretWithConfig(ctx, k8sClient, secretName, namespace, jwt.KeyPrefix, jwt.KeySizeBytes, numberOfKeys)
+}
+
+// rotateSecretWithConfig performs key rotation with configurable prefix and key size.
+func rotateSecretWithConfig(ctx context.Context, k8sClient client.Client, secretName string, namespace string, keyPrefix string, keySize int, numberOfKeys int) error {
 	if numberOfKeys < 1 {
 		return fmt.Errorf("numberOfKeys must be at least 1, got %d", numberOfKeys)
 	}
 
-	// Get current secret
 	secret := &corev1.Secret{}
 	err := k8sClient.Get(ctx, types.NamespacedName{
 		Name:      secretName,
@@ -58,16 +92,15 @@ func RotateSecret(ctx context.Context, k8sClient client.Client, secretName strin
 		secret.Data = make(map[string][]byte)
 	}
 
-	// Parse existing keys
+	// Parse existing keys matching the prefix
 	keys := make([]keyEntry, 0, len(secret.Data))
 	for name, value := range secret.Data {
-		if !strings.HasPrefix(name, jwt.KeyPrefix) {
+		if !strings.HasPrefix(name, keyPrefix) {
 			continue
 		}
 
-		timestamp, err := jwt.ParseKeyTimestamp(name)
+		timestamp, err := parseKeyTimestampWithPrefix(name, keyPrefix)
 		if err != nil {
-			// Log warning but continue - don't fail rotation due to malformed key
 			log.Printf("Warning: skipping malformed key %s: %v\n", name, err)
 			continue
 		}
@@ -79,28 +112,24 @@ func RotateSecret(ctx context.Context, k8sClient client.Client, secretName strin
 		})
 	}
 
-	// Sort keys by timestamp (oldest first)
 	sort.Slice(keys, func(i, j int) bool {
 		return keys[i].timestamp < keys[j].timestamp
 	})
 
-	// Generate new key
-	newKey, err := GenerateKey()
+	newKey, err := GenerateKeyWithSize(keySize)
 	if err != nil {
 		return fmt.Errorf("failed to generate new key: %w", err)
 	}
 
 	now := time.Now().UTC().Unix()
-	newKeyName := jwt.BuildKeyName(now)
+	newKeyName := fmt.Sprintf("%s%d", keyPrefix, now)
 
-	// Check if key with this timestamp already exists (clock skew or very fast rotation)
 	for _, k := range keys {
 		if k.name == newKeyName {
 			return fmt.Errorf("key with timestamp %d already exists, refusing to overwrite", now)
 		}
 	}
 
-	// Add new key
 	secret.Data[newKeyName] = newKey
 	keys = append(keys, keyEntry{
 		name:      newKeyName,
@@ -108,12 +137,10 @@ func RotateSecret(ctx context.Context, k8sClient client.Client, secretName strin
 		value:     newKey,
 	})
 
-	// Re-sort after adding new key
 	sort.Slice(keys, func(i, j int) bool {
 		return keys[i].timestamp < keys[j].timestamp
 	})
 
-	// Keep only the latest numberOfKeys keys
 	if len(keys) > numberOfKeys {
 		keysToRemove := keys[:len(keys)-numberOfKeys]
 		for _, k := range keysToRemove {
@@ -122,7 +149,6 @@ func RotateSecret(ctx context.Context, k8sClient client.Client, secretName strin
 		log.Printf("Pruned %d old keys: %v\n", len(keysToRemove), getKeyNames(keysToRemove))
 	}
 
-	// Update secret
 	err = k8sClient.Update(ctx, secret)
 	if err != nil {
 		return fmt.Errorf("failed to update secret %s: %w", secretName, err)
@@ -133,6 +159,19 @@ func RotateSecret(ctx context.Context, k8sClient client.Client, secretName strin
 		secret.Namespace, secretName, newKeyName, remainingKeys)
 
 	return nil
+}
+
+// parseKeyTimestampWithPrefix extracts the timestamp from a key name with a given prefix.
+func parseKeyTimestampWithPrefix(keyName string, prefix string) (int64, error) {
+	if !strings.HasPrefix(keyName, prefix) {
+		return 0, fmt.Errorf("key name %s does not have prefix %s", keyName, prefix)
+	}
+	timestampStr := strings.TrimPrefix(keyName, prefix)
+	var timestamp int64
+	if _, err := fmt.Sscanf(timestampStr, "%d", &timestamp); err != nil {
+		return 0, fmt.Errorf("invalid timestamp in key name %s: %w", keyName, err)
+	}
+	return timestamp, nil
 }
 
 // getKeyNames extracts key names from keyEntry slice for logging

--- a/internal/rotator/rotator.go
+++ b/internal/rotator/rotator.go
@@ -128,7 +128,7 @@ func RotateSecret(ctx context.Context, k8sClient client.Client, namespace string
 	}
 
 	now := time.Now().UTC().Unix()
-	newKeyName := fmt.Sprintf("%s%d", keyPrefix, now)
+	newKeyName := jwt.BuildKeyName(now, keyPrefix)
 
 	for _, k := range keys {
 		if k.name == newKeyName {

--- a/internal/rotator/rotator.go
+++ b/internal/rotator/rotator.go
@@ -29,6 +29,16 @@ type SecretConfig struct {
 	NumberOfKeys int    `json:"numberOfKeys"`
 }
 
+// DefaultJWTConfig returns a SecretConfig with JWT defaults for single-secret mode.
+func DefaultJWTConfig(secretName string, numberOfKeys int) SecretConfig {
+	return SecretConfig{
+		SecretName:   secretName,
+		KeyPrefix:    jwt.KeyPrefix,
+		KeySize:      jwt.KeySizeBytes,
+		NumberOfKeys: numberOfKeys,
+	}
+}
+
 // GenerateKey generates a cryptographically random signing key of the default size.
 func GenerateKey() ([]byte, error) {
 	return GenerateKeyWithSize(jwt.KeySizeBytes)
@@ -53,7 +63,7 @@ func RotateSecrets(ctx context.Context, k8sClient client.Client, namespace strin
 	for _, cfg := range configs {
 		log.Printf("Rotating secret %s (prefix=%s, keySize=%d, numberOfKeys=%d)",
 			cfg.SecretName, cfg.KeyPrefix, cfg.KeySize, cfg.NumberOfKeys)
-		if err := rotateSecretWithConfig(ctx, k8sClient, cfg.SecretName, namespace, cfg.KeyPrefix, cfg.KeySize, cfg.NumberOfKeys); err != nil {
+		if err := RotateSecret(ctx, k8sClient, namespace, cfg); err != nil {
 			return fmt.Errorf("failed to rotate secret %s: %w", cfg.SecretName, err)
 		}
 	}
@@ -67,14 +77,10 @@ type keyEntry struct {
 	value     []byte
 }
 
-// RotateSecret performs key rotation on a Kubernetes secret using the default JWT key prefix and size.
-// Backward compatible — delegates to the generalized rotateSecretWithConfig.
-func RotateSecret(ctx context.Context, k8sClient client.Client, secretName string, namespace string, numberOfKeys int) error {
-	return rotateSecretWithConfig(ctx, k8sClient, secretName, namespace, jwt.KeyPrefix, jwt.KeySizeBytes, numberOfKeys)
-}
+// RotateSecret performs key rotation on a single Kubernetes secret.
+func RotateSecret(ctx context.Context, k8sClient client.Client, namespace string, cfg SecretConfig) error {
+	secretName, keyPrefix, keySize, numberOfKeys := cfg.SecretName, cfg.KeyPrefix, cfg.KeySize, cfg.NumberOfKeys
 
-// rotateSecretWithConfig performs key rotation with configurable prefix and key size.
-func rotateSecretWithConfig(ctx context.Context, k8sClient client.Client, secretName string, namespace string, keyPrefix string, keySize int, numberOfKeys int) error {
 	if numberOfKeys < 1 {
 		return fmt.Errorf("numberOfKeys must be at least 1, got %d", numberOfKeys)
 	}
@@ -99,7 +105,7 @@ func rotateSecretWithConfig(ctx context.Context, k8sClient client.Client, secret
 			continue
 		}
 
-		timestamp, err := parseKeyTimestampWithPrefix(name, keyPrefix)
+		timestamp, err := jwt.ParseKeyTimestampWithPrefix(name, keyPrefix)
 		if err != nil {
 			log.Printf("Warning: skipping malformed key %s: %v\n", name, err)
 			continue
@@ -159,19 +165,6 @@ func rotateSecretWithConfig(ctx context.Context, k8sClient client.Client, secret
 		secret.Namespace, secretName, newKeyName, remainingKeys)
 
 	return nil
-}
-
-// parseKeyTimestampWithPrefix extracts the timestamp from a key name with a given prefix.
-func parseKeyTimestampWithPrefix(keyName string, prefix string) (int64, error) {
-	if !strings.HasPrefix(keyName, prefix) {
-		return 0, fmt.Errorf("key name %s does not have prefix %s", keyName, prefix)
-	}
-	timestampStr := strings.TrimPrefix(keyName, prefix)
-	var timestamp int64
-	if _, err := fmt.Sscanf(timestampStr, "%d", &timestamp); err != nil {
-		return 0, fmt.Errorf("invalid timestamp in key name %s: %w", keyName, err)
-	}
-	return timestamp, nil
 }
 
 // getKeyNames extracts key names from keyEntry slice for logging

--- a/internal/rotator/rotator_test.go
+++ b/internal/rotator/rotator_test.go
@@ -31,6 +31,7 @@ func getTestClient(objects ...client.Object) client.Client {
 	return fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
 }
 
+
 func TestGenerateKey(t *testing.T) {
 	key, err := GenerateKey()
 	if err != nil {
@@ -66,7 +67,7 @@ func TestRotateSecret_NewSecret(t *testing.T) {
 	k8sClient := getTestClient(secret)
 
 	// Rotate secret
-	err := RotateSecret(ctx, k8sClient, secretName, testNamespace, 3)
+	err := RotateSecret(ctx, k8sClient, testNamespace, DefaultJWTConfig(secretName, 3))
 	if err != nil {
 		t.Fatalf("RotateSecret failed: %v", err)
 	}
@@ -110,7 +111,7 @@ func TestRotateSecret_AddAndPruneKeys(t *testing.T) {
 	// Rotate 4 times (should end up with 3 keys due to pruning)
 	for i := 0; i < 4; i++ {
 		time.Sleep(1 * time.Second) // Ensure different timestamps (unix timestamp precision is 1 second)
-		err := RotateSecret(ctx, k8sClient, secretName, testNamespace, numberOfKeys)
+		err := RotateSecret(ctx, k8sClient, testNamespace, DefaultJWTConfig(secretName, numberOfKeys))
 		if err != nil {
 			t.Fatalf("RotateSecret failed on iteration %d: %v", i, err)
 		}
@@ -146,7 +147,7 @@ func TestRotateSecret_InvalidNumberOfKeys(t *testing.T) {
 	k8sClient := getTestClient()
 	ctx := context.Background()
 
-	err := RotateSecret(ctx, k8sClient, testSecretName, testNamespace, 0)
+	err := RotateSecret(ctx, k8sClient, testNamespace, DefaultJWTConfig(testSecretName, 0))
 	if err == nil {
 		t.Fatal("Expected error for numberOfKeys=0")
 	}
@@ -160,7 +161,7 @@ func TestRotateSecret_SecretNotFound(t *testing.T) {
 	k8sClient := getTestClient()
 	ctx := context.Background()
 
-	err := RotateSecret(ctx, k8sClient, "nonexistent-secret", testNamespace, 3)
+	err := RotateSecret(ctx, k8sClient, testNamespace, DefaultJWTConfig("nonexistent-secret", 3))
 	if err == nil {
 		t.Fatal("Expected error for nonexistent secret")
 	}
@@ -191,7 +192,7 @@ func TestRotateSecret_MalformedKeysSkipped(t *testing.T) {
 	k8sClient := getTestClient(secret)
 
 	// Rotation should succeed and skip malformed keys
-	err := RotateSecret(ctx, k8sClient, secretName, testNamespace, 3)
+	err := RotateSecret(ctx, k8sClient, testNamespace, DefaultJWTConfig(secretName, 3))
 	if err != nil {
 		t.Fatalf("RotateSecret should skip malformed keys, but failed: %v", err)
 	}

--- a/internal/rotator/rotator_test.go
+++ b/internal/rotator/rotator_test.go
@@ -156,6 +156,83 @@ func TestRotateSecret_InvalidNumberOfKeys(t *testing.T) {
 	}
 }
 
+func TestRotateSecrets_MultipleSecrets(t *testing.T) {
+	ctx := context.Background()
+
+	secret1 := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "jwt-secret",
+			Namespace: testNamespace,
+		},
+	}
+	secret2 := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "session-secret",
+			Namespace: testNamespace,
+		},
+	}
+	k8sClient := getTestClient(secret1, secret2)
+
+	configs := []SecretConfig{
+		{SecretName: "jwt-secret", KeyPrefix: "jwt-signing-key-", KeySize: 64, NumberOfKeys: 3},
+		{SecretName: "session-secret", KeyPrefix: "session-key-", KeySize: 32, NumberOfKeys: 2},
+	}
+
+	err := RotateSecrets(ctx, k8sClient, testNamespace, configs)
+	if err != nil {
+		t.Fatalf("RotateSecrets failed: %v", err)
+	}
+
+	// Verify both secrets were rotated
+	for _, cfg := range configs {
+		updated := &corev1.Secret{}
+		err := k8sClient.Get(ctx, types.NamespacedName{Name: cfg.SecretName, Namespace: testNamespace}, updated)
+		if err != nil {
+			t.Fatalf("Failed to get secret %s: %v", cfg.SecretName, err)
+		}
+
+		keyCount := 0
+		for name, value := range updated.Data {
+			if hasPrefix(name, cfg.KeyPrefix) {
+				keyCount++
+				if len(value) != cfg.KeySize {
+					t.Errorf("Secret %s: key %s has size %d, expected %d", cfg.SecretName, name, len(value), cfg.KeySize)
+				}
+			}
+		}
+		if keyCount != 1 {
+			t.Errorf("Secret %s: expected 1 key after first rotation, got %d", cfg.SecretName, keyCount)
+		}
+	}
+}
+
+func TestRotateSecrets_StopsOnError(t *testing.T) {
+	ctx := context.Background()
+
+	// Only create the first secret — second will fail with "not found"
+	secret1 := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "good-secret",
+			Namespace: testNamespace,
+		},
+	}
+	k8sClient := getTestClient(secret1)
+
+	configs := []SecretConfig{
+		{SecretName: "good-secret", KeyPrefix: "jwt-signing-key-", KeySize: 64, NumberOfKeys: 3},
+		{SecretName: "missing-secret", KeyPrefix: "session-key-", KeySize: 32, NumberOfKeys: 2},
+	}
+
+	err := RotateSecrets(ctx, k8sClient, testNamespace, configs)
+	if err == nil {
+		t.Fatal("Expected error when second secret is missing")
+	}
+
+	if !contains(err.Error(), "missing-secret") {
+		t.Errorf("Expected error to mention missing-secret, got: %v", err)
+	}
+}
+
 func TestRotateSecret_SecretNotFound(t *testing.T) {
 	k8sClient := getTestClient()
 	ctx := context.Background()

--- a/internal/rotator/rotator_test.go
+++ b/internal/rotator/rotator_test.go
@@ -31,7 +31,6 @@ func getTestClient(objects ...client.Object) client.Client {
 	return fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
 }
 
-
 func TestGenerateKey(t *testing.T) {
 	key, err := GenerateKey()
 	if err != nil {

--- a/test/helm/guided-aws-traefik-dex/oidc_consistency_test.go
+++ b/test/helm/guided-aws-traefik-dex/oidc_consistency_test.go
@@ -73,7 +73,7 @@ var _ = Describe("OIDC Configuration Consistency", func() {
 		By(fmt.Sprintf("Extracted dex issuer URL: %s", dexIssuerURL))
 
 		// Extract redirectURI
-		matches = regexp.MustCompile(`(?m)redirectURIs:\s*\n\s*-\s*(.+)`).FindStringSubmatch(dexConfigmapContent)
+		matches = regexp.MustCompile(`(?m)redirectURIs:\s*\n(?:\s*#.*\n)*\s*-\s*(.+)`).FindStringSubmatch(dexConfigmapContent)
 		Expect(matches).To(HaveLen(2), "Could not find redirectURI in dex configmap")
 		dexRedirectURI = matches[1]
 		Expect(dexRedirectURI).NotTo(BeEmpty(), "RedirectURI in dex configmap is empty")
@@ -87,7 +87,7 @@ var _ = Describe("OIDC Configuration Consistency", func() {
 		By(fmt.Sprintf("Extracted oauth2-proxy client ID from dex: %s", dexOAuth2ClientID))
 
 		// Extract oauth2-proxy client secret
-		oauth2ProxySecretRegex := `(?m)^\s*name:\s*'OAuth2 Proxy'\s*\n\s*secret:\s*(\S+)`
+		oauth2ProxySecretRegex := `(?m)^\s*name:\s*'OAuth2 Proxy'\s*\n(?:\s*#.*\n)*\s*secret:\s*(\S+)`
 		matches = regexp.MustCompile(oauth2ProxySecretRegex).FindStringSubmatch(dexConfigmapContent)
 		Expect(matches).To(HaveLen(2), "Could not find oauth2-proxy secret in dex configmap")
 		dexOAuth2Secret = matches[1]


### PR DESCRIPTION
## Summary

Rebased from the previously merged fork branch. Changes include:

- Add session secret generation, RBAC, and IngressRoute for web-app session cookies in the aws-traefik-dex guided chart
- Extend the secret rotator to handle session key rotation alongside OAuth2 proxy cookie secrets, with session timings derived from `oauth2Proxy.cookieExpire` via Helm helpers