### PR TITLE
chore: ci release

### DIFF
--- a/.github/AGENT.md
+++ b/.github/AGENT.md
@@ -1,0 +1,69 @@
+# .github — CI Workflows
+
+## Workflows
+
+| Workflow | Trigger | Purpose |
+|----------|---------|---------|
+| `lint.yml` | push/PR | golangci-lint + helm lint |
+| `test.yml` | push/PR | Unit tests |
+| `test-chart.yml` | push/PR | Helm install on Kind (operator-only chart) |
+| `test-e2e.yml` | push/PR/dispatch | Full E2E on Kind |
+| `release.yml` | `workflow_dispatch` | Orchestrator: stage → e2e → promote → release |
+| `release-stage-images.yml` | `workflow_call` / `workflow_dispatch` | Build multi-arch images, push to staging GHCR |
+| `release-stage-chart.yml` | `workflow_call` / `workflow_dispatch` | Generate, package, push chart to staging GHCR |
+| `release-e2e.yml` | `workflow_call` / `workflow_dispatch` | E2E suite against staging artifacts |
+| `release-promote-images.yml` | `workflow_call` / `workflow_dispatch` | Promote images: crane copy staging → production |
+| `release-promote-chart.yml` | `workflow_call` / `workflow_dispatch` | Promote chart: helm pull staging, push production |
+
+## Testing Workflow Changes
+
+To iterate on workflow changes from a feature branch, create a temporary push-triggered
+workflow that calls the reusable sub-workflows:
+
+```yaml
+# .github/workflows/test-<name>.yml  — DO NOT merge to main
+name: Test workflow (temporary)
+on:
+  push:
+    branches: [your-branch]
+permissions:
+  contents: read
+  packages: write
+jobs:
+  test:
+    uses: ./.github/workflows/release-stage-images.yml
+    with:
+      version: v0.1.0-rc.1
+      short_sha: ""
+    permissions:
+      contents: read
+      packages: write
+```
+
+- `workflow_dispatch` only fires on the default branch — use push triggers for feature branches.
+- Each release sub-workflow supports both `workflow_call` and `workflow_dispatch`, so after
+  merging you can trigger each step individually from the Actions UI.
+- Use pre-release versions (e.g. `v0.1.0-rc.1`) to avoid colliding with real releases.
+- Remove test workflows before merging to main.
+
+## Release Flow
+
+```
+workflow_dispatch (version + dry_run)
+  → validate (semver, tag uniqueness, branch check)
+  → stage-images (multi-arch build → staging GHCR)
+  → stage-chart (helm-generate → package → staging GHCR)
+  → e2e (full test suite against staging)
+  → promote-images (crane copy → production GHCR)     [skipped if dry_run]
+  → promote-chart (helm pull/push → production GHCR)  [skipped if dry_run]
+  → release (git tag + GitHub Release)                 [skipped if dry_run]
+```
+
+## Registries
+
+| Namespace | Visibility | Purpose |
+|-----------|-----------|---------|
+| `ghcr.io/jupyter-infra/staging/` | Private | Pre-release validation |
+| `ghcr.io/jupyter-infra/` | Public | Production artifacts |
+| `ghcr.io/jupyter-infra/staging/charts/` | Private | Chart staging |
+| `ghcr.io/jupyter-infra/charts/` | Public | Chart production |

--- a/.github/workflows/release-e2e.yml
+++ b/.github/workflows/release-e2e.yml
@@ -1,0 +1,71 @@
+name: "Release: E2E"
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+      chart_version:
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Staging image tag (e.g. v0.2.0)'
+        required: true
+      chart_version:
+        description: 'Staging chart version without v prefix (e.g. 0.2.0)'
+        required: true
+
+env:
+  STAGING_REGISTRY: ghcr.io/jupyter-infra/staging
+
+jobs:
+  e2e:
+    name: E2E against staging
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install Kind
+        run: |
+          curl -Lo ./kind https://kind.sigs.k8s.io/dl/latest/kind-linux-amd64
+          chmod +x ./kind
+          sudo mv ./kind /usr/local/bin/kind
+
+      - name: Install kubebuilder
+        run: |
+          curl -L -o kubebuilder "https://go.kubebuilder.io/dl/latest/$(go env GOOS)/$(go env GOARCH)"
+          chmod +x kubebuilder
+          sudo mv kubebuilder /usr/local/bin/
+
+      - name: Install Helm
+        run: make install-helm
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login Helm to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Run e2e against staging
+        run: |
+          make test-e2e-staging \
+            STAGING_REGISTRY=${{ env.STAGING_REGISTRY }} \
+            STAGING_TAG=${{ inputs.version }} \
+            STAGING_CHART_VERSION=${{ inputs.chart_version }} \
+            CONTAINER_TOOL=docker

