### PR TITLE
fix: access probe reset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,7 @@ test: manifests generate fmt vet setup-envtest ## Run tests.
 
 # Used for automated e2e tests
 KIND_CLUSTER ?= jupyter-k8s-test-e2e
+E2E_MANAGER_IMAGE ?= jupyter.org/jupyter-k8s:v0.0.1
 
 # Used for manual development
 DEV_KIND_CLUSTER ?= jupyter-k8s-dev
@@ -427,13 +428,14 @@ load-images: docker-build build-rotator ## Build and load images into the Kind c
 	$(MAKE) -C images push-all-kind CLUSTER_NAME=$(DEV_KIND_CLUSTER) CONTAINER_TOOL=$(CONTAINER_TOOL)
 
 .PHONY: load-images-e2e
-load-images-e2e: build-rotator ## Build and load application images into the e2e test Kind cluster
-	@echo "Removing stale images to force rebuild..."
-	@$(CONTAINER_TOOL) rmi jupyter.org/jupyter-k8s:v0.0.1 2>/dev/null || true
-	@$(CONTAINER_TOOL) rmi docker.io/library/rotator:local 2>/dev/null || true
-	@echo "Loading application images into e2e test cluster ${KIND_CLUSTER}..."
-	@echo "Loading rotator image into e2e test cluster ${KIND_CLUSTER}..."
+load-images-e2e: build-rotator ## Build and load all images into the e2e test Kind cluster
+	@echo "Building manager image..."
+	$(CONTAINER_TOOL) build $(BUILD_OPTS) -t $(E2E_MANAGER_IMAGE) .
+	@echo "Loading images into e2e test cluster ${KIND_CLUSTER}..."
 	@mkdir -p /tmp/kind-images
+	$(CONTAINER_TOOL) save $(E2E_MANAGER_IMAGE) -o /tmp/kind-images/manager.tar
+	$(KIND) load image-archive /tmp/kind-images/manager.tar --name $(KIND_CLUSTER)
+	rm -f /tmp/kind-images/manager.tar
 	$(CONTAINER_TOOL) save docker.io/library/rotator:local -o /tmp/kind-images/rotator.tar
 	$(KIND) load image-archive /tmp/kind-images/rotator.tar --name $(KIND_CLUSTER)
 	rm -f /tmp/kind-images/rotator.tar

--- a/Makefile
+++ b/Makefile
@@ -135,18 +135,18 @@ DEV_KIND_CLUSTER ?= jupyter-k8s-dev
 USE_KIND ?= false
 
 .PHONY: setup-test-e2e
-setup-test-e2e: ## Set up a Kind cluster for e2e tests if it does not exist
+setup-test-e2e: ## Set up a fresh Kind cluster for e2e tests (deletes existing cluster first)
 	@command -v $(KIND) >/dev/null 2>&1 || { \
 		echo "Kind is not installed. Please install Kind manually."; \
 		exit 1; \
 	}
 	@case "$$($(KIND) get clusters)" in \
 		*"$(KIND_CLUSTER)"*) \
-			echo "Kind cluster '$(KIND_CLUSTER)' already exists. Skipping creation." ;; \
-		*) \
-			echo "Creating Kind cluster '$(KIND_CLUSTER)'..."; \
-			$(KIND) create cluster --name $(KIND_CLUSTER) ;; \
+			echo "Deleting existing Kind cluster '$(KIND_CLUSTER)' for a fresh start..."; \
+			$(KIND) delete cluster --name $(KIND_CLUSTER) ;; \
 	esac
+	@echo "Creating Kind cluster '$(KIND_CLUSTER)'..."
+	@$(KIND) create cluster --name $(KIND_CLUSTER)
 	@if ! kubectl get namespace cert-manager > /dev/null 2>&1; then \
 		echo "Installing cert-manager"; \
 		helm repo add jetstack https://charts.jetstack.io; \
@@ -428,8 +428,10 @@ load-images: docker-build build-rotator ## Build and load images into the Kind c
 
 .PHONY: load-images-e2e
 load-images-e2e: build-rotator ## Build and load application images into the e2e test Kind cluster
