### PR TITLE
fix: dns cache issues

### DIFF
--- a/api/v1alpha1/workspace_types.go
+++ b/api/v1alpha1/workspace_types.go
@@ -246,11 +246,11 @@ type WorkspaceStatus struct {
 	// +optional
 	AccessStartupProbeFailures *int32 `json:"accessStartupProbeFailures,omitempty"`
 
-	// LastAccessStartupProbeTime records when the last access startup probe
-	// was executed. Used to enforce minimum spacing (periodSeconds) between
-	// probes across reconcile cycles.
+	// EarliestNextProbeTime is the earliest wall-clock time at which the next
+	// access startup probe may fire. Set by the controller after each probe
+	// attempt to enforce spacing; survives watch-triggered re-reconciliations.
 	// +optional
-	LastAccessStartupProbeTime *metav1.Time `json:"lastAccessStartupProbeTime,omitempty"`
+	EarliestNextProbeTime *metav1.Time `json:"earliestNextProbeTime,omitempty"`
 
 	// Conditions represent the current state of the Workspace resource.
 	// Each condition has a unique type and reflects the status of a specific aspect of the resource.

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -765,8 +765,8 @@ func (in *WorkspaceStatus) DeepCopyInto(out *WorkspaceStatus) {
 		*out = new(int32)
 		**out = **in
 	}
-	if in.LastAccessStartupProbeTime != nil {
-		in, out := &in.LastAccessStartupProbeTime, &out.LastAccessStartupProbeTime
+	if in.EarliestNextProbeTime != nil {
+		in, out := &in.EarliestNextProbeTime, &out.EarliestNextProbeTime
 		*out = (*in).DeepCopy()
 	}
 	if in.Conditions != nil {

--- a/config/crd/bases/workspace.jupyter.org_workspaces.yaml
+++ b/config/crd/bases/workspace.jupyter.org_workspaces.yaml
@@ -2225,11 +2225,11 @@ spec:
                 description: DeploymentName is the name of the deployment managing
                   the Workspace pods
                 type: string
-              lastAccessStartupProbeTime:
+              earliestNextProbeTime:
                 description: |-
-                  LastAccessStartupProbeTime records when the last access startup probe
-                  was executed. Used to enforce minimum spacing (periodSeconds) between
-                  probes across reconcile cycles.
+                  EarliestNextProbeTime is the earliest wall-clock time at which the next
+                  access startup probe may fire. Set by the controller after each probe
+                  attempt to enforce spacing; survives watch-triggered re-reconciliations.
                 format: date-time
                 type: string
               serviceName:

--- a/dist/chart/templates/crd/workspaces.workspace.jupyter.org.yaml
+++ b/dist/chart/templates/crd/workspaces.workspace.jupyter.org.yaml
@@ -2228,11 +2228,11 @@ spec:
                 description: DeploymentName is the name of the deployment managing
                   the Workspace pods
                 type: string
-              lastAccessStartupProbeTime:
+              earliestNextProbeTime:
                 description: |-
-                  LastAccessStartupProbeTime records when the last access startup probe
-                  was executed. Used to enforce minimum spacing (periodSeconds) between
-                  probes across reconcile cycles.
+                  EarliestNextProbeTime is the earliest wall-clock time at which the next
+                  access startup probe may fire. Set by the controller after each probe
+                  attempt to enforce spacing; survives watch-triggered re-reconciliations.
                 format: date-time
                 type: string
               serviceName:

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -7558,11 +7558,11 @@ spec:
                 description: DeploymentName is the name of the deployment managing
                   the Workspace pods
                 type: string
-              lastAccessStartupProbeTime:
+              earliestNextProbeTime:
                 description: |-
-                  LastAccessStartupProbeTime records when the last access startup probe
-                  was executed. Used to enforce minimum spacing (periodSeconds) between
-                  probes across reconcile cycles.
+                  EarliestNextProbeTime is the earliest wall-clock time at which the next
+                  access startup probe may fire. Set by the controller after each probe
+                  attempt to enforce spacing; survives watch-triggered re-reconciliations.
                 format: date-time
                 type: string
               serviceName:

--- a/hack/apply-helm-patches.sh
+++ b/hack/apply-helm-patches.sh
@@ -340,4 +340,10 @@ sed -i '/--application-images-pull-policy/d' "${CHART_DIR}/values.yaml"
 sed -i '/--application-images-registry/d' "${CHART_DIR}/values.yaml"
 sed -i '/--default-template-namespace/d' "${CHART_DIR}/values.yaml"
 
+# --- Restore CI workflow files that kubebuilder overwrites with local values ---
+# kubebuilder edit substitutes CONTAINER_TOOL and IMG with local defaults
+# (e.g. finch instead of docker), breaking the CI workflow.
+echo "Restoring CI workflow files..."
+git checkout -- "${SCRIPT_DIR}/../.github/workflows/test-chart.yml" 2>/dev/null || true
+
 echo "Helm chart patches applied successfully"

--- a/internal/controller/access_startup_prober.go
+++ b/internal/controller/access_startup_prober.go
@@ -7,7 +7,9 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"time"
 
@@ -84,9 +86,14 @@ func (p *AccessStartupProber) Probe(
 
 	resp, err := p.client.Do(req)
 	if err != nil {
-		// Connection failures (refused, timeout, DNS) are expected while the
-		// route propagates — return (false, nil) so the caller treats this as
-		// a normal probe failure and retries, not as a reconciliation error.
+		var dnsErr *net.DNSError
+		if errors.As(err, &dnsErr) {
+			logger.Info("Access startup probe: DNS not yet resolved",
+				"url", url, "dnsError", dnsErr)
+			return false, nil
+		}
+		// Connection failures (refused, timeout) are expected while the
+		// route propagates — return not-ready so the caller retries.
 		logger.V(1).Info("Access startup probe connection failed", "url", url, "error", err)
 		return false, nil
 	}

--- a/internal/controller/access_startup_prober_test.go
+++ b/internal/controller/access_startup_prober_test.go
@@ -200,6 +200,19 @@ var _ = Describe("AccessStartupProber", func() {
 			Expect(ready).To(BeFalse())
 		})
 
+		It("should return false for unresolvable hostname", func() {
+			accessStrategy.Spec.AccessStartupProbe = &workspacev1alpha1.AccessStartupProbe{
+				HTTPGet: &workspacev1alpha1.AccessHTTPGetProbe{
+					URLTemplate: "http://this-host-does-not-exist.invalid:8080/",
+				},
+				TimeoutSeconds: 5,
+			}
+
+			ready, err := prober.Probe(context.Background(), workspace, accessStrategy, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ready).To(BeFalse())
+		})
+
 		It("should not follow redirects", func() {
 			redirectCount := 0
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -86,7 +86,16 @@ const (
 	// DefaultAccessStartupProbeTimeoutSeconds is the default probe timeout in seconds
 	DefaultAccessStartupProbeTimeoutSeconds = 5
 	// DefaultAccessStartupProbeFailureThreshold is the default max consecutive failures
-	DefaultAccessStartupProbeFailureThreshold = 30
+	DefaultAccessStartupProbeFailureThreshold = 20
+
+	// ProbeBackoffThreshold is the number of retries (counting from the end)
+	// that use exponential backoff. The first max(0, failureThreshold - this)
+	// retries use the configured periodSeconds; the last 10 use backoff.
+	ProbeBackoffThreshold = 10
+	// ProbeBackoffMaxRetrySeconds caps the exponential backoff interval.
+	// 302s comfortably exceeds any standard CoreDNS negative cache TTL
+	// (default 30s, SOA-driven up to 300s).
+	ProbeBackoffMaxRetrySeconds = 302
 
 	// MinimalRequeueDelay is the delay for near-immediate requeue
 	MinimalRequeueDelay = 10 * time.Millisecond

--- a/internal/controller/state_machine_access.go
+++ b/internal/controller/state_machine_access.go
@@ -136,27 +136,26 @@ func (sm *StateMachine) ProbeAccessStartup(
 		if probe.InitialDelaySeconds > 0 {
 			logger.Info("Access startup probe: waiting for initial delay",
 				"initialDelaySeconds", probe.InitialDelaySeconds)
-			now := metav1.Now()
-			workspace.Status.LastAccessStartupProbeTime = &now
+			delay := time.Duration(probe.InitialDelaySeconds) * time.Second
+			deadline := metav1.NewTime(time.Now().Add(delay))
+			workspace.Status.EarliestNextProbeTime = &deadline
 			return &ProbeResult{
 				Status:       ProbeRetrying,
-				RequeueAfter: time.Duration(probe.InitialDelaySeconds) * time.Second,
+				RequeueAfter: delay,
 			}, nil
 		}
 	}
 
 	// Enforce minimum spacing between probes. Status updates trigger
 	// watch events that re-reconcile faster than RequeueAfter; skip
-	// the actual HTTP probe until enough time has elapsed.
-	if remaining := timeUntilNextProbe(workspace, periodSeconds); remaining > 0 {
+	// the actual HTTP probe until the deadline has passed.
+	if remaining := timeUntilProbeDeadline(workspace); remaining > 0 {
 		return &ProbeResult{
 			Status:       ProbePendingRetry,
 			RequeueAfter: remaining,
 		}, nil
 	}
 
-	now := metav1.Now()
-	workspace.Status.LastAccessStartupProbeTime = &now
 	ready, err := sm.accessStartupProber.Probe(ctx, workspace, accessStrategy, service)
 	if err != nil {
 		return nil, fmt.Errorf("access startup probe error: %w", err)
@@ -176,32 +175,52 @@ func (sm *StateMachine) ProbeAccessStartup(
 	if failures >= failureThreshold {
 		logger.Info("Access startup probe failed: threshold exceeded",
 			"failures", failures, "failureThreshold", failureThreshold)
-		workspace.Status.LastAccessStartupProbeTime = nil
+		workspace.Status.EarliestNextProbeTime = nil
 		return &ProbeResult{Status: ProbeFailureThresholdExceeded}, nil
 	}
 
+	retrySeconds := probeRetrySeconds(periodSeconds, failures, failureThreshold)
+
+	delay := time.Duration(retrySeconds) * time.Second
+	deadline := metav1.NewTime(time.Now().Add(delay))
+	workspace.Status.EarliestNextProbeTime = &deadline
+
 	logger.Info("Access startup probe failed, retrying",
 		"failures", failures, "failureThreshold", failureThreshold,
-		"retryAfterSeconds", periodSeconds)
+		"retryAfterSeconds", retrySeconds)
 	return &ProbeResult{
 		Status:       ProbeRetrying,
-		RequeueAfter: time.Duration(periodSeconds) * time.Second,
+		RequeueAfter: delay,
 	}, nil
 }
 
 func clearProbeState(workspace *workspacev1alpha1.Workspace) {
 	workspace.Status.AccessStartupProbeFailures = nil
-	workspace.Status.LastAccessStartupProbeTime = nil
+	workspace.Status.EarliestNextProbeTime = nil
 }
 
-func timeUntilNextProbe(workspace *workspacev1alpha1.Workspace, periodSeconds int32) time.Duration {
-	if workspace.Status.LastAccessStartupProbeTime == nil {
+func probeRetrySeconds(periodSeconds int32, failures int32, failureThreshold int32) int32 {
+	backoffStart := max(failureThreshold-ProbeBackoffThreshold, 0)
+	if failures <= backoffStart {
+		return periodSeconds
+	}
+	backoff := periodSeconds
+	for i := int32(0); i < failures-backoffStart; i++ {
+		backoff *= 2
+		if backoff >= ProbeBackoffMaxRetrySeconds {
+			return ProbeBackoffMaxRetrySeconds
+		}
+	}
+	return backoff
+}
+
+func timeUntilProbeDeadline(workspace *workspacev1alpha1.Workspace) time.Duration {
+	if workspace.Status.EarliestNextProbeTime == nil {
 		return 0
 	}
-	elapsed := time.Since(workspace.Status.LastAccessStartupProbeTime.Time)
-	period := time.Duration(periodSeconds) * time.Second
-	if elapsed < period {
-		return period - elapsed
+	remaining := time.Until(workspace.Status.EarliestNextProbeTime.Time)
+	if remaining > 0 {
+		return remaining
 	}
 	return 0
 }

--- a/internal/controller/state_machine_access_test.go
+++ b/internal/controller/state_machine_access_test.go
@@ -114,7 +114,7 @@ var _ = Describe("ProbeAccessStartup", func() {
 		Expect(result.RequeueAfter).To(Equal(5 * time.Second))
 		Expect(workspace.Status.AccessStartupProbeFailures).NotTo(BeNil())
 		Expect(*workspace.Status.AccessStartupProbeFailures).To(Equal(int32(0)))
-		Expect(workspace.Status.LastAccessStartupProbeTime).NotTo(BeNil())
+		Expect(workspace.Status.EarliestNextProbeTime).NotTo(BeNil())
 	})
 
 	It("should probe immediately on first attempt without initialDelaySeconds", func() {
@@ -135,7 +135,9 @@ var _ = Describe("ProbeAccessStartup", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).NotTo(BeNil())
 		Expect(result.Status).To(Equal(ProbeRetrying))
-		Expect(result.RequeueAfter).To(Equal(1 * time.Second))
+		// failureThreshold=3 < ProbeBackoffThreshold, so backoff is active
+		// from the start: first failure → periodSeconds*2 = 2s
+		Expect(result.RequeueAfter).To(Equal(2 * time.Second))
 		Expect(*workspace.Status.AccessStartupProbeFailures).To(Equal(int32(1)))
 	})
 
@@ -149,7 +151,7 @@ var _ = Describe("ProbeAccessStartup", func() {
 		Expect(result).NotTo(BeNil())
 		Expect(result.Status).To(Equal(ProbeSucceeded))
 		Expect(workspace.Status.AccessStartupProbeFailures).To(BeNil())
-		Expect(workspace.Status.LastAccessStartupProbeTime).To(BeNil())
+		Expect(workspace.Status.EarliestNextProbeTime).To(BeNil())
 	})
 
 	It("should return ProbeAlreadySucceeded when access resources are already ready", func() {
@@ -185,12 +187,12 @@ var _ = Describe("ProbeAccessStartup", func() {
 		Expect(err.Error()).To(ContainSubstring("template resolution failed"))
 	})
 
-	It("should skip probe and requeue when less than periodSeconds has elapsed", func() {
+	It("should skip probe and requeue when deadline has not passed", func() {
 		mockProber.ready = false
 		zero := int32(0)
 		workspace.Status.AccessStartupProbeFailures = &zero
-		recent := metav1.Now()
-		workspace.Status.LastAccessStartupProbeTime = &recent
+		future := metav1.NewTime(time.Now().Add(1 * time.Second))
+		workspace.Status.EarliestNextProbeTime = &future
 
 		result, err := sm.ProbeAccessStartup(ctx, workspace, accessStrategy, nil)
 		Expect(err).NotTo(HaveOccurred())
@@ -226,20 +228,78 @@ var _ = Describe("ProbeAccessStartup", func() {
 		Expect(workspace.Status.AccessStartupProbeFailures).NotTo(BeNil())
 		Expect(*workspace.Status.AccessStartupProbeFailures).To(Equal(int32(DefaultAccessStartupProbeFailureThreshold)))
 	})
+
+	It("should use normal periodSeconds in the fast phase", func() {
+		mockProber.ready = false
+		// threshold=20, backoff starts at failure 11
+		// failure 9 is still in the fast phase
+		accessStrategy.Spec.AccessStartupProbe.FailureThreshold = 20
+		failures := int32(8)
+		workspace.Status.AccessStartupProbeFailures = &failures
+
+		result, err := sm.ProbeAccessStartup(ctx, workspace, accessStrategy, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Status).To(Equal(ProbeRetrying))
+		Expect(result.RequeueAfter).To(Equal(1 * time.Second))
+	})
+
+	It("should start exponential backoff in the last 10 retries", func() {
+		mockProber.ready = false
+		// threshold=20, backoff starts at failure 11
+		accessStrategy.Spec.AccessStartupProbe.FailureThreshold = 20
+
+		failures := int32(10)
+		workspace.Status.AccessStartupProbeFailures = &failures
+
+		// Failure 11 (1st in backoff phase) → 1*2=2s
+		result, err := sm.ProbeAccessStartup(ctx, workspace, accessStrategy, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Status).To(Equal(ProbeRetrying))
+		Expect(result.RequeueAfter).To(Equal(2 * time.Second))
+
+		workspace.Status.EarliestNextProbeTime = nil
+
+		// Failure 12 → 1*4=4s
+		result, err = sm.ProbeAccessStartup(ctx, workspace, accessStrategy, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Status).To(Equal(ProbeRetrying))
+		Expect(result.RequeueAfter).To(Equal(4 * time.Second))
+
+		workspace.Status.EarliestNextProbeTime = nil
+
+		// Failure 13 → 1*8=8s
+		result, err = sm.ProbeAccessStartup(ctx, workspace, accessStrategy, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Status).To(Equal(ProbeRetrying))
+		Expect(result.RequeueAfter).To(Equal(8 * time.Second))
+	})
+
+	It("should use all backoff when failureThreshold <= ProbeBackoffThreshold", func() {
+		mockProber.ready = false
+		accessStrategy.Spec.AccessStartupProbe.FailureThreshold = 5
+		zero := int32(0)
+		workspace.Status.AccessStartupProbeFailures = &zero
+
+		// threshold=5 < ProbeBackoffThreshold=10, so backoff from failure 1
+		result, err := sm.ProbeAccessStartup(ctx, workspace, accessStrategy, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Status).To(Equal(ProbeRetrying))
+		Expect(result.RequeueAfter).To(Equal(2 * time.Second))
+	})
 })
 
 var _ = Describe("clearProbeState", func() {
-	It("should clear both failures and last probe time", func() {
+	It("should clear both failures and earliest next probe time", func() {
 		failures := int32(5)
-		now := metav1.Now()
+		future := metav1.NewTime(time.Now().Add(5 * time.Second))
 		workspace := &workspacev1alpha1.Workspace{}
 		workspace.Status.AccessStartupProbeFailures = &failures
-		workspace.Status.LastAccessStartupProbeTime = &now
+		workspace.Status.EarliestNextProbeTime = &future
 
 		clearProbeState(workspace)
 
 		Expect(workspace.Status.AccessStartupProbeFailures).To(BeNil())
-		Expect(workspace.Status.LastAccessStartupProbeTime).To(BeNil())
+		Expect(workspace.Status.EarliestNextProbeTime).To(BeNil())
 	})
 
 	It("should be a no-op when both fields are already nil", func() {
@@ -248,40 +308,68 @@ var _ = Describe("clearProbeState", func() {
 		clearProbeState(workspace)
 
 		Expect(workspace.Status.AccessStartupProbeFailures).To(BeNil())
-		Expect(workspace.Status.LastAccessStartupProbeTime).To(BeNil())
+		Expect(workspace.Status.EarliestNextProbeTime).To(BeNil())
 	})
 })
 
-var _ = Describe("timeUntilNextProbe", func() {
-	It("should return 0 when LastAccessStartupProbeTime is nil", func() {
+var _ = Describe("timeUntilProbeDeadline", func() {
+	It("should return 0 when EarliestNextProbeTime is nil", func() {
 		workspace := &workspacev1alpha1.Workspace{}
 
-		Expect(timeUntilNextProbe(workspace, 2)).To(Equal(time.Duration(0)))
+		Expect(timeUntilProbeDeadline(workspace)).To(Equal(time.Duration(0)))
 	})
 
-	It("should return remaining duration when within period", func() {
+	It("should return remaining duration when deadline is in the future", func() {
 		workspace := &workspacev1alpha1.Workspace{}
-		recent := metav1.NewTime(time.Now().Add(-500 * time.Millisecond))
-		workspace.Status.LastAccessStartupProbeTime = &recent
+		future := metav1.NewTime(time.Now().Add(1500 * time.Millisecond))
+		workspace.Status.EarliestNextProbeTime = &future
 
-		remaining := timeUntilNextProbe(workspace, 2)
+		remaining := timeUntilProbeDeadline(workspace)
 		Expect(remaining).To(BeNumerically(">", 0))
-		Expect(remaining).To(BeNumerically("<=", 2*time.Second))
+		Expect(remaining).To(BeNumerically("<=", 1500*time.Millisecond))
 	})
 
-	It("should return 0 when period has fully elapsed", func() {
+	It("should return 0 when deadline has passed", func() {
 		workspace := &workspacev1alpha1.Workspace{}
-		old := metav1.NewTime(time.Now().Add(-5 * time.Second))
-		workspace.Status.LastAccessStartupProbeTime = &old
+		past := metav1.NewTime(time.Now().Add(-5 * time.Second))
+		workspace.Status.EarliestNextProbeTime = &past
 
-		Expect(timeUntilNextProbe(workspace, 2)).To(Equal(time.Duration(0)))
+		Expect(timeUntilProbeDeadline(workspace)).To(Equal(time.Duration(0)))
 	})
 
-	It("should return 0 when exactly at period boundary", func() {
+	It("should return 0 when deadline is exactly now", func() {
 		workspace := &workspacev1alpha1.Workspace{}
-		exact := metav1.NewTime(time.Now().Add(-2 * time.Second))
-		workspace.Status.LastAccessStartupProbeTime = &exact
+		now := metav1.NewTime(time.Now())
+		workspace.Status.EarliestNextProbeTime = &now
 
-		Expect(timeUntilNextProbe(workspace, 2)).To(Equal(time.Duration(0)))
+		Expect(timeUntilProbeDeadline(workspace)).To(Equal(time.Duration(0)))
+	})
+})
+
+var _ = Describe("probeRetrySeconds", func() {
+	It("should return periodSeconds in the fast phase", func() {
+		// failureThreshold=20, backoffStart=10
+		Expect(probeRetrySeconds(2, 0, 20)).To(Equal(int32(2)))
+		Expect(probeRetrySeconds(2, 5, 20)).To(Equal(int32(2)))
+		Expect(probeRetrySeconds(2, 10, 20)).To(Equal(int32(2)))
+	})
+
+	It("should double on each failure in the backoff phase", func() {
+		// failureThreshold=20, backoffStart=10: failure 11→4, 12→8, 13→16
+		Expect(probeRetrySeconds(2, 11, 20)).To(Equal(int32(4)))
+		Expect(probeRetrySeconds(2, 12, 20)).To(Equal(int32(8)))
+		Expect(probeRetrySeconds(2, 13, 20)).To(Equal(int32(16)))
+	})
+
+	It("should cap at ProbeBackoffMaxRetrySeconds", func() {
+		Expect(probeRetrySeconds(2, 100, 20)).To(Equal(int32(ProbeBackoffMaxRetrySeconds)))
+		Expect(probeRetrySeconds(10, 100, 20)).To(Equal(int32(ProbeBackoffMaxRetrySeconds)))
+	})
+
+	It("should use all backoff when failureThreshold <= ProbeBackoffThreshold", func() {
+		// failureThreshold=5, backoffStart=max(5-10,0)=0
+		Expect(probeRetrySeconds(2, 1, 5)).To(Equal(int32(4)))
+		Expect(probeRetrySeconds(2, 2, 5)).To(Equal(int32(8)))
+		Expect(probeRetrySeconds(2, 3, 5)).To(Equal(int32(16)))
 	})
 })

--- a/internal/controller/state_machine_running_access_test.go
+++ b/internal/controller/state_machine_running_access_test.go
@@ -261,7 +261,9 @@ var _ = Describe("reconcileDesiredRunningStatus probe integration", func() {
 			sm := buildStateMachine()
 			result, err := sm.ReconcileDesiredState(ctx, workspace, accessStrategy)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result.RequeueAfter).To(Equal(2 * time.Second))
+			// failureThreshold=3 < ProbeBackoffThreshold, so backoff is active
+			// from the start: first failure → periodSeconds*2 = 4s
+			Expect(result.RequeueAfter).To(Equal(4 * time.Second))
 
 			progressing := getCondition(workspace, ConditionTypeProgressing)
 			Expect(progressing).NotTo(BeNil())
@@ -286,9 +288,9 @@ var _ = Describe("reconcileDesiredRunningStatus probe integration", func() {
 			defer func() { _ = k8sClient.Delete(ctx, workspace) }()
 
 			one := int32(1)
-			now := metav1.Now()
+			future := metav1.NewTime(time.Now().Add(2 * time.Second))
 			workspace.Status.AccessStartupProbeFailures = &one
-			workspace.Status.LastAccessStartupProbeTime = &now
+			workspace.Status.EarliestNextProbeTime = &future
 			Expect(k8sClient.Status().Update(ctx, workspace)).To(Succeed())
 			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(workspace), workspace)).To(Succeed())
 


### PR DESCRIPTION
This PR adds exponential backoff to the `AccessStartupProbe` defined in `AccessStrategy`. By default, the last 10 probes use exponential backoff, using the `periodSeconds` of the `accessStrategy.spec.accessStartupProbe`.

Closes: #369 

Related PR: https://github.com/jupyter-infra/jupyter-k8s-aws/pull/13

### Challenge
- CoreDNS caches DNS resolution in the cluster, which can lead to apparent probe failures
- CoreDNS config is cluster-specific, the operator has no control over it
- if we hit the same cache record too frequently, we risk extending the cache TTL
- this leads to conflicting constraints: on the one hand we want to try fast enough to allow workspace to get to `Available` as fast as possible, on the other hand backoff enough on DNS failure to allow the cached record to invalidate

### Implementation
1. log DNS failure at info level (instead of debug) for traceability
2. change `workspace.status.lastAccessStartupProbeTime` > `workspace.status.earliestNextProbeTime` to support exponential backoff
3. add logic to increase the retry time exponentially for the last 10 probes
4. update default `failureThreshold` to 20, leading to 10 fast polls followed by exponential backoff

### Testing
- unit tests
- E2E tests
- see https://github.com/jupyter-infra/jupyter-k8s-aws/pull/13