--- a/.github/workflows/release-promote-chart.yml
+++ b/.github/workflows/release-promote-chart.yml
@@ -1,0 +1,39 @@
+name: "Release: Promote Chart"
+
+on:
+  workflow_call:
+    inputs:
+      chart_version:
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      chart_version:
+        description: 'Chart version to promote (e.g. 0.2.0)'
+        required: true
+
+env:
+  STAGING_REGISTRY: ghcr.io/jupyter-infra/staging
+  PROD_REGISTRY: ghcr.io/jupyter-infra
+  CHART_NAME: jupyter-k8s
+
+jobs:
+  promote:
+    name: Promote chart
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: Login Helm to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Pull from staging and push to production
+        run: |
+          helm pull oci://${{ env.STAGING_REGISTRY }}/charts/${{ env.CHART_NAME }} \
+            --version ${{ inputs.chart_version }}
+          helm push ${{ env.CHART_NAME }}-${{ inputs.chart_version }}.tgz \
+            oci://${{ env.PROD_REGISTRY }}/charts/

--- a/.github/workflows/release-promote-images.yml
+++ b/.github/workflows/release-promote-images.yml
@@ -1,0 +1,59 @@
+name: "Release: Promote Images"
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+      short_sha:
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Image tag to promote (e.g. v0.2.0)'
+        required: true
+      short_sha:
+        description: 'Short SHA tag to promote'
+        required: true
+
+env:
+  STAGING_REGISTRY: ghcr.io/jupyter-infra/staging
+  PROD_REGISTRY: ghcr.io/jupyter-infra
+
+jobs:
+  promote:
+    name: Promote ${{ matrix.image }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        image:
+          - jupyter-k8s-controller
+          - jupyter-k8s-authmiddleware
+          - jupyter-k8s-rotator
+    steps:
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install crane
+        uses: imjasonh/setup-crane@v0.4
+
+      - name: Copy from staging to production
+        run: |
+          crane copy \
+            ${{ env.STAGING_REGISTRY }}/${{ matrix.image }}:${{ inputs.version }} \
+            ${{ env.PROD_REGISTRY }}/${{ matrix.image }}:${{ inputs.version }}
+          crane copy \
+            ${{ env.STAGING_REGISTRY }}/${{ matrix.image }}:sha-${{ inputs.short_sha }} \
+            ${{ env.PROD_REGISTRY }}/${{ matrix.image }}:sha-${{ inputs.short_sha }}
+          crane copy \
+            ${{ env.STAGING_REGISTRY }}/${{ matrix.image }}:${{ inputs.version }} \
+            ${{ env.PROD_REGISTRY }}/${{ matrix.image }}:latest

--- a/.github/workflows/release-stage-chart.yml
+++ b/.github/workflows/release-stage-chart.yml
@@ -68,9 +68,3 @@ jobs:
 
       - name: Push chart to staging
         run: helm push dist/${{ env.CHART_NAME }}-${{ inputs.chart_version }}.tgz oci://${{ env.STAGING_REGISTRY }}/charts/
-
-      - name: Upload chart artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: helm-chart
-          path: dist/${{ env.CHART_NAME }}-${{ inputs.chart_version }}.tgz

--- a/.github/workflows/release-stage-chart.yml
+++ b/.github/workflows/release-stage-chart.yml
@@ -1,0 +1,76 @@
+name: "Release: Stage Chart"
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+      chart_version:
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'App version / image tag (e.g. v0.2.0)'
+        required: true
+      chart_version:
+        description: 'Chart version without v prefix (e.g. 0.2.0)'
+        required: true
+
+env:
+  STAGING_REGISTRY: ghcr.io/jupyter-infra/staging
+  CHART_NAME: jupyter-k8s
+
+jobs:
+  package-and-push:
+    name: Package and push chart
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install kubebuilder
+        run: |
+          curl -L -o kubebuilder "https://go.kubebuilder.io/dl/latest/$(go env GOOS)/$(go env GOARCH)"
+          chmod +x kubebuilder
+          sudo mv kubebuilder /usr/local/bin/
+
+      - name: Install Helm
+        run: make install-helm
+
+      - name: Generate chart
+        run: make helm-generate
+
+      - name: Patch chart version
+        run: |
+          sed -i "s/^version: .*/version: ${{ inputs.chart_version }}/" dist/chart/Chart.yaml
+          sed -i "s/^appVersion: .*/appVersion: \"${{ inputs.version }}\"/" dist/chart/Chart.yaml
+          echo "## Chart.yaml" >> "$GITHUB_STEP_SUMMARY"
+          cat dist/chart/Chart.yaml >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Lint chart
+        run: helm lint dist/chart
+
+      - name: Package chart
+        run: helm package dist/chart -d dist/
+
+      - name: Login to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Push chart to staging
+        run: helm push dist/${{ env.CHART_NAME }}-${{ inputs.chart_version }}.tgz oci://${{ env.STAGING_REGISTRY }}/charts/
+
+      - name: Upload chart artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: helm-chart
+          path: dist/${{ env.CHART_NAME }}-${{ inputs.chart_version }}.tgz

--- a/.github/workflows/release-stage-images.yml
+++ b/.github/workflows/release-stage-images.yml
@@ -1,0 +1,80 @@
+name: "Release: Stage Images"
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+      short_sha:
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Image tag (e.g. v0.2.0)'
+        required: true
+      short_sha:
+        description: 'Short SHA (leave empty to use current HEAD)'
+        required: false
+
+env:
+  STAGING_REGISTRY: ghcr.io/jupyter-infra/staging
+
+jobs:
+  build-and-push:
+    name: Build ${{ matrix.image.name }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        image:
+          - name: jupyter-k8s-controller
+            dockerfile: Dockerfile
+          - name: jupyter-k8s-authmiddleware
+            dockerfile: images/authmiddleware/Dockerfile
+          - name: jupyter-k8s-rotator
+            dockerfile: images/rotator/Dockerfile
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve short SHA
+        id: sha
+        run: |
+          SHA="${{ inputs.short_sha }}"
+          if [ -z "$SHA" ]; then
+            SHA=$(git rev-parse --short HEAD)
+          fi
+          echo "short_sha=$SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.image.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.STAGING_REGISTRY }}/${{ matrix.image.name }}:${{ inputs.version }}
+            ${{ env.STAGING_REGISTRY }}/${{ matrix.image.name }}:sha-${{ steps.sha.outputs.short_sha }}
+            ${{ env.STAGING_REGISTRY }}/${{ matrix.image.name }}:latest
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.version=${{ inputs.version }}
+            org.opencontainers.image.revision=${{ github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,153 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g. v0.2.0)'
+        required: true
+      dry_run:
+        description: 'Push to staging + run e2e, skip promotion and release'
+        type: boolean
+        default: false
+
+env:
+  CHART_NAME: jupyter-k8s
+
+jobs:
+  validate:
+    name: Validate
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.validate.outputs.version }}
+      chart_version: ${{ steps.validate.outputs.chart_version }}
+      short_sha: ${{ steps.validate.outputs.short_sha }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate inputs
+        id: validate
+        run: |
+          VERSION="${{ inputs.version }}"
+
+          # Validate semver format
+          if ! echo "$VERSION" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'; then
+            echo "::error::Invalid version format: $VERSION (expected vX.Y.Z or vX.Y.Z-prerelease)"
+            exit 1
+          fi
+
+          # Chart version strips the v prefix
+          CHART_VERSION="${VERSION#v}"
+
+          # Check tag doesn't already exist
+          if git rev-parse "refs/tags/$VERSION" >/dev/null 2>&1; then
+            echo "::error::Tag $VERSION already exists"
+            exit 1
+          fi
+
+          # Verify on main branch (skip for dry_run)
+          if [ "${{ inputs.dry_run }}" != "true" ]; then
+            BRANCH=$(git rev-parse --abbrev-ref HEAD)
+            if [ "$BRANCH" != "main" ]; then
+              echo "::error::Release must be from main branch (currently on $BRANCH). Use dry_run for testing from other branches."
+              exit 1
+            fi
+          fi
+
+          SHORT_SHA=$(git rev-parse --short HEAD)
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "chart_version=$CHART_VERSION" >> "$GITHUB_OUTPUT"
+          echo "short_sha=$SHORT_SHA" >> "$GITHUB_OUTPUT"
+
+          echo "## Release validation passed" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Version: $VERSION" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Chart version: $CHART_VERSION" >> "$GITHUB_STEP_SUMMARY"
+          echo "- SHA: $SHORT_SHA" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Dry run: ${{ inputs.dry_run }}" >> "$GITHUB_STEP_SUMMARY"
+
+  stage-images:
+    name: Stage images
+    needs: validate
+    uses: ./.github/workflows/release-stage-images.yml
+    with:
+      version: ${{ needs.validate.outputs.version }}
+      short_sha: ${{ needs.validate.outputs.short_sha }}
+    permissions:
+      contents: read
+      packages: write
+
+  stage-chart:
+    name: Stage chart
+    needs: [validate, stage-images]
+    uses: ./.github/workflows/release-stage-chart.yml
+    with:
+      version: ${{ needs.validate.outputs.version }}
+      chart_version: ${{ needs.validate.outputs.chart_version }}
+    permissions:
+      contents: read
+      packages: write
+
+  e2e:
+    name: E2E
+    needs: [validate, stage-images, stage-chart]
+    uses: ./.github/workflows/release-e2e.yml
+    with:
+      version: ${{ needs.validate.outputs.version }}
+      chart_version: ${{ needs.validate.outputs.chart_version }}
+    permissions:
+      contents: read
+      packages: read
+
+  promote-images:
+    name: Promote images
+    needs: [validate, e2e]
+    if: inputs.dry_run == false
+    uses: ./.github/workflows/release-promote-images.yml
+    with:
+      version: ${{ needs.validate.outputs.version }}
+      short_sha: ${{ needs.validate.outputs.short_sha }}
+    permissions:
+      contents: read
+      packages: write
+
+  promote-chart:
+    name: Promote chart
+    needs: [validate, e2e]
+    if: inputs.dry_run == false
+    uses: ./.github/workflows/release-promote-chart.yml
+    with:
+      chart_version: ${{ needs.validate.outputs.chart_version }}
+    permissions:
+      contents: read
+      packages: write
+
+  release:
+    name: Create release
+    needs: [validate, promote-images, promote-chart]
+    if: inputs.dry_run == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download chart artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: helm-chart
+
+      - name: Create tag
+        run: |
+          git tag ${{ needs.validate.outputs.version }}
+          git push origin ${{ needs.validate.outputs.version }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.validate.outputs.version }}
+          generate_release_notes: true
+          files: ${{ env.CHART_NAME }}-${{ needs.validate.outputs.chart_version }}.tgz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-tags: true
 
       - name: Validate inputs
         id: validate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,6 @@ on:
         type: boolean
         default: false
 
-env:
-  CHART_NAME: jupyter-k8s
-
 jobs:
   validate:
     name: Validate
@@ -130,15 +127,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      packages: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Download chart artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: helm-chart
 
       - name: Create tag
         run: |
@@ -150,4 +141,3 @@ jobs:
         with:
           tag_name: ${{ needs.validate.outputs.version }}
           generate_release_notes: true
-          files: ${{ env.CHART_NAME }}-${{ needs.validate.outputs.chart_version }}.tgz

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,11 @@ Ask user before running.
 - Run end-to-end tests (creates a separate kind cluster): `make test-e2e`
 - Run focused e2e tests: `make test-e2e-focus FOCUS="<selector name>"` (e.g., `FOCUS="Workspace Access Strategy"`)
 
+## CI & Release
+
+See [`.github/AGENT.md`](.github/AGENT.md) for workflow details, release flow, and how to
+test workflow changes from feature branches.
+
 ## Notes
 
 - The project uses Kubebuilder with the Helm extension

--- a/Makefile
+++ b/Makefile
@@ -362,6 +362,39 @@ test-e2e-focus: setup-test-e2e manifests generate fmt vet helm-generate load-ima
 	KIND_CLUSTER=$(KIND_CLUSTER) CONTAINER_TOOL=$(CONTAINER_TOOL) go test -tags=e2e ./test/e2e/ -v -timeout 60m -ginkgo.v -ginkgo.focus="$(FOCUS)" -ginkgo.timeout 60m
 	$(MAKE) cleanup-test-e2e
 
+STAGING_REGISTRY ?= ghcr.io/jupyter-infra/staging
+STAGING_TAG ?=
+STAGING_CHART_VERSION ?=
+
+.PHONY: test-e2e-staging
+test-e2e-staging: setup-test-e2e ## Run e2e tests against staging GHCR images and chart. Set STAGING_TAG and STAGING_CHART_VERSION.
+	@if [ -z "$(STAGING_TAG)" ] || [ -z "$(STAGING_CHART_VERSION)" ]; then \
+		echo "Error: STAGING_TAG and STAGING_CHART_VERSION are required."; \
+		echo "Usage: make test-e2e-staging STAGING_TAG=v0.1.0-rc.1 STAGING_CHART_VERSION=0.1.0-rc.1"; \
+		exit 1; \
+	fi
+	@echo "Pulling staging images..."
+	$(CONTAINER_TOOL) pull $(STAGING_REGISTRY)/jupyter-k8s-controller:$(STAGING_TAG)
+	$(CONTAINER_TOOL) pull $(STAGING_REGISTRY)/jupyter-k8s-rotator:$(STAGING_TAG)
+	@echo "Loading staging images into e2e cluster $(KIND_CLUSTER)..."
+	@mkdir -p /tmp/kind-images
+	$(CONTAINER_TOOL) save $(STAGING_REGISTRY)/jupyter-k8s-controller:$(STAGING_TAG) -o /tmp/kind-images/staging-controller.tar
+	$(KIND) load image-archive /tmp/kind-images/staging-controller.tar --name $(KIND_CLUSTER)
+	rm -f /tmp/kind-images/staging-controller.tar
+	$(CONTAINER_TOOL) save $(STAGING_REGISTRY)/jupyter-k8s-rotator:$(STAGING_TAG) -o /tmp/kind-images/staging-rotator.tar
+	$(KIND) load image-archive /tmp/kind-images/staging-rotator.tar --name $(KIND_CLUSTER)
+	rm -f /tmp/kind-images/staging-rotator.tar
+	@echo "Loading application images into e2e cluster $(KIND_CLUSTER)..."
+	$(MAKE) -C images push-all-kind CLUSTER_NAME=$(KIND_CLUSTER) CONTAINER_TOOL=$(CONTAINER_TOOL)
+	@echo "Running e2e tests against staging artifacts..."
+	KIND_CLUSTER=$(KIND_CLUSTER) CONTAINER_TOOL=$(CONTAINER_TOOL) \
+		E2E_MANAGER_IMAGE=$(STAGING_REGISTRY)/jupyter-k8s-controller:$(STAGING_TAG) \
+		E2E_ROTATOR_IMAGE=$(STAGING_REGISTRY)/jupyter-k8s-rotator:$(STAGING_TAG) \
+		E2E_CHART_SOURCE=oci://$(STAGING_REGISTRY)/charts/jupyter-k8s \
+		E2E_CHART_VERSION=$(STAGING_CHART_VERSION) \
+		go test -tags=e2e ./test/e2e/ -v -timeout 60m -ginkgo.v -ginkgo.timeout 60m
+	$(MAKE) cleanup-test-e2e
+
 .PHONY: teardown-kind
 teardown-kind: ## Tear down the Kind cluster, registry, and clean up images
 	# Delete the Kind cluster
@@ -426,6 +459,8 @@ deploy-kind: docker-build build-rotator helm-generate kubectl-kind ## Build, loa
 	$(MAKE) load-images
 	helm upgrade --install $(HELM_RELEASE) dist/chart \
 		--namespace jupyter-k8s-system --create-namespace \
+		--set manager.image.repository=$${IMG%:*} \
+		--set manager.image.tag=$${IMG##*:} \
 		--set manager.image.pullPolicy=Never \
 		--set application.imagesPullPolicy=Never \
 		--set application.imagesRegistry='docker.io/library' \

--- a/dist/chart/templates/extras/jwt-rotator.yaml
+++ b/dist/chart/templates/extras/jwt-rotator.yaml
@@ -33,7 +33,7 @@ spec:
               value: {{ .Values.extensionApi.jwtSecret.rotationInterval | quote }}
             - name: DRY_RUN
               value: "false"
-            image: "{{ .Values.extensionApi.jwtSecret.rotator.repository }}/{{ .Values.extensionApi.jwtSecret.rotator.imageName }}:{{ .Values.extensionApi.jwtSecret.rotator.imageTag }}"
+            image: "{{ .Values.extensionApi.jwtSecret.rotator.repository }}/{{ .Values.extensionApi.jwtSecret.rotator.imageName }}:{{ .Values.extensionApi.jwtSecret.rotator.imageTag | default .Chart.AppVersion }}"
             imagePullPolicy: {{ .Values.extensionApi.jwtSecret.rotator.imagePullPolicy }}
             name: rotator
             resources:

--- a/dist/chart/templates/manager/manager.yaml
+++ b/dist/chart/templates/manager/manager.yaml
@@ -98,7 +98,7 @@ spec:
           {{- else }}
           []
           {{- end }}
-        image: "{{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag }}"
+        image: "{{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.manager.image.pullPolicy }}
         livenessProbe:
           httpGet:

--- a/dist/chart/values.yaml
+++ b/dist/chart/values.yaml
@@ -12,8 +12,8 @@ manager:
   replicas: 1
 
   image:
-    repository: controller
-    tag: latest
+    repository: ghcr.io/jupyter-infra/jupyter-k8s-controller
+    tag: ""
     pullPolicy: IfNotPresent
 
   ## Arguments
@@ -201,9 +201,9 @@ extensionApi:
     newKeyUseDelay: "5s"
     rotationInterval: "15m"
     rotator:
-      repository: "docker.io/library"
+      repository: "ghcr.io/jupyter-infra"
       imageName: "jupyter-k8s-rotator"
-      imageTag: "latest"
+      imageTag: ""
       imagePullPolicy: "IfNotPresent"
       resources:
         requests:

--- a/hack/apply-helm-patches.sh
+++ b/hack/apply-helm-patches.sh
@@ -202,7 +202,7 @@ spec:
               value: {{ .Values.extensionApi.jwtSecret.rotationInterval | quote }}
             - name: DRY_RUN
               value: "false"
-            image: "{{ .Values.extensionApi.jwtSecret.rotator.repository }}/{{ .Values.extensionApi.jwtSecret.rotator.imageName }}:{{ .Values.extensionApi.jwtSecret.rotator.imageTag }}"
+            image: "{{ .Values.extensionApi.jwtSecret.rotator.repository }}/{{ .Values.extensionApi.jwtSecret.rotator.imageName }}:{{ .Values.extensionApi.jwtSecret.rotator.imageTag | default .Chart.AppVersion }}"
             imagePullPolicy: {{ .Values.extensionApi.jwtSecret.rotator.imagePullPolicy }}
             name: rotator
             resources:
@@ -361,6 +361,18 @@ fi
 
 # --- Set fullnameOverride so resource names are jupyter-k8s-* regardless of release name ---
 sed -i 's/^# fullnameOverride: ""/fullnameOverride: "jupyter-k8s"/' "${CHART_DIR}/values.yaml"
+
+# --- Set GHCR image defaults ---
+# Manager image: use GHCR path with empty tag (falls back to .Chart.AppVersion)
+echo "Setting GHCR image defaults..."
+sed -i '/^  image:$/,/^  ##/{
+    s|repository: .*|repository: ghcr.io/jupyter-infra/jupyter-k8s-controller|
+    s|tag: .*|tag: ""|
+}' "${CHART_DIR}/values.yaml"
+
+# --- Manager image tag: use appVersion fallback ---
+echo "Setting appVersion fallback for image tags..."
+sed -i 's#image: "{{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag }}"#image: "{{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag | default .Chart.AppVersion }}"#' "${MANAGER_YAML}"
 
 # --- Ensure rbacHelpers defaults to true ---
 # Our chart has always shipped these roles; v2-alpha defaults to false

--- a/hack/helm-patches/values.yaml.patch
+++ b/hack/helm-patches/values.yaml.patch
@@ -44,9 +44,9 @@ extensionApi:
     newKeyUseDelay: "5s"
     rotationInterval: "15m"
     rotator:
-      repository: "docker.io/library"
+      repository: "ghcr.io/jupyter-infra"
       imageName: "jupyter-k8s-rotator"
-      imageTag: "latest"
+      imageTag: ""
       imagePullPolicy: "IfNotPresent"
       resources:
         requests:

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -25,18 +25,50 @@ import (
 var (
 	// Optional Environment Variables:
 	// - CERT_MANAGER_INSTALL_SKIP=true: Skips CertManager installation during test setup.
-	// These variables are useful if CertManager is already installed, avoiding
-	// re-installation and conflicts.
+	// - E2E_MANAGER_IMAGE: Override manager image (default: jupyter.org/jupyter-k8s:v0.0.1)
+	// - E2E_ROTATOR_IMAGE: Override rotator image (default: docker.io/library/rotator:local)
+	// - E2E_CHART_SOURCE: Override chart source — local path or oci:// URL (default: dist/chart)
+	// - E2E_CHART_VERSION: Chart version for OCI source (required when E2E_CHART_SOURCE is oci://)
 	skipCertManagerInstall = os.Getenv("CERT_MANAGER_INSTALL_SKIP") == "true"
 	// isCertManagerAlreadyInstalled will be set true when CertManager CRDs be found on the cluster
 	isCertManagerAlreadyInstalled = false
 
-	// projectImage is the name of the image which will be build and loaded
-	// with the code source changes to be tested.
-	projectImage = "jupyter.org/jupyter-k8s:v0.0.1"
-
+	projectImage    = envOrDefault("E2E_MANAGER_IMAGE", "jupyter.org/jupyter-k8s:v0.0.1")
+	rotatorImage    = envOrDefault("E2E_ROTATOR_IMAGE", "docker.io/library/rotator:local")
+	chartSource     = envOrDefault("E2E_CHART_SOURCE", "dist/chart")
+	chartVersion    = os.Getenv("E2E_CHART_VERSION")
 	helmReleaseName = "jupyter-k8s"
 )
+
+func envOrDefault(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+// splitImageRepo splits "ghcr.io/jupyter-infra/jupyter-k8s-rotator:tag" into
+// ("ghcr.io/jupyter-infra", "jupyter-k8s-rotator:tag").
+func splitImageRepo(image string) (string, string) {
+	// Remove tag for path parsing
+	path := image
+	if idx := strings.LastIndex(image, ":"); idx > 0 {
+		path = image[:idx]
+	}
+	lastSlash := strings.LastIndex(path, "/")
+	if lastSlash < 0 {
+		return "", image
+	}
+	return image[:lastSlash], image[lastSlash+1:]
+}
+
+// splitImageNameTag splits "jupyter-k8s-rotator:tag" into ("jupyter-k8s-rotator", "tag").
+func splitImageNameTag(nameTag string) (string, string) {
+	if idx := strings.LastIndex(nameTag, ":"); idx > 0 {
+		return nameTag[:idx], nameTag[idx+1:]
+	}
+	return nameTag, "latest"
+}
 
 // TestE2E runs the end-to-end (e2e) test suite for the project. These tests execute in an isolated,
 // temporary environment to validate project changes with the purpose of being used in CI jobs.
@@ -70,25 +102,34 @@ var _ = BeforeSuite(func() {
 	// Check if operator is already installed and clean up the cluster if needed
 	checkAndCleanCluster()
 
-	// Check if image exists to skip unnecessary rebuild
-	By("checking if manager image exists")
 	containerTool := os.Getenv("CONTAINER_TOOL")
 	if containerTool == "" {
 		containerTool = "docker"
 	}
-	cmd := exec.Command(containerTool, "image", "inspect", projectImage)
-	if _, err := cmd.CombinedOutput(); err != nil {
-		By("building the manager(Operator) image")
-		cmd = exec.Command("make", "docker-build", fmt.Sprintf("IMG=%s", projectImage))
-		_, err := utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to build manager image")
+
+	// Build the manager image only when using the default local image.
+	// When E2E_MANAGER_IMAGE is set, assume the image is already available locally
+	// (e.g., pulled from GHCR and loaded into Kind by the caller).
+	if os.Getenv("E2E_MANAGER_IMAGE") == "" {
+		By("checking if manager image exists")
+		inspectCmd := exec.Command(containerTool, "image", "inspect", projectImage)
+		if _, err := inspectCmd.CombinedOutput(); err != nil {
+			By("building the manager(Operator) image")
+			buildCmd := exec.Command("make", "docker-build", fmt.Sprintf("IMG=%s", projectImage))
+			_, err := utils.Run(buildCmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to build manager image")
+		} else {
+			_, _ = fmt.Fprintf(GinkgoWriter, "Manager image already exists, skipping build\n")
+		}
+
+		By("loading the manager(Operator) image on Kind")
+		Expect(utils.LoadImageToKindClusterWithName(projectImage)).To(Succeed(), "Failed to load image to Kind cluster")
 	} else {
-		_, _ = fmt.Fprintf(GinkgoWriter, "Manager image already exists, skipping build\n")
+		_, _ = fmt.Fprintf(GinkgoWriter, "Using pre-built manager image: %s\n", projectImage)
 	}
 
-	By("loading the manager(Operator) image on Kind")
-	err := utils.LoadImageToKindClusterWithName(projectImage)
-	Expect(err).NotTo(HaveOccurred(), "Failed to load image to Kind cluster")
+	var cmd *exec.Cmd
+	var err error
 
 	// The tests-e2e are intended to run on a temporary cluster that is created and destroyed for testing.
 	// To prevent errors when tests run in environments with CertManager already installed,
@@ -150,9 +191,13 @@ var _ = BeforeSuite(func() {
 
 	// Deploy operator via helm chart — this installs CRDs, RBAC, webhooks, extension API,
 	// and the controller in a single step, matching what users actually consume.
-	By("deploying operator via helm chart")
+	By(fmt.Sprintf("deploying operator via helm chart (source: %s)", chartSource))
+
+	rotatorRepo, rotatorNameTag := splitImageRepo(rotatorImage)
+	rotatorName, rotatorTag := splitImageNameTag(rotatorNameTag)
+
 	helmArgs := []string{
-		"upgrade", "--install", helmReleaseName, "dist/chart",
+		"upgrade", "--install", helmReleaseName, chartSource,
 		"--namespace", OperatorNamespace, "--create-namespace",
 		"--set", fmt.Sprintf("manager.image.repository=%s", strings.Split(projectImage, ":")[0]),
 		"--set", fmt.Sprintf("manager.image.tag=%s", strings.Split(projectImage, ":")[1]),
@@ -161,14 +206,17 @@ var _ = BeforeSuite(func() {
 		"--set", "application.imagesRegistry=docker.io/library",
 		"--set", "extensionApi.enable=true",
 		"--set", "extensionApi.jwtSecret.enable=true",
-		"--set", "extensionApi.jwtSecret.rotator.repository=docker.io/library",
-		"--set", "extensionApi.jwtSecret.rotator.imageName=rotator",
-		"--set", "extensionApi.jwtSecret.rotator.imageTag=local",
+		"--set", fmt.Sprintf("extensionApi.jwtSecret.rotator.repository=%s", rotatorRepo),
+		"--set", fmt.Sprintf("extensionApi.jwtSecret.rotator.imageName=%s", rotatorName),
+		"--set", fmt.Sprintf("extensionApi.jwtSecret.rotator.imageTag=%s", rotatorTag),
 		"--set", "extensionApi.jwtSecret.rotator.imagePullPolicy=Never",
 		"--set", "workspacePodWatching.enable=true",
 		"--set", "accessResources.traefik.enable=true",
 		"--wait",
 		"--timeout", "5m",
+	}
+	if strings.HasPrefix(chartSource, "oci://") && chartVersion != "" {
+		helmArgs = append(helmArgs, "--version", chartVersion)
 	}
 	cmd = exec.Command("helm", helmArgs...)
 	_, err = utils.Run(cmd)


### PR DESCRIPTION
This PR adds a release github workflow which publishes 4 packages to `ghcr` of `jupyter-infra`: 
1. operator image to `jupyper-k8s`
2. authmiddleware image to `jupyter-k8s-authmiddleware`
3. rotator image to `jupyter-k8s-rotator` 
4. operator chart to `charts/jupyter-k8s`

### Implementation
1. add workflow triggered jobs:
    1.1. `release-stage-images.yml` > build & push each docker image to `staging/<img>` in `ghcr` of `jupyter-infra`
    1.2. `release-stage-chart.yml` > build & push chart to `staging/charts/jupyter-k8s` (using `oci://`)
    1.3. `release-e2e.yml` > start a `kind` cluster, install the staged chart (1.2) which pins (1.1) images, run the E2E tests
    1.4. `promote-images.yml` > copy img from `staging/<img>` to `<img>` in `ghcr`
    1.5. `promote-chart.yml` > copy chart from `staging/charts/<chart>` to `charts/<chart>` in `ghcr` (using `oci://`)
2. add `release.yml` workflow in `.github/release.yml` which takes version to release (semver) as arg
3. add `Makefile` method for running E2E tests against staging
4. add `.github/AGENT.md` to explain how to test the CI
5. add pointer to `.github/AGENT.md` in root `CLAUDE.md`

### Testing
- pushed to another branch of the repo, run each workflow separately
- ran a release workflow, see [results](https://github.com/jupyter-infra/jupyter-k8s/actions/runs/25119405189)