+	@echo "Removing stale images to force rebuild..."
+	@$(CONTAINER_TOOL) rmi jupyter.org/jupyter-k8s:v0.0.1 2>/dev/null || true
+	@$(CONTAINER_TOOL) rmi docker.io/library/rotator:local 2>/dev/null || true
 	@echo "Loading application images into e2e test cluster ${KIND_CLUSTER}..."
-	@echo "Note: Controller image is built and loaded by the e2e test suite itself"
 	@echo "Loading rotator image into e2e test cluster ${KIND_CLUSTER}..."
 	@mkdir -p /tmp/kind-images
 	$(CONTAINER_TOOL) save docker.io/library/rotator:local -o /tmp/kind-images/rotator.tar

--- a/api/v1alpha1/workspace_types.go
+++ b/api/v1alpha1/workspace_types.go
@@ -232,6 +232,12 @@ type WorkspaceStatus struct {
 	// +optional
 	AccessResources []AccessResourceStatus `json:"accessResources,omitempty"`
 
+	// ObservedAccessStrategyVersion is a token capturing the identity and
+	// version of the AccessStrategy last evaluated during workspace
+	// reconciliation. The controller resets probe state when this value changes.
+	// +optional
+	ObservedAccessStrategyVersion string `json:"observedAccessStrategyVersion,omitempty"`
+
 	// AccessStartupProbeSucceeded indicates whether the access startup probe
 	// has passed. Set to true when the probe succeeds; reset to false when
 	// the workspace stops.

--- a/config/crd/bases/workspace.jupyter.org_workspaces.yaml
+++ b/config/crd/bases/workspace.jupyter.org_workspaces.yaml
@@ -2230,6 +2230,12 @@ spec:
                   attempt to enforce spacing; survives watch-triggered re-reconciliations.
                 format: date-time
                 type: string
+              observedAccessStrategyVersion:
+                description: |-
+                  ObservedAccessStrategyVersion is a token capturing the identity and
+                  version of the AccessStrategy last evaluated during workspace
+                  reconciliation. The controller resets probe state when this value changes.
+                type: string
               serviceName:
                 description: ServiceName is the name of the service exposing the Workspace
                 type: string

--- a/dist/chart/templates/crd/workspaces.workspace.jupyter.org.yaml
+++ b/dist/chart/templates/crd/workspaces.workspace.jupyter.org.yaml
@@ -2233,6 +2233,12 @@ spec:
                   attempt to enforce spacing; survives watch-triggered re-reconciliations.
                 format: date-time
                 type: string
+              observedAccessStrategyVersion:
+                description: |-
+                  ObservedAccessStrategyVersion is a token capturing the identity and
+                  version of the AccessStrategy last evaluated during workspace
+                  reconciliation. The controller resets probe state when this value changes.
+                type: string
               serviceName:
                 description: ServiceName is the name of the service exposing the Workspace
                 type: string

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -7563,6 +7563,12 @@ spec:
                   attempt to enforce spacing; survives watch-triggered re-reconciliations.
                 format: date-time
                 type: string
+              observedAccessStrategyVersion:
+                description: |-
+                  ObservedAccessStrategyVersion is a token capturing the identity and
+                  version of the AccessStrategy last evaluated during workspace
+                  reconciliation. The controller resets probe state when this value changes.
+                type: string
               serviceName:
                 description: ServiceName is the name of the service exposing the Workspace
                 type: string

--- a/internal/controller/state_machine_access.go
+++ b/internal/controller/state_machine_access.go
@@ -51,6 +51,7 @@ func (sm *StateMachine) ReconcileAccessForDesiredRunningStatus(
 	workspace.Status.AccessURL = ""
 	workspace.Status.AccessResourceSelector = ""
 	workspace.Status.AccessStartupProbeSucceeded = false
+	workspace.Status.ObservedAccessStrategyVersion = ""
 	clearProbeState(workspace)
 
 	err := sm.resourceManager.EnsureAccessResourcesDeleted(ctx, workspace)
@@ -68,6 +69,7 @@ func (sm *StateMachine) ReconcileAccessForDesiredStoppedStatus(ctx context.Conte
 	workspace.Status.AccessURL = ""
 	workspace.Status.AccessResourceSelector = ""
 	workspace.Status.AccessStartupProbeSucceeded = false
+	workspace.Status.ObservedAccessStrategyVersion = ""
 	clearProbeState(workspace)
 
 	err := sm.resourceManager.EnsureAccessResourcesDeleted(ctx, workspace)
@@ -108,6 +110,17 @@ func (sm *StateMachine) ProbeAccessStartup(
 ) (*ProbeResult, error) {
 	if accessStrategy == nil || accessStrategy.Spec.AccessStartupProbe == nil {
 		return &ProbeResult{Status: ProbeNotDefined}, nil
+	}
+
+	// Reset probe state when the AccessStrategy identity or spec changes.
+	// Without this, degraded workspaces cannot self-heal after an
+	// AccessStrategy fix, and already-succeeded probes are never
+	// re-evaluated after a strategy or ref change. (issue #368)
+	currentVersionedId := versionedAccessStrategyID(accessStrategy)
+	if workspace.Status.ObservedAccessStrategyVersion != currentVersionedId {
+		clearProbeState(workspace)
+		workspace.Status.AccessStartupProbeSucceeded = false
+		workspace.Status.ObservedAccessStrategyVersion = currentVersionedId
 	}
 
 	if workspace.Status.AccessStartupProbeSucceeded {
@@ -197,6 +210,10 @@ func (sm *StateMachine) ProbeAccessStartup(
 func clearProbeState(workspace *workspacev1alpha1.Workspace) {
 	workspace.Status.AccessStartupProbeFailures = nil
 	workspace.Status.EarliestNextProbeTime = nil
+}
+
+func versionedAccessStrategyID(as *workspacev1alpha1.WorkspaceAccessStrategy) string {
+	return fmt.Sprintf("%s.%d", as.UID, as.Generation)
 }
 
 func probeRetrySeconds(periodSeconds int32, failures int32, failureThreshold int32) int32 {

--- a/internal/controller/state_machine_access_test.go
+++ b/internal/controller/state_machine_access_test.go
@@ -14,6 +14,7 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 
 	workspacev1alpha1 "github.com/jupyter-infra/jupyter-k8s/api/v1alpha1"
@@ -63,8 +64,10 @@ var _ = Describe("ProbeAccessStartup", func() {
 
 		accessStrategy = &workspacev1alpha1.WorkspaceAccessStrategy{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-strategy",
-				Namespace: "default",
+				Name:       "test-strategy",
+				Namespace:  "default",
+				UID:        types.UID("test-uid"),
+				Generation: 1,
 			},
 			Spec: workspacev1alpha1.WorkspaceAccessStrategySpec{
 				DisplayName:             "Test Strategy",
@@ -78,6 +81,9 @@ var _ = Describe("ProbeAccessStartup", func() {
 				},
 			},
 		}
+
+		workspace.Status.ObservedAccessStrategyVersion = fmt.Sprintf("%s.%d",
+			accessStrategy.UID, accessStrategy.Generation)
 
 		sm = &StateMachine{
 			accessStartupProber: mockProber,
@@ -286,20 +292,89 @@ var _ = Describe("ProbeAccessStartup", func() {
 		Expect(result.Status).To(Equal(ProbeRetrying))
 		Expect(result.RequeueAfter).To(Equal(2 * time.Second))
 	})
+
+	It("should reset probe when AccessStrategy generation changes (degraded self-heal)", func() {
+		mockProber.ready = false
+		failures := int32(3) // already at threshold
+		workspace.Status.AccessStartupProbeFailures = &failures
+
+		result, err := sm.ProbeAccessStartup(ctx, workspace, accessStrategy, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Status).To(Equal(ProbeFailureThresholdExceeded))
+
+		// Simulate AccessStrategy spec update (generation bump)
+		accessStrategy.Generation = 2
+		mockProber.ready = true
+
+		result, err = sm.ProbeAccessStartup(ctx, workspace, accessStrategy, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Status).To(Equal(ProbeSucceeded))
+		Expect(workspace.Status.AccessStartupProbeSucceeded).To(BeTrue())
+		Expect(workspace.Status.ObservedAccessStrategyVersion).To(Equal(
+			fmt.Sprintf("%s.%d", accessStrategy.UID, accessStrategy.Generation)))
+	})
+
+	It("should reset probe when AccessStrategy generation changes (already succeeded)", func() {
+		workspace.Status.AccessStartupProbeSucceeded = true
+
+		result, err := sm.ProbeAccessStartup(ctx, workspace, accessStrategy, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Status).To(Equal(ProbeAlreadySucceeded))
+
+		// Simulate AccessStrategy spec update (generation bump)
+		accessStrategy.Generation = 2
+		mockProber.ready = false
+
+		result, err = sm.ProbeAccessStartup(ctx, workspace, accessStrategy, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Status).To(Equal(ProbeRetrying))
+		Expect(workspace.Status.AccessStartupProbeSucceeded).To(BeFalse())
+	})
+
+	It("should reset probe when AccessStrategy UID changes (ref switch)", func() {
+		workspace.Status.AccessStartupProbeSucceeded = true
+
+		result, err := sm.ProbeAccessStartup(ctx, workspace, accessStrategy, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Status).To(Equal(ProbeAlreadySucceeded))
+
+		// Simulate switching to a different AccessStrategy (different UID, same generation)
+		accessStrategy.UID = types.UID("different-uid")
+		accessStrategy.Generation = 1
+		mockProber.ready = true
+
+		result, err = sm.ProbeAccessStartup(ctx, workspace, accessStrategy, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Status).To(Equal(ProbeSucceeded))
+		Expect(workspace.Status.ObservedAccessStrategyVersion).To(Equal("different-uid.1"))
+	})
+
+	It("should not reset probe when AccessStrategy version has not changed", func() {
+		mockProber.ready = false
+		failures := int32(1)
+		workspace.Status.AccessStartupProbeFailures = &failures
+
+		result, err := sm.ProbeAccessStartup(ctx, workspace, accessStrategy, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Status).To(Equal(ProbeRetrying))
+		Expect(*workspace.Status.AccessStartupProbeFailures).To(Equal(int32(2)))
+	})
 })
 
 var _ = Describe("clearProbeState", func() {
-	It("should clear both failures and earliest next probe time", func() {
+	It("should clear failures and earliest next probe time but not version", func() {
 		failures := int32(5)
 		future := metav1.NewTime(time.Now().Add(5 * time.Second))
 		workspace := &workspacev1alpha1.Workspace{}
 		workspace.Status.AccessStartupProbeFailures = &failures
 		workspace.Status.EarliestNextProbeTime = &future
+		workspace.Status.ObservedAccessStrategyVersion = "some-uid.1"
 
 		clearProbeState(workspace)
 
 		Expect(workspace.Status.AccessStartupProbeFailures).To(BeNil())
 		Expect(workspace.Status.EarliestNextProbeTime).To(BeNil())
+		Expect(workspace.Status.ObservedAccessStrategyVersion).To(Equal("some-uid.1"))
 	})
 
 	It("should be a no-op when both fields are already nil", func() {

--- a/internal/controller/state_machine_running_access_test.go
+++ b/internal/controller/state_machine_running_access_test.go
@@ -15,6 +15,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
@@ -172,8 +173,10 @@ var _ = Describe("reconcileDesiredRunningStatus probe integration", func() {
 		BeforeEach(func() {
 			accessStrategy = &workspacev1alpha1.WorkspaceAccessStrategy{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-strategy",
-					Namespace: "default",
+					Name:       "test-strategy",
+					Namespace:  "default",
+					UID:        types.UID("test-uid"),
+					Generation: 1,
 				},
 				Spec: workspacev1alpha1.WorkspaceAccessStrategySpec{
 					DisplayName:             "Test Strategy",
@@ -223,6 +226,7 @@ var _ = Describe("reconcileDesiredRunningStatus probe integration", func() {
 
 			failures := int32(2)
 			workspace.Status.AccessStartupProbeFailures = &failures
+			workspace.Status.ObservedAccessStrategyVersion = fmt.Sprintf("%s.%d", accessStrategy.UID, accessStrategy.Generation)
 			Expect(k8sClient.Status().Update(ctx, workspace)).To(Succeed())
 			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(workspace), workspace)).To(Succeed())
 
@@ -255,6 +259,7 @@ var _ = Describe("reconcileDesiredRunningStatus probe integration", func() {
 
 			zero := int32(0)
 			workspace.Status.AccessStartupProbeFailures = &zero
+			workspace.Status.ObservedAccessStrategyVersion = fmt.Sprintf("%s.%d", accessStrategy.UID, accessStrategy.Generation)
 			Expect(k8sClient.Status().Update(ctx, workspace)).To(Succeed())
 			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(workspace), workspace)).To(Succeed())
 
@@ -291,6 +296,7 @@ var _ = Describe("reconcileDesiredRunningStatus probe integration", func() {
 			future := metav1.NewTime(time.Now().Add(2 * time.Second))
 			workspace.Status.AccessStartupProbeFailures = &one
 			workspace.Status.EarliestNextProbeTime = &future
+			workspace.Status.ObservedAccessStrategyVersion = fmt.Sprintf("%s.%d", accessStrategy.UID, accessStrategy.Generation)
 			Expect(k8sClient.Status().Update(ctx, workspace)).To(Succeed())
 			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(workspace), workspace)).To(Succeed())
 
@@ -324,6 +330,7 @@ var _ = Describe("reconcileDesiredRunningStatus probe integration", func() {
 			defer func() { _ = k8sClient.Delete(ctx, workspace) }()
 
 			workspace.Status.AccessStartupProbeSucceeded = true
+			workspace.Status.ObservedAccessStrategyVersion = fmt.Sprintf("%s.%d", accessStrategy.UID, accessStrategy.Generation)
 			Expect(k8sClient.Status().Update(ctx, workspace)).To(Succeed())
 			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(workspace), workspace)).To(Succeed())
 
@@ -343,6 +350,41 @@ var _ = Describe("reconcileDesiredRunningStatus probe integration", func() {
 			Expect(mockProber.probeCount).To(Equal(0))
 		})
 
+		It("should re-probe when AccessStrategy generation changes on an Available workspace", func() {
+			mockProber.ready = true
+			workspace := newWorkspaceWithAccessStrategy()
+			dep := createReadyDeployment(workspace)
+			svc := createService(workspace)
+			defer func() { _ = k8sClient.Delete(ctx, dep) }()
+			defer func() { _ = k8sClient.Delete(ctx, svc) }()
+			defer func() { _ = k8sClient.Delete(ctx, workspace) }()
+
+			workspace.Status.AccessStartupProbeSucceeded = true
+			workspace.Status.ObservedAccessStrategyVersion = fmt.Sprintf("%s.%d", accessStrategy.UID, accessStrategy.Generation)
+			Expect(k8sClient.Status().Update(ctx, workspace)).To(Succeed())
+			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(workspace), workspace)).To(Succeed())
+
+			// Simulate AccessStrategy spec update
+			accessStrategy.Generation = 2
+			mockProber.ready = false
+
+			sm := buildStateMachine()
+			result, err := sm.ReconcileDesiredState(ctx, workspace, accessStrategy)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeNumerically(">", 0))
+
+			progressing := getCondition(workspace, ConditionTypeProgressing)
+			Expect(progressing).NotTo(BeNil())
+			Expect(progressing.Status).To(Equal(metav1.ConditionTrue))
+			Expect(progressing.Reason).To(Equal(ReasonAccessNotReady))
+
+			available := getCondition(workspace, ConditionTypeAvailable)
+			Expect(available).NotTo(BeNil())
+			Expect(available.Status).To(Equal(metav1.ConditionFalse))
+
+			Expect(mockProber.probeCount).To(Equal(1))
+		})
+
 		It("should mark Degraded when failure threshold is exceeded", func() {
 			mockProber.ready = false
 			workspace := newWorkspaceWithAccessStrategy()
@@ -354,6 +396,7 @@ var _ = Describe("reconcileDesiredRunningStatus probe integration", func() {
 
 			failures := int32(2) // next failure (3) >= threshold (3)
 			workspace.Status.AccessStartupProbeFailures = &failures
+			workspace.Status.ObservedAccessStrategyVersion = fmt.Sprintf("%s.%d", accessStrategy.UID, accessStrategy.Generation)
 			Expect(k8sClient.Status().Update(ctx, workspace)).To(Succeed())
 			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(workspace), workspace)).To(Succeed())
 
@@ -394,6 +437,7 @@ var _ = Describe("reconcileDesiredRunningStatus probe integration", func() {
 
 			zero := int32(0)
 			workspace.Status.AccessStartupProbeFailures = &zero
+			workspace.Status.ObservedAccessStrategyVersion = fmt.Sprintf("%s.%d", accessStrategy.UID, accessStrategy.Generation)
 			Expect(k8sClient.Status().Update(ctx, workspace)).To(Succeed())
 			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(workspace), workspace)).To(Succeed())
 
@@ -435,8 +479,10 @@ var _ = Describe("reconcileDesiredRunningStatus probe integration", func() {
 		BeforeEach(func() {
 			accessStrategy = &workspacev1alpha1.WorkspaceAccessStrategy{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-strategy",
-					Namespace: "default",
+					Name:       "test-strategy",
+					Namespace:  "default",
+					UID:        types.UID("test-uid"),
+					Generation: 1,
 				},
 				Spec: workspacev1alpha1.WorkspaceAccessStrategySpec{
 					DisplayName:             "Test Strategy",
@@ -478,6 +524,7 @@ var _ = Describe("reconcileDesiredRunningStatus probe integration", func() {
 
 			failures := int32(2)
 			workspace.Status.AccessStartupProbeFailures = &failures
+			workspace.Status.ObservedAccessStrategyVersion = fmt.Sprintf("%s.%d", accessStrategy.UID, accessStrategy.Generation)
 			Expect(k8sClient.Status().Update(ctx, workspace)).To(Succeed())
 			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(workspace), workspace)).To(Succeed())
 
@@ -517,6 +564,7 @@ var _ = Describe("reconcileDesiredRunningStatus probe integration", func() {
 
 			zero := int32(0)
 			workspace.Status.AccessStartupProbeFailures = &zero
+			workspace.Status.ObservedAccessStrategyVersion = fmt.Sprintf("%s.%d", accessStrategy.UID, accessStrategy.Generation)
 			Expect(k8sClient.Status().Update(ctx, workspace)).To(Succeed())
 			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(workspace), workspace)).To(Succeed())
 

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -102,32 +102,6 @@ var _ = BeforeSuite(func() {
 	// Check if operator is already installed and clean up the cluster if needed
 	checkAndCleanCluster()
 
-	containerTool := os.Getenv("CONTAINER_TOOL")
-	if containerTool == "" {
-		containerTool = "docker"
-	}
-
-	// Build the manager image only when using the default local image.
-	// When E2E_MANAGER_IMAGE is set, assume the image is already available locally
-	// (e.g., pulled from GHCR and loaded into Kind by the caller).
-	if os.Getenv("E2E_MANAGER_IMAGE") == "" {
-		By("checking if manager image exists")
-		inspectCmd := exec.Command(containerTool, "image", "inspect", projectImage)
-		if _, err := inspectCmd.CombinedOutput(); err != nil {
-			By("building the manager(Operator) image")
-			buildCmd := exec.Command("make", "docker-build", fmt.Sprintf("IMG=%s", projectImage))
-			_, err := utils.Run(buildCmd)
-			Expect(err).NotTo(HaveOccurred(), "Failed to build manager image")
-		} else {
-			_, _ = fmt.Fprintf(GinkgoWriter, "Manager image already exists, skipping build\n")
-		}
-
-		By("loading the manager(Operator) image on Kind")
-		Expect(utils.LoadImageToKindClusterWithName(projectImage)).To(Succeed(), "Failed to load image to Kind cluster")
-	} else {
-		_, _ = fmt.Fprintf(GinkgoWriter, "Using pre-built manager image: %s\n", projectImage)
-	}
-
 	var cmd *exec.Cmd
 	var err error
 

--- a/test/e2e/static/access-probe/patch-probe-url-to-reachable.json
+++ b/test/e2e/static/access-probe/patch-probe-url-to-reachable.json
@@ -1,0 +1,12 @@
+{
+  "spec": {
+    "accessStartupProbe": {
+      "httpGet": {
+        "urlTemplate": "http://{{ .Service.Name }}.{{ .Workspace.Namespace }}.svc.cluster.local:8888/"
+      },
+      "periodSeconds": 2,
+      "timeoutSeconds": 5,
+      "failureThreshold": 120
+    }
+  }
+}

--- a/test/e2e/static/access-probe/patch-probe-url-to-unreachable.json
+++ b/test/e2e/static/access-probe/patch-probe-url-to-unreachable.json
@@ -1,0 +1,12 @@
+{
+  "spec": {
+    "accessStartupProbe": {
+      "httpGet": {
+        "urlTemplate": "http://does-not-exist.default.svc.cluster.local:9999/"
+      },
+      "periodSeconds": 1,
+      "timeoutSeconds": 1,
+      "failureThreshold": 3
+    }
+  }
+}

--- a/test/e2e/static/access-probe/patch-workspace-switch-to-failure-strategy.json
+++ b/test/e2e/static/access-probe/patch-workspace-switch-to-failure-strategy.json
@@ -1,0 +1,8 @@
+{
+  "spec": {
+    "accessStrategy": {
+      "name": "access-strategy-probe-failure",
+      "namespace": "jupyter-k8s-shared"
+    }
+  }
+}

--- a/test/e2e/workspace_access_probe_test.go
+++ b/test/e2e/workspace_access_probe_test.go
@@ -22,8 +22,10 @@ import (
 
 var _ = Describe("Workspace Access Startup Probe", Ordered, func() {
 	const (
-		workspaceNamespace = "default"
-		groupDir           = "access-probe"
+		workspaceNamespace    = "default"
+		groupDir              = "access-probe"
+		workspaceProbeSuccess = "workspace-probe-success"
+		workspaceProbeFailure = "workspace-probe-failure"
 	)
 
 	AfterEach(func() {
@@ -42,7 +44,7 @@ var _ = Describe("Workspace Access Startup Probe", Ordered, func() {
 
 	Context("Access startup probe succeeds", func() {
 		It("should become Available after probe succeeds via ClusterIP service", func() {
-			workspaceName := "workspace-probe-success"
+			workspaceName := workspaceProbeSuccess
 
 			By("creating an access strategy with probe targeting the ClusterIP service")
 			createAccessStrategyForTest("access-strategy-probe-success", groupDir, "")
@@ -93,7 +95,7 @@ var _ = Describe("Workspace Access Startup Probe", Ordered, func() {
 
 	Context("Access startup probe failure threshold exceeded", func() {
 		It("should become Degraded after probe exceeds failureThreshold", func() {
-			workspaceName := "workspace-probe-failure"
+			workspaceName := workspaceProbeFailure
 
 			By("creating an access strategy with probe targeting unreachable URL (failureThreshold=3)")
 			createAccessStrategyForTest("access-strategy-probe-failure", groupDir, "")
@@ -129,6 +131,129 @@ var _ = Describe("Workspace Access Startup Probe", Ordered, func() {
 				"{.status.accessStartupProbeFailures}")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(probeFailures).To(Equal("3"))
+		})
+	})
+
+	Context("Probe reset on AccessStrategy update", func() {
+		It("should self-heal from Degraded when AccessStrategy probe URL is fixed", func() {
+			workspaceName := workspaceProbeFailure
+
+			By("creating an access strategy with unreachable probe URL (failureThreshold=3)")
+			createAccessStrategyForTest("access-strategy-probe-failure", groupDir, "")
+
+			By("creating a workspace referencing the access strategy")
+			createWorkspaceForTest(workspaceName, groupDir, "")
+
+			By("waiting for the workspace to become Degraded")
+			WaitForWorkspaceToReachCondition(
+				workspaceName,
+				workspaceNamespace,
+				controller.ConditionTypeDegraded,
+				ConditionTrue,
+			)
+
+			By("patching access strategy to point probe at the reachable ClusterIP service")
+			patchAccessStrategy("access", "probe", "patch-probe-url-to-reachable", "access-strategy-probe-failure")
+
+			By("waiting for the workspace to become Available after probe reset")
+			WaitForWorkspaceToReachCondition(
+				workspaceName,
+				workspaceNamespace,
+				controller.ConditionTypeAvailable,
+				ConditionTrue,
+			)
+
+			By("verifying all conditions after self-heal")
+			VerifyWorkspaceConditions(workspaceName, workspaceNamespace, map[string]string{
+				controller.ConditionTypeProgressing: ConditionFalse,
+				controller.ConditionTypeDegraded:    ConditionFalse,
+				controller.ConditionTypeAvailable:   ConditionTrue,
+				controller.ConditionTypeStopped:     ConditionFalse,
+			})
+
+			By("verifying accessStartupProbeFailures is cleared after success")
+			probeFailures, _ := kubectlGet("workspace", workspaceName, workspaceNamespace,
+				"{.status.accessStartupProbeFailures}")
+			Expect(probeFailures).To(BeEmpty())
+		})
+
+		It("should re-probe and become Degraded when a Running workspace's strategy changes to unreachable", func() {
+			workspaceName := workspaceProbeSuccess
+
+			By("creating an access strategy with reachable probe")
+			createAccessStrategyForTest("access-strategy-probe-success", groupDir, "")
+
+			By("creating a workspace referencing the access strategy")
+			createWorkspaceForTest(workspaceName, groupDir, "")
+
+			By("waiting for the workspace to become Available")
+			WaitForWorkspaceToReachCondition(
+				workspaceName,
+				workspaceNamespace,
+				controller.ConditionTypeAvailable,
+				ConditionTrue,
+			)
+
+			By("patching access strategy to point probe at an unreachable URL (failureThreshold=3)")
+			patchAccessStrategy("access", "probe", "patch-probe-url-to-unreachable", "access-strategy-probe-success")
+
+			By("waiting for the workspace to become Degraded after probe reset")
+			WaitForWorkspaceToReachCondition(
+				workspaceName,
+				workspaceNamespace,
+				controller.ConditionTypeDegraded,
+				ConditionTrue,
+			)
+
+			By("verifying Degraded condition reason")
+			reason, err := kubectlGet("workspace", workspaceName, workspaceNamespace,
+				fmt.Sprintf("{.status.conditions[?(@.type==\"%s\")].reason}",
+					controller.ConditionTypeDegraded))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(reason).To(Equal(controller.ReasonAccessProbeThresholdExceeded))
+		})
+	})
+
+	Context("Probe reset on accessStrategyRef switch", func() {
+		It("should re-probe when workspace switches to a different AccessStrategy", func() {
+			workspaceName := workspaceProbeSuccess
+
+			By("creating both access strategies")
+			createAccessStrategyForTest("access-strategy-probe-success", groupDir, "")
+			createAccessStrategyForTest("access-strategy-probe-failure", groupDir, "")
+
+			By("creating a workspace referencing the reachable access strategy")
+			createWorkspaceForTest(workspaceName, groupDir, "")
+
+			By("waiting for the workspace to become Available")
+			WaitForWorkspaceToReachCondition(
+				workspaceName,
+				workspaceNamespace,
+				controller.ConditionTypeAvailable,
+				ConditionTrue,
+			)
+
+			By("patching workspace to switch accessStrategyRef to unreachable strategy")
+			cmd := exec.Command("kubectl", "patch", "workspace", workspaceName,
+				"-n", workspaceNamespace, "--type=merge", "--patch-file",
+				"test/e2e/static/access-probe/patch-workspace-switch-to-failure-strategy.json")
+			_, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("waiting for the workspace to become Degraded after probe reset")
+			WaitForWorkspaceToReachCondition(
+				workspaceName,
+				workspaceNamespace,
+				controller.ConditionTypeDegraded,
+				ConditionTrue,
+			)
+
+			By("verifying Degraded condition reason")
+			reason, err := kubectlGet("workspace", workspaceName, workspaceNamespace,
+				fmt.Sprintf("{.status.conditions[?(@.type==\"%s\")].reason}",
+					controller.ConditionTypeDegraded))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(reason).To(Equal(controller.ReasonAccessProbeThresholdExceeded))
 		})
 	})
 })


### PR DESCRIPTION
This PR handles cases where the `accessStartupProbe` should be invalidated:
- `ws.spec.accessStrategyRef` is updated or removed
- `accessstrategy.spec` is updated

Closes: #368 

Also in this PR:
- fix e2e image build logic to ensure controller and rotator images are always rebuilt

### Implementation
1. add `ws.status.observedAccessStrategyVersion` to `Workspace` CRD which tracks (`{AccessStrategy.UID}.{AccessStrategy.Generation}`. `Generation` is a monotonically increasing int that tracks object.spec updates, see [blog](https://alenkacz.medium.com/kubernetes-operator-best-practices-implementing-observedgeneration-250728868792)
2. during reconciliation, compare the current access strategy `ID.generation` w/ the token tracked in status
3. if different, invalidate the `accessStartupProbe`, which triggers new reconciliation (via `workspace.status` update)

### Testing
- added unit tests w/ envtest
- added E2E test cases
- manually tested in an cluster w/ `aws-oidc` chart