### PR TITLE
feat: default desiredStatus to Running in mutating webhook

### DIFF
--- a/internal/webhook/v1alpha1/workspace_webhook.go
+++ b/internal/webhook/v1alpha1/workspace_webhook.go
@@ -267,6 +267,10 @@ func (d *WorkspaceCustomDefaulter) Default(ctx context.Context, obj runtime.Obje
 		return nil
 	}
 
+	if workspace.Spec.DesiredStatus == "" {
+		workspace.Spec.DesiredStatus = controller.DefaultDesiredStatus
+	}
+
 	// Add ownership tracking annotations
 	if workspace.Annotations == nil {
 		workspace.Annotations = make(map[string]string)

--- a/internal/webhook/v1alpha1/workspace_webhook_test.go
+++ b/internal/webhook/v1alpha1/workspace_webhook_test.go
@@ -124,6 +124,20 @@ var _ = Describe("Workspace Webhook", func() {
 			Expect(workspace.Annotations).To(Equal(map[string]string{}))
 		})
 
+		It("should default desiredStatus to Running when not set", func() {
+			workspace.Spec.DesiredStatus = ""
+			err := defaulter.Default(ctx, workspace)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(workspace.Spec.DesiredStatus).To(Equal(controller.DefaultDesiredStatus))
+		})
+
+		It("should not override desiredStatus when already set", func() {
+			workspace.Spec.DesiredStatus = controller.DesiredStateStopped
+			err := defaulter.Default(ctx, workspace)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(workspace.Spec.DesiredStatus).To(Equal(controller.DesiredStateStopped))
+		})
+
 		It("should return error for wrong object type", func() {
 			wrongObj := &runtime.Unknown{}
 			err := defaulter.Default(ctx, wrongObj)

--- a/test/e2e/static/status/workspace-no-desired-status.yaml
+++ b/test/e2e/static/status/workspace-no-desired-status.yaml
@@ -1,0 +1,17 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: Workspace
+metadata:
+  name: workspace-no-desired-status
+  namespace: default
+spec:
+  displayName: "Status Test - No DesiredStatus"
+  image: jk8s-application-jupyter-uv:latest
+  resources:
+    requests:
+      cpu: 200m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  storage:
+    size: 1Gi

--- a/test/e2e/workspace_status_test.go
+++ b/test/e2e/workspace_status_test.go
@@ -356,6 +356,21 @@ var _ = Describe("Workspace Status", Ordered, func() {
 				To(BeTrue(), "Service should exist")
 		})
 	})
+
+	Context("DesiredStatus Defaulting", func() {
+		const noDesiredStatusWorkspace = "workspace-no-desired-status"
+
+		It("should default desiredStatus to Running when not specified", func() {
+			By("creating workspace without desiredStatus field")
+			createWorkspaceForTest(noDesiredStatusWorkspace, statusGroupDir, statusSubgroupDir)
+
+			By("verifying spec.desiredStatus was defaulted to Running by the webhook")
+			desiredStatus, err := kubectlGet("workspace", noDesiredStatusWorkspace, statusTestNamespace,
+				"{.spec.desiredStatus}")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(desiredStatus).To(Equal("Running"), "desiredStatus should be defaulted to Running by the mutating webhook")
+		})
+	})
 })
 
 func deleteResourcesForStatusTest() {


### PR DESCRIPTION
## Summary

Set `spec.desiredStatus` to `"Running"` at admission time in the mutating webhook when the field is empty.

Previously the default was only applied in-memory during controller reconciliation, leaving the persisted spec empty. This makes the intent explicit in the stored resource.

## Changes

- Added defaulting logic in `WorkspaceCustomDefaulter.Default()` to set `desiredStatus` to `Running` when unset
- Added unit tests for both the defaulting case and preservation of existing values
- Added e2e test that creates a workspace without `desiredStatus` and verifies the webhook defaults it to `Running`
## Testing

- All unit tests pass (283 webhook specs)
- All `./internal/...` tests pass
- E2e test compiles cleanly (`go vet -tags=e2e`)
- Manually verified on `sagemaker-test-cluster-9e08ff90-eks` that a workspace without `desiredStatus` reaches Available=True