### PR TITLE
fix: pass template defaults for primary storage

### DIFF
--- a/api/v1alpha1/workspace_types.go
+++ b/api/v1alpha1/workspace_types.go
@@ -44,12 +44,10 @@ type StorageSpec struct {
 	// Size specifies the size of the persistent volume
 	// Supports standard Kubernetes resource quantities (e.g., "10Gi", "500Mi", "1Ti")
 	// Integer values without units are interpreted as bytes
-	// Defaults to 10Gi (applied by webhook, not CRD default, to allow template overrides)
 	Size resource.Quantity `json:"size,omitempty"`
 
 	// MountPath specifies where to mount the persistent volume in the container
 	// Default is /home/jovyan (jovyan is the standard user in Jupyter images)
-	// Defaults applied by webhook, not CRD default, to allow template overrides
 	MountPath string `json:"mountPath,omitempty"`
 }
 

--- a/api/v1alpha1/workspace_types.go
+++ b/api/v1alpha1/workspace_types.go
@@ -44,12 +44,12 @@ type StorageSpec struct {
 	// Size specifies the size of the persistent volume
 	// Supports standard Kubernetes resource quantities (e.g., "10Gi", "500Mi", "1Ti")
 	// Integer values without units are interpreted as bytes
-	// +kubebuilder:default="10Gi"
+	// Defaults to 10Gi (applied by webhook, not CRD default, to allow template overrides)
 	Size resource.Quantity `json:"size,omitempty"`
 
 	// MountPath specifies where to mount the persistent volume in the container
 	// Default is /home/jovyan (jovyan is the standard user in Jupyter images)
-	// +kubebuilder:default="/home/jovyan"
+	// Defaults applied by webhook, not CRD default, to allow template overrides
 	MountPath string `json:"mountPath,omitempty"`
 }
 

--- a/config/crd/bases/workspace.jupyter.org_workspaces.yaml
+++ b/config/crd/bases/workspace.jupyter.org_workspaces.yaml
@@ -1992,7 +1992,6 @@ spec:
                     description: |-
                       MountPath specifies where to mount the persistent volume in the container
                       Default is /home/jovyan (jovyan is the standard user in Jupyter images)
-                      Defaults applied by webhook, not CRD default, to allow template overrides
                     type: string
                   size:
                     anyOf:
@@ -2002,7 +2001,6 @@ spec:
                       Size specifies the size of the persistent volume
                       Supports standard Kubernetes resource quantities (e.g., "10Gi", "500Mi", "1Ti")
                       Integer values without units are interpreted as bytes
-                      Defaults to 10Gi (applied by webhook, not CRD default, to allow template overrides)
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   storageClassName:

--- a/config/crd/bases/workspace.jupyter.org_workspaces.yaml
+++ b/config/crd/bases/workspace.jupyter.org_workspaces.yaml
@@ -1989,20 +1989,20 @@ spec:
                 description: Storage specifies the storage configuration
                 properties:
                   mountPath:
-                    default: /home/jovyan
                     description: |-
                       MountPath specifies where to mount the persistent volume in the container
                       Default is /home/jovyan (jovyan is the standard user in Jupyter images)
+                      Defaults applied by webhook, not CRD default, to allow template overrides
                     type: string
                   size:
                     anyOf:
                     - type: integer
                     - type: string
-                    default: 10Gi
                     description: |-
                       Size specifies the size of the persistent volume
                       Supports standard Kubernetes resource quantities (e.g., "10Gi", "500Mi", "1Ti")
                       Integer values without units are interpreted as bytes
+                      Defaults to 10Gi (applied by webhook, not CRD default, to allow template overrides)
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   storageClassName:

--- a/dist/chart/templates/crd/workspaces.workspace.jupyter.org.yaml
+++ b/dist/chart/templates/crd/workspaces.workspace.jupyter.org.yaml
@@ -1995,7 +1995,6 @@ spec:
                     description: |-
                       MountPath specifies where to mount the persistent volume in the container
                       Default is /home/jovyan (jovyan is the standard user in Jupyter images)
-                      Defaults applied by webhook, not CRD default, to allow template overrides
                     type: string
                   size:
                     anyOf:
@@ -2005,7 +2004,6 @@ spec:
                       Size specifies the size of the persistent volume
                       Supports standard Kubernetes resource quantities (e.g., "10Gi", "500Mi", "1Ti")
                       Integer values without units are interpreted as bytes
-                      Defaults to 10Gi (applied by webhook, not CRD default, to allow template overrides)
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   storageClassName:

--- a/dist/chart/templates/crd/workspaces.workspace.jupyter.org.yaml
+++ b/dist/chart/templates/crd/workspaces.workspace.jupyter.org.yaml
@@ -1992,20 +1992,20 @@ spec:
                 description: Storage specifies the storage configuration
                 properties:
                   mountPath:
-                    default: /home/jovyan
                     description: |-
                       MountPath specifies where to mount the persistent volume in the container
                       Default is /home/jovyan (jovyan is the standard user in Jupyter images)
+                      Defaults applied by webhook, not CRD default, to allow template overrides
                     type: string
                   size:
                     anyOf:
                     - type: integer
                     - type: string
-                    default: 10Gi
                     description: |-
                       Size specifies the size of the persistent volume
                       Supports standard Kubernetes resource quantities (e.g., "10Gi", "500Mi", "1Ti")
                       Integer values without units are interpreted as bytes
+                      Defaults to 10Gi (applied by webhook, not CRD default, to allow template overrides)
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   storageClassName:

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -7322,20 +7322,20 @@ spec:
                 description: Storage specifies the storage configuration
                 properties:
                   mountPath:
-                    default: /home/jovyan
                     description: |-
                       MountPath specifies where to mount the persistent volume in the container
                       Default is /home/jovyan (jovyan is the standard user in Jupyter images)
+                      Defaults applied by webhook, not CRD default, to allow template overrides
                     type: string
                   size:
                     anyOf:
                     - type: integer
                     - type: string
-                    default: 10Gi
                     description: |-
                       Size specifies the size of the persistent volume
                       Supports standard Kubernetes resource quantities (e.g., "10Gi", "500Mi", "1Ti")
                       Integer values without units are interpreted as bytes
+                      Defaults to 10Gi (applied by webhook, not CRD default, to allow template overrides)
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   storageClassName:

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -7325,7 +7325,6 @@ spec:
                     description: |-
                       MountPath specifies where to mount the persistent volume in the container
                       Default is /home/jovyan (jovyan is the standard user in Jupyter images)
-                      Defaults applied by webhook, not CRD default, to allow template overrides
                     type: string
                   size:
                     anyOf:
@@ -7335,7 +7334,6 @@ spec:
                       Size specifies the size of the persistent volume
                       Supports standard Kubernetes resource quantities (e.g., "10Gi", "500Mi", "1Ti")
                       Integer values without units are interpreted as bytes
-                      Defaults to 10Gi (applied by webhook, not CRD default, to allow template overrides)
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                   storageClassName:


### PR DESCRIPTION
When a `WorkspaceTemplate` specifies `primaryStorage.defaultMountPath` (e.g., `/mnt/ebs-volume`), workspaces using that template always get `/home/jovyan` instead. The same issue affects `defaultSize`.

   ### Root Cause

   `StorageSpec.MountPath` and `StorageSpec.Size` had `+kubebuilder:default` markers in the CRD. CRD defaults are applied by the API server **before** the mutating webhook runs. By the time the storage defaulter checks `if workspace.Spec.Storage.MountPath == ""`, the field is
   already `/home/jovyan` — so the template's `defaultMountPath` is never applied.

   ### Fix

   Remove the `+kubebuilder:default` markers from `StorageSpec.Size` and `StorageSpec.MountPath`. The template defaulter and controller fallbacks already handle all scenarios.

   ### Behavior Matrix

   | # | Template? | Template has primaryStorage? | User specifies storage? | User sets mountPath/size? | Before (CRD defaults): After API server | After (no CRD defaults): Persisted on object |
   |---|---|---|---|---|---|---|
   | 1 | Yes | Yes | No | No | Storage is nil (no storage key submitted) | Template values persisted. Same behavior as before. |
   | 2 | Yes | Yes | Yes | Yes | User values kept as-is | User values persisted. Same behavior as before. |
   | 3 | Yes | Yes | Yes | No | CRD pre-fills /home/jovyan + 10Gi before webhook runs | Template values persisted. This is the bug fix — previously CRD defaults won over template. |
   | 4 | Yes | No primaryStorage | Yes | No | CRD pre-fills /home/jovyan + 10Gi before webhook runs | Empty fields on the persisted object. Works at runtime because the controller (pvc_builder.go) has hardcoded fallbacks to /home/jovyan + 10Gi. |
   | 5 | No | N/A | Yes | Yes | User values kept as-is | User values persisted. Same behavior as before. |
   | 6 | No | N/A | Yes | No | CRD pre-fills /home/jovyan + 10Gi before webhook runs | Same as row 4. Empty fields on the persisted object, controller fills them at runtime. |
   | 7 | No | N/A | No | No | Storage is nil | No storage created, no PVC. Same behavior as before. |

 fix #372 
