### PR TITLE
docs: add web UI integration page

### DIFF
--- a/docs/source/integrations/guided-charts/aws-charts.md
+++ b/docs/source/integrations/guided-charts/aws-charts.md
@@ -12,6 +12,7 @@ A full web-access stack for EKS clusters. Users access the applications running 
 - [Dex](https://dexidp.io/docs/getting-started/) as the OIDC identity provider
 - [OAuth2-Proxy](https://oauth2-proxy.github.io/oauth2-proxy/) to manage workspace-wide cookies
 - **Auth middleware** configured to verify the OIDC token from `dex`
+- [Web UI](../web-ui/index) — workspace management console for creating and managing workspaces from the browser
 - Preconfigured access strategies and templates for browser-based workspace access
 
 **Access pattern:**

--- a/docs/source/integrations/index.md
+++ b/docs/source/integrations/index.md
@@ -34,10 +34,10 @@ The operator chart deploys the core controller, **Extension API** and CRDs, but 
 - **Integrate with cloud providers** — deploy cloud-specific plugins and resources (e.g. ALB ingress, SSM activations).
 - **Define access strategies** —integrate workspaces with the routing layer by creating access strategies.
 
-
 ```{toctree}
 :hidden:
 
+web-ui/index
 plugins/index
 guided-charts/index
 ```

--- a/docs/source/integrations/web-ui/index.md
+++ b/docs/source/integrations/web-ui/index.md
@@ -13,17 +13,26 @@ The UI operates on the `workspace.jupyter.org/v1alpha1` CRD API directly — it 
 
 ## Installation
 
-The **Web UI** is included in the {ref}`AWS-OIDC chart <chart-aws-oidc>`. No additional installation is required when using that chart.
-
-For standalone deployment, add the container to your cluster with a routing layer that provides OIDC authentication:
+The **Web UI** is deployed via the `jupyter-k8s-aws-oidc` Helm chart. Enable it in your [`values.yaml`](https://github.com/jupyter-infra/jupyter-k8s-aws/blob/main/charts/aws-oidc/values.yaml):
 
 ```yaml
 webApp:
+  enabled: true
   repository: ghcr.io/jupyter-infra
   imageName: jupyter-k8s-ui
-  imageTag: v0.1.0-rc.1
+  imageTag: latest
   namespace: default
 ```
+
+Then install or upgrade the chart:
+
+```bash
+helm upgrade --install jupyter-k8s-aws-oidc \
+  oci://ghcr.io/jupyter-infra/charts/jupyter-k8s-aws-oidc \
+  -f values.yaml
+```
+
+This creates a Deployment, Service, IngressRoute, and RBAC resources for the Web UI.
 
 ## Requirements
 

--- a/docs/source/integrations/web-ui/index.md
+++ b/docs/source/integrations/web-ui/index.md
@@ -1,0 +1,64 @@
+# Web UI
+
+The **Web UI** is a workspace management console that lets users create, monitor, and manage their Jupyter workspaces from a browser.
+
+## What it does
+
+1. **List workspaces** — shows the user's workspaces with real-time status (Starting, Running, Stopped).
+2. **Create workspaces** — form-based creation with template selection, resource configuration, and validation against template bounds.
+3. **Manage lifecycle** — start, stop, and delete workspaces.
+4. **View details** — resource usage, status conditions, and workspace metadata.
+
+The UI operates on the `workspace.jupyter.org/v1alpha1` CRD API directly — it has no dependency on the controller.
+
+## Installation
+
+The **Web UI** is included in the {ref}`AWS-OIDC chart <chart-aws-oidc>`. No additional installation is required when using that chart.
+
+For standalone deployment, add the container to your cluster with a routing layer that provides OIDC authentication:
+
+```yaml
+webApp:
+  repository: ghcr.io/jupyter-infra
+  imageName: jupyter-k8s-ui
+  imageTag: v0.1.0-rc.1
+  namespace: default
+```
+
+## Requirements
+
+The **Web UI** expects an authenticating reverse proxy upstream (e.g. OAuth2-Proxy) that:
+
+1. Authenticates the user via OIDC.
+2. Forwards the access token in the `X-Forwarded-Access-Token` header.
+
+The container's service account does not need Kubernetes permissions — each request uses the forwarded user token to talk to the API server directly.
+
+## Access flow
+
+```text
+Browser → Router → OAuth2-Proxy → Web UI → K8s API Server
+```
+
+- **OAuth2-Proxy** handles the OIDC login flow and sets the token header.
+- **Web UI** extracts the token, creates a per-user Kubernetes client, and performs workspace CRUD.
+- A session cookie layer caches the authenticated session to reduce latency on subsequent requests.
+
+## Configuration
+
+The container is configured via environment variables. The most common ones:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `NAMESPACE` | `default` | Kubernetes namespace for workspace operations |
+| `SESSION_ENABLED` | `true` | Enable session cookie layer |
+| `SESSION_EXPECTED_DOMAIN` | (empty) | CSRF origin domain enforcement |
+
+See the [source repository](https://github.com/jupyter-infra/jupyter-k8s-ui) for the full list of configuration options.
+
+## Source and packages
+
+| | |
+|---|---|
+| Repository | [jupyter-k8s-ui](https://github.com/jupyter-infra/jupyter-k8s-ui) |
+| Image | `ghcr.io/jupyter-infra/jupyter-k8s-ui` |


### PR DESCRIPTION
## Summary
- Adds `docs/source/integrations/web-ui/index.md` — documents the jupyter-k8s-ui workspace management console (what it does, installation, requirements, access flow, configuration)
- Adds `web-ui/index` to the integrations toctree
- Adds Web UI bullet to the AWS-OIDC chart's "What it deploys" list

## Test plan
- [x] `make html` builds successfully with no errors
- [x] ReadTheDocs preview renders correctly