### PR TITLE
feat: template access strategy ref rules

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -371,7 +371,7 @@ func main() {
 	// This webhook manages lazy finalizers to prevent template deletion while in use
 	// nolint:goconst
 	if os.Getenv("ENABLE_WORKSPACE_TEMPLATE_WEBHOOK") != "false" {
-		if err := webhookv1alpha1.SetupWorkspaceTemplateWebhookWithManager(mgr); err != nil {
+		if err := webhookv1alpha1.SetupWorkspaceTemplateWebhookWithManager(mgr, defaultTemplateNamespace); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "WorkspaceTemplate")
 			os.Exit(1)
 		}

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -110,6 +110,7 @@ webhooks:
     apiVersions:
     - v1alpha1
     operations:
+    - CREATE
     - UPDATE
     resources:
     - workspacetemplates

--- a/dist/chart/templates/webhook/validating-webhook-configuration.yaml
+++ b/dist/chart/templates/webhook/validating-webhook-configuration.yaml
@@ -66,6 +66,7 @@ webhooks:
     apiVersions:
     - v1alpha1
     operations:
+    - CREATE
     - UPDATE
     resources:
     - workspacetemplates

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -13749,6 +13749,7 @@ webhooks:
     apiVersions:
     - v1alpha1
     operations:
+    - CREATE
     - UPDATE
     resources:
     - workspacetemplates

--- a/docs/source/concepts/templates/shared-namespace.md
+++ b/docs/source/concepts/templates/shared-namespace.md
@@ -28,7 +28,9 @@ If neither namespace contains a default template, the webhook leaves `spec.templ
 
 ## Cross-namespace references
 
-Normally, a `workspace.spec.templateRef` and `workspace.spec.accessStrategy` can only reference resources in the workspace's own namespace. The shared namespace is the one exception — workspaces in any namespace may reference templates and access strategies that live in the shared namespace.
+Normally, a `workspace.spec.templateRef` and `workspace.spec.accessStrategy` can only reference resources in the workspace's own namespace. The same rule applies to templates: a `template.spec.defaultAccessStrategy` can only reference an access strategy in the template's own namespace or the shared namespace. This prevents admins from creating templates that would make any referencing workspace un-admittable.
+
+The shared namespace is the one exception to both rules — workspaces and templates in any namespace may reference templates and access strategies that live in the shared namespace.
 
 ## Example setup
 

--- a/docs/source/dive-deeper/webhooks/template-validation.md
+++ b/docs/source/dive-deeper/webhooks/template-validation.md
@@ -1,10 +1,12 @@
 # Template Validation
 
-WorkspaceTemplates have a validating-only webhook that fires on `UPDATE`. It uses `failurePolicy: Ignore`, so template updates succeed even when the webhook is unavailable.
+WorkspaceTemplates have a validating webhook that fires on `CREATE` and `UPDATE`. It uses `failurePolicy: Ignore`, so template operations succeed even when the webhook is unavailable.
 
 ## Behavior
 
-The webhook never blocks updates. When constraint fields change, it returns a **warning** telling the user that the template controller will re-validate affected workspaces.
+On **create and update**, the webhook rejects templates whose `defaultAccessStrategy` references an access strategy in a disallowed namespace (see [shared namespace](../../concepts/templates/shared-namespace.md)). This prevents admins from creating templates that would make any referencing workspace un-admittable.
+
+On **update**, when constraint fields change, the webhook returns a **warning** telling the user that the template controller will re-validate affected workspaces.
 
 ## Constraint fields
 

--- a/internal/webhook/v1alpha1/access_strategy_validator.go
+++ b/internal/webhook/v1alpha1/access_strategy_validator.go
@@ -23,24 +23,19 @@ func NewAccessStrategyValidator(sharedNamespace string) *AccessStrategyValidator
 	}
 }
 
-// validateAccessStrategyNamespace checks that accessStrategy.namespace targets an allowed namespace.
-// Workspaces can only reference access strategies from their own namespace or the shared namespace.
-func (v *AccessStrategyValidator) validateAccessStrategyNamespace(workspace *workspacev1alpha1.Workspace) error {
-	if workspace.Spec.AccessStrategy == nil {
-		return nil
-	}
-
-	asNamespace := workspace.Spec.AccessStrategy.Namespace
-	workspaceNamespace := workspace.Namespace
-
-	if asNamespace == "" || asNamespace == workspaceNamespace {
+// validateNamespaceScope checks that an access strategy reference targets an allowed namespace.
+// Both workspaces and templates may only reference access strategies from the referrer's own
+// namespace or the configured shared namespace. referrerKind ("workspace" / "template") only
+// shapes the error message; the rules are identical.
+func (v *AccessStrategyValidator) validateNamespaceScope(asNamespace, referrerNamespace, referrerKind string) error {
+	if asNamespace == "" || asNamespace == referrerNamespace {
 		return nil
 	}
 
 	if v.sharedNamespace == "" {
 		return fmt.Errorf(
-			"accessStrategy.namespace %q is not allowed: access strategies must be in the workspace namespace %q",
-			asNamespace, workspaceNamespace,
+			"accessStrategy.namespace %q is not allowed: access strategies must be in the %s namespace %q",
+			asNamespace, referrerKind, referrerNamespace,
 		)
 	}
 
@@ -49,9 +44,29 @@ func (v *AccessStrategyValidator) validateAccessStrategyNamespace(workspace *wor
 	}
 
 	return fmt.Errorf(
-		"accessStrategy.namespace %q is not allowed: access strategies must be in the workspace namespace %q or the shared namespace %q",
-		asNamespace, workspaceNamespace, v.sharedNamespace,
+		"accessStrategy.namespace %q is not allowed: access strategies must be in the %s namespace %q or the shared namespace %q",
+		asNamespace, referrerKind, referrerNamespace, v.sharedNamespace,
 	)
+}
+
+// validateAccessStrategyNamespace checks that accessStrategy.namespace targets an allowed namespace.
+// Workspaces can only reference access strategies from their own namespace or the shared namespace.
+func (v *AccessStrategyValidator) validateAccessStrategyNamespace(workspace *workspacev1alpha1.Workspace) error {
+	if workspace.Spec.AccessStrategy == nil {
+		return nil
+	}
+	return v.validateNamespaceScope(workspace.Spec.AccessStrategy.Namespace, workspace.Namespace, "workspace")
+}
+
+// validateTemplateAccessStrategyNamespace checks that a template's defaultAccessStrategy.namespace
+// targets an allowed namespace. Templates can only reference access strategies from their own
+// namespace or the shared namespace — the same rule workspaces are subject to. Enforcing it here
+// prevents admins from creating templates that would make any referencing workspace un-admittable.
+func (v *AccessStrategyValidator) validateTemplateAccessStrategyNamespace(template *workspacev1alpha1.WorkspaceTemplate) error {
+	if template.Spec.DefaultAccessStrategy == nil {
+		return nil
+	}
+	return v.validateNamespaceScope(template.Spec.DefaultAccessStrategy.Namespace, template.Namespace, "template")
 }
 
 // ValidateCreateWorkspace validates access strategy namespace on workspace creation
@@ -64,4 +79,16 @@ func (v *AccessStrategyValidator) ValidateCreateWorkspace(workspace *workspacev1
 // which covers the "removed" case. The admission webhook is the single enforcement point.
 func (v *AccessStrategyValidator) ValidateUpdateWorkspace(_, newWorkspace *workspacev1alpha1.Workspace) error {
 	return v.validateAccessStrategyNamespace(newWorkspace)
+}
+
+// ValidateCreateTemplate validates the access strategy namespace on template creation.
+func (v *AccessStrategyValidator) ValidateCreateTemplate(template *workspacev1alpha1.WorkspaceTemplate) error {
+	return v.validateTemplateAccessStrategyNamespace(template)
+}
+
+// ValidateUpdateTemplate validates the access strategy namespace on template update.
+// Like the workspace case, nil defaultAccessStrategy is handled (covers the "removed" case),
+// so removing the reference is always allowed.
+func (v *AccessStrategyValidator) ValidateUpdateTemplate(_, newTemplate *workspacev1alpha1.WorkspaceTemplate) error {
+	return v.validateTemplateAccessStrategyNamespace(newTemplate)
 }

--- a/internal/webhook/v1alpha1/access_strategy_validator_test.go
+++ b/internal/webhook/v1alpha1/access_strategy_validator_test.go
@@ -189,4 +189,91 @@ var _ = Describe("AccessStrategyValidator", func() {
 			Expect(err.Error()).To(ContainSubstring("team-b"))
 		})
 	})
+
+	Context("Template namespace scope validation", func() {
+		// All template cases use namespace "team-a"; only the access strategy namespace varies.
+		templateWithAS := func(asNamespace string) *workspacev1alpha1.WorkspaceTemplate {
+			return &workspacev1alpha1.WorkspaceTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: "tmpl", Namespace: "team-a"},
+				Spec: workspacev1alpha1.WorkspaceTemplateSpec{
+					DefaultAccessStrategy: &workspacev1alpha1.AccessStrategyRef{
+						Name:      "some-strategy",
+						Namespace: asNamespace,
+					},
+				},
+			}
+		}
+
+		It("should reject defaultAccessStrategy targeting another team's namespace", func() {
+			validator := NewAccessStrategyValidator("jupyter-k8s-shared")
+
+			err := validator.ValidateCreateTemplate(templateWithAS("team-b"))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("team-b"))
+			Expect(err.Error()).To(ContainSubstring("team-a"))
+			Expect(err.Error()).To(ContainSubstring("jupyter-k8s-shared"))
+			Expect(err.Error()).To(ContainSubstring("template namespace"))
+		})
+
+		It("should allow defaultAccessStrategy targeting the template's own namespace", func() {
+			validator := NewAccessStrategyValidator("jupyter-k8s-shared")
+
+			err := validator.ValidateCreateTemplate(templateWithAS("team-a"))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should allow defaultAccessStrategy targeting the shared namespace", func() {
+			validator := NewAccessStrategyValidator("jupyter-k8s-shared")
+
+			err := validator.ValidateCreateTemplate(templateWithAS("jupyter-k8s-shared"))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should allow defaultAccessStrategy with empty namespace", func() {
+			validator := NewAccessStrategyValidator("jupyter-k8s-shared")
+
+			err := validator.ValidateCreateTemplate(templateWithAS(""))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should reject cross-namespace when no shared namespace is configured", func() {
+			validator := NewAccessStrategyValidator("")
+
+			err := validator.ValidateCreateTemplate(templateWithAS("jupyter-k8s-shared"))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("jupyter-k8s-shared"))
+			Expect(err.Error()).To(ContainSubstring("team-a"))
+			Expect(err.Error()).NotTo(ContainSubstring("shared namespace"))
+		})
+
+		It("should skip validation when template has no defaultAccessStrategy", func() {
+			validator := NewAccessStrategyValidator("jupyter-k8s-shared")
+
+			template := &workspacev1alpha1.WorkspaceTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: "tmpl", Namespace: "team-a"},
+			}
+			err := validator.ValidateCreateTemplate(template)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should validate when defaultAccessStrategy namespace changes to a foreign namespace", func() {
+			validator := NewAccessStrategyValidator("jupyter-k8s-shared")
+
+			err := validator.ValidateUpdateTemplate(
+				templateWithAS("team-a"),
+				templateWithAS("team-b"))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("team-b"))
+		})
+
+		It("should skip validation when defaultAccessStrategy is removed", func() {
+			validator := NewAccessStrategyValidator("jupyter-k8s-shared")
+
+			newTemplate := &workspacev1alpha1.WorkspaceTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: "tmpl", Namespace: "team-a"},
+			}
+			err := validator.ValidateUpdateTemplate(templateWithAS("team-b"), newTemplate)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
 })

--- a/internal/webhook/v1alpha1/template_webhook.go
+++ b/internal/webhook/v1alpha1/template_webhook.go
@@ -26,11 +26,15 @@ var templatelog = logf.Log.WithName("workspacetemplate-resource")
 
 // SetupWorkspaceTemplateWebhookWithManager registers the webhook for WorkspaceTemplate in the manager.
 func SetupWorkspaceTemplateWebhookWithManager(mgr ctrl.Manager, defaultTemplateNamespace string) error {
+	accessStrategyValidator := NewAccessStrategyValidator(defaultTemplateNamespace)
 	return ctrl.NewWebhookManagedBy(mgr).For(&workspacev1alpha1.WorkspaceTemplate{}).
 		WithValidator(&WorkspaceTemplateCustomValidator{
-			accessStrategyValidator: NewAccessStrategyValidator(defaultTemplateNamespace),
+			accessStrategyValidator: accessStrategyValidator,
 		}).
-		WithDefaulter(&WorkspaceTemplateCustomDefaulter{client: mgr.GetClient()}).
+		WithDefaulter(&WorkspaceTemplateCustomDefaulter{
+			client:                  mgr.GetClient(),
+			accessStrategyValidator: accessStrategyValidator,
+		}).
 		Complete()
 }
 
@@ -48,7 +52,8 @@ func SetupWorkspaceTemplateWebhookWithManager(mgr ctrl.Manager, defaultTemplateN
 // NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
 // as this struct is used only for temporary operations and does not need to be deeply copied.
 type WorkspaceTemplateCustomDefaulter struct {
-	client client.Client
+	client                  client.Client
+	accessStrategyValidator *AccessStrategyValidator
 }
 
 var _ webhook.CustomDefaulter = &WorkspaceTemplateCustomDefaulter{}
@@ -76,7 +81,11 @@ func (d *WorkspaceTemplateCustomDefaulter) Default(ctx context.Context, obj runt
 	// add when referenced, never remove here - the AccessStrategy controller removes it when the last
 	// referrer (across workspaces and templates) is gone. mustExist=true rejects the template write when
 	// the referenced AccessStrategy does not exist, matching the workspace webhook.
+	// Check namespace scope first so we never modify an AccessStrategy in a disallowed namespace.
 	if template.Spec.DefaultAccessStrategy != nil && template.Spec.DefaultAccessStrategy.Name != "" {
+		if err := d.accessStrategyValidator.ValidateCreateTemplate(template); err != nil {
+			return err
+		}
 		asName := template.Labels[workspaceutil.LabelAccessStrategyName]
 		asNamespace := template.Labels[workspaceutil.LabelAccessStrategyNamespace]
 		if err := workspaceutil.EnsureAccessStrategyFinalizerByRef(ctx, templatelog, d.client, asName, asNamespace,

--- a/internal/webhook/v1alpha1/template_webhook.go
+++ b/internal/webhook/v1alpha1/template_webhook.go
@@ -25,9 +25,11 @@ import (
 var templatelog = logf.Log.WithName("workspacetemplate-resource")
 
 // SetupWorkspaceTemplateWebhookWithManager registers the webhook for WorkspaceTemplate in the manager.
-func SetupWorkspaceTemplateWebhookWithManager(mgr ctrl.Manager) error {
+func SetupWorkspaceTemplateWebhookWithManager(mgr ctrl.Manager, defaultTemplateNamespace string) error {
 	return ctrl.NewWebhookManagedBy(mgr).For(&workspacev1alpha1.WorkspaceTemplate{}).
-		WithValidator(&WorkspaceTemplateCustomValidator{}).
+		WithValidator(&WorkspaceTemplateCustomValidator{
+			accessStrategyValidator: NewAccessStrategyValidator(defaultTemplateNamespace),
+		}).
 		WithDefaulter(&WorkspaceTemplateCustomDefaulter{client: mgr.GetClient()}).
 		Complete()
 }
@@ -88,15 +90,19 @@ func (d *WorkspaceTemplateCustomDefaulter) Default(ctx context.Context, obj runt
 	return nil
 }
 
-// +kubebuilder:webhook:path=/validate-workspace-jupyter-org-v1alpha1-workspacetemplate,mutating=false,failurePolicy=ignore,sideEffects=None,groups=workspace.jupyter.org,resources=workspacetemplates,verbs=update,versions=v1alpha1,name=vworkspacetemplate-v1alpha1.kb.io,admissionReviewVersions=v1,serviceName=jupyter-k8s-controller-manager,servicePort=9443
+// +kubebuilder:webhook:path=/validate-workspace-jupyter-org-v1alpha1-workspacetemplate,mutating=false,failurePolicy=ignore,sideEffects=None,groups=workspace.jupyter.org,resources=workspacetemplates,verbs=create;update,versions=v1alpha1,name=vworkspacetemplate-v1alpha1.kb.io,admissionReviewVersions=v1,serviceName=jupyter-k8s-controller-manager,servicePort=9443
 
 // WorkspaceTemplateCustomValidator struct is responsible for validating the WorkspaceTemplate resource
-// when it is updated. It checks if constraint fields changed and returns warnings.
-// The WorkspaceTemplate controller is responsible for marking affected workspaces for compliance checking.
+// when it is created or updated. On create/update it enforces that any referenced access strategy lives
+// in an allowed namespace (the template's own or the shared namespace), so the template cannot make
+// referencing workspaces un-admittable. On update it also checks if constraint fields changed and
+// returns warnings; the WorkspaceTemplate controller is responsible for marking affected workspaces
+// for compliance checking.
 //
 // NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
 // as this struct is used only for temporary operations and does not need to be deeply copied.
 type WorkspaceTemplateCustomValidator struct {
+	accessStrategyValidator *AccessStrategyValidator
 }
 
 var _ webhook.CustomValidator = &WorkspaceTemplateCustomValidator{}
@@ -109,7 +115,12 @@ func (v *WorkspaceTemplateCustomValidator) ValidateCreate(ctx context.Context, o
 	}
 	templatelog.Info("Validation for WorkspaceTemplate upon creation", "name", template.GetName())
 
-	// No special validation needed on create
+	// Enforce that the referenced access strategy is in an allowed namespace, so the template
+	// cannot make referencing workspaces fail their own admission webhook.
+	if err := v.accessStrategyValidator.ValidateCreateTemplate(template); err != nil {
+		return nil, err
+	}
+
 	return nil, nil
 }
 
@@ -124,6 +135,12 @@ func (v *WorkspaceTemplateCustomValidator) ValidateUpdate(ctx context.Context, o
 		return nil, fmt.Errorf("expected a WorkspaceTemplate object for the newObj but got %T", newObj)
 	}
 	templatelog.Info("Validation for WorkspaceTemplate upon update", "name", newTemplate.GetName())
+
+	// Enforce that the referenced access strategy is in an allowed namespace, so the template
+	// cannot make referencing workspaces fail their own admission webhook.
+	if err := v.accessStrategyValidator.ValidateUpdateTemplate(oldTemplate, newTemplate); err != nil {
+		return nil, err
+	}
 
 	// Check if constraint fields changed
 	if constraintsChanged(oldTemplate, newTemplate) {

--- a/internal/webhook/v1alpha1/template_webhook_test.go
+++ b/internal/webhook/v1alpha1/template_webhook_test.go
@@ -32,7 +32,10 @@ var _ = Describe("WorkspaceTemplate Defaulter", func() {
 	// newDefaulter builds a defaulter backed by a fake client seeded with the given objects.
 	newDefaulter := func(objs ...client.Object) WorkspaceTemplateCustomDefaulter {
 		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
-		return WorkspaceTemplateCustomDefaulter{client: fakeClient}
+		return WorkspaceTemplateCustomDefaulter{
+			client:                  fakeClient,
+			accessStrategyValidator: NewAccessStrategyValidator("shared-ns"),
+		}
 	}
 
 	accessStrategyIn := func(name, namespace string) *workspacev1alpha1.WorkspaceAccessStrategy {

--- a/internal/webhook/v1alpha1/template_webhook_test.go
+++ b/internal/webhook/v1alpha1/template_webhook_test.go
@@ -111,3 +111,130 @@ var _ = Describe("WorkspaceTemplate Defaulter", func() {
 		Expect(err).To(HaveOccurred())
 	})
 })
+
+var _ = Describe("WorkspaceTemplate Validator", func() {
+	var (
+		ctx       context.Context
+		validator WorkspaceTemplateCustomValidator
+	)
+
+	// templateWithAS builds a template in "team-a" referencing an access strategy in asNamespace.
+	templateWithAS := func(asNamespace string) *workspacev1alpha1.WorkspaceTemplate {
+		return &workspacev1alpha1.WorkspaceTemplate{
+			ObjectMeta: metav1.ObjectMeta{Name: "tmpl", Namespace: "team-a"},
+			Spec: workspacev1alpha1.WorkspaceTemplateSpec{
+				DefaultAccessStrategy: &workspacev1alpha1.AccessStrategyRef{
+					Name:      "some-strategy",
+					Namespace: asNamespace,
+				},
+			},
+		}
+	}
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		validator = WorkspaceTemplateCustomValidator{
+			accessStrategyValidator: NewAccessStrategyValidator("shared-ns"),
+		}
+	})
+
+	Context("ValidateCreate", func() {
+		It("allows a template referencing an access strategy in its own namespace", func() {
+			warnings, err := validator.ValidateCreate(ctx, templateWithAS("team-a"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(warnings).To(BeEmpty())
+		})
+
+		It("allows a template referencing an access strategy in the shared namespace", func() {
+			warnings, err := validator.ValidateCreate(ctx, templateWithAS("shared-ns"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(warnings).To(BeEmpty())
+		})
+
+		It("rejects a template referencing an access strategy in another namespace", func() {
+			_, err := validator.ValidateCreate(ctx, templateWithAS("team-b"))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("team-b"))
+			Expect(err.Error()).To(ContainSubstring("template namespace"))
+		})
+
+		It("returns an error for a non-template object", func() {
+			_, err := validator.ValidateCreate(ctx, &workspacev1alpha1.Workspace{})
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Context("ValidateUpdate", func() {
+		It("rejects an update that points the access strategy at another namespace", func() {
+			_, err := validator.ValidateUpdate(ctx, templateWithAS("team-a"), templateWithAS("team-b"))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("team-b"))
+		})
+
+		It("allows removing the access strategy reference", func() {
+			oldTemplate := templateWithAS("team-b")
+			newTemplate := &workspacev1alpha1.WorkspaceTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: "tmpl", Namespace: "team-a"},
+			}
+			warnings, err := validator.ValidateUpdate(ctx, oldTemplate, newTemplate)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(warnings).To(BeEmpty())
+		})
+
+		It("returns a warning when constraint fields change", func() {
+			oldTemplate := &workspacev1alpha1.WorkspaceTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: "tmpl", Namespace: "team-a"},
+				Spec: workspacev1alpha1.WorkspaceTemplateSpec{
+					AllowedImages: []string{"image-a"},
+				},
+			}
+			newTemplate := &workspacev1alpha1.WorkspaceTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: "tmpl", Namespace: "team-a"},
+				Spec: workspacev1alpha1.WorkspaceTemplateSpec{
+					AllowedImages: []string{"image-a", "image-b"},
+				},
+			}
+			warnings, err := validator.ValidateUpdate(ctx, oldTemplate, newTemplate)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(warnings).To(HaveLen(1))
+			Expect(warnings[0]).To(ContainSubstring("compliance validation"))
+		})
+
+		It("returns no warning when no constraint fields change", func() {
+			oldTemplate := &workspacev1alpha1.WorkspaceTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: "tmpl", Namespace: "team-a"},
+				Spec:       workspacev1alpha1.WorkspaceTemplateSpec{DisplayName: "before"},
+			}
+			newTemplate := &workspacev1alpha1.WorkspaceTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: "tmpl", Namespace: "team-a"},
+				Spec:       workspacev1alpha1.WorkspaceTemplateSpec{DisplayName: "after"},
+			}
+			warnings, err := validator.ValidateUpdate(ctx, oldTemplate, newTemplate)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(warnings).To(BeEmpty())
+		})
+
+		It("returns an error when the new object is not a template", func() {
+			_, err := validator.ValidateUpdate(ctx, templateWithAS("team-a"), &workspacev1alpha1.Workspace{})
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("returns an error when the old object is not a template", func() {
+			_, err := validator.ValidateUpdate(ctx, &workspacev1alpha1.Workspace{}, templateWithAS("team-a"))
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Context("ValidateDelete", func() {
+		It("allows deletion and returns no warnings", func() {
+			warnings, err := validator.ValidateDelete(ctx, templateWithAS("team-b"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(warnings).To(BeEmpty())
+		})
+
+		It("returns an error for a non-template object", func() {
+			_, err := validator.ValidateDelete(ctx, &workspacev1alpha1.Workspace{})
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})

--- a/test/e2e/helpers_access_strategy.go
+++ b/test/e2e/helpers_access_strategy.go
@@ -185,9 +185,8 @@ func verifyAccessStrategyHeldByTemplate(accessStrategyName string) {
 }
 
 // verifyCreateTemplateRejectedByWebhook attempts to create a template from the given fixture and asserts
-// the template mutating webhook rejects it (because the referenced AccessStrategy does not exist at the
-// resolved name/namespace), then that the template was not persisted.
-func verifyCreateTemplateRejectedByWebhook(filename, group, templateName string) {
+// the webhook rejects it with an error containing expectedSubstring, then that the template was not persisted.
+func verifyCreateTemplateRejectedByWebhook(filename, group, templateName, expectedSubstring string) {
 	ginkgo.GinkgoHelper()
 
 	path := BuildTestResourcePath(filename, group, "")
@@ -195,9 +194,9 @@ func verifyCreateTemplateRejectedByWebhook(filename, group, templateName string)
 	cmd := exec.Command("kubectl", "apply", "-f", path)
 	output, err := utils.Run(cmd)
 	gomega.Expect(err).To(gomega.HaveOccurred(),
-		fmt.Sprintf("template webhook should reject %s referencing a non-existent access strategy", templateName))
-	gomega.Expect(output).To(gomega.ContainSubstring("not found"),
-		"rejection should explain that the referenced access strategy was not found")
+		fmt.Sprintf("template webhook should reject %s", templateName))
+	gomega.Expect(output).To(gomega.ContainSubstring(expectedSubstring),
+		fmt.Sprintf("rejection should contain %q", expectedSubstring))
 
 	ginkgo.By(fmt.Sprintf("verifying template %s was not created", templateName))
 	cmd = exec.Command("kubectl", "get", "workspacetemplate", templateName, "-n", SharedNamespace, "--ignore-not-found")

--- a/test/e2e/static/template-scope/template-cross-ns-as-rejected.yaml
+++ b/test/e2e/static/template-scope/template-cross-ns-as-rejected.yaml
@@ -1,0 +1,18 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: WorkspaceTemplate
+metadata:
+  name: template-cross-ns-as-rejected
+  namespace: default
+spec:
+  displayName: "Template referencing a cross-namespace access strategy"
+  defaultImage: jk8s-application-jupyter-uv:latest
+  allowedImages:
+    - jk8s-application-jupyter-uv:latest
+  primaryStorage:
+    defaultSize: 1Gi
+    minSize: 100Mi
+    maxSize: 20Gi
+  appType: jupyter
+  defaultAccessStrategy:
+    name: team-b-access-strategy
+    namespace: scope-team-b

--- a/test/e2e/static/template-scope/template-local-as.yaml
+++ b/test/e2e/static/template-scope/template-local-as.yaml
@@ -1,0 +1,18 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: WorkspaceTemplate
+metadata:
+  name: template-local-as
+  namespace: default
+spec:
+  displayName: "Template with local access strategy"
+  defaultImage: jk8s-application-jupyter-uv:latest
+  allowedImages:
+    - jk8s-application-jupyter-uv:latest
+  primaryStorage:
+    defaultSize: 1Gi
+    minSize: 100Mi
+    maxSize: 20Gi
+  appType: jupyter
+  defaultAccessStrategy:
+    name: local-access-strategy
+    namespace: default

--- a/test/e2e/static/template-scope/template-shared-as.yaml
+++ b/test/e2e/static/template-scope/template-shared-as.yaml
@@ -1,0 +1,18 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: WorkspaceTemplate
+metadata:
+  name: template-shared-as
+  namespace: default
+spec:
+  displayName: "Template with shared access strategy"
+  defaultImage: jk8s-application-jupyter-uv:latest
+  allowedImages:
+    - jk8s-application-jupyter-uv:latest
+  primaryStorage:
+    defaultSize: 1Gi
+    minSize: 100Mi
+    maxSize: 20Gi
+  appType: jupyter
+  defaultAccessStrategy:
+    name: shared-access-strategy
+    namespace: jupyter-k8s-shared

--- a/test/e2e/template_access_strategy_test.go
+++ b/test/e2e/template_access_strategy_test.go
@@ -94,7 +94,7 @@ var _ = Describe("Template Access Strategy Protection", Ordered, func() {
 	Context("Webhook rejection when the access strategy cannot be resolved", func() {
 		It("should reject creating a template whose access strategy does not exist", func() {
 			By("creating a template referencing a non-existent access strategy")
-			verifyCreateTemplateRejectedByWebhook(missingASTemplateFilename, groupDir, missingASTemplateName)
+			verifyCreateTemplateRejectedByWebhook(missingASTemplateFilename, groupDir, missingASTemplateName, "not found")
 		})
 
 		It("should reject creating a template whose access strategy exists only in another namespace", func() {
@@ -102,7 +102,8 @@ var _ = Describe("Template Access Strategy Protection", Ordered, func() {
 			createAccessStrategyForTest(accessStrategyFilename, groupDir, "")
 
 			By("creating a template that references the same name but in the 'default' namespace")
-			verifyCreateTemplateRejectedByWebhook(wrongNamespaceTemplateFile, groupDir, wrongNamespaceTemplateName)
+			verifyCreateTemplateRejectedByWebhook(
+				wrongNamespaceTemplateFile, groupDir, wrongNamespaceTemplateName, "is not allowed")
 		})
 
 		It("should reject mutating a template to reference a non-existent access strategy", func() {

--- a/test/e2e/template_namespace_scope_test.go
+++ b/test/e2e/template_namespace_scope_test.go
@@ -1,0 +1,91 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package e2e
+
+import (
+	"os/exec"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jupyter-infra/jupyter-k8s/test/utils"
+)
+
+// Templates referencing an access strategy via spec.defaultAccessStrategy are subject to the same
+// namespace-scope rule as workspaces: the reference may only target the template's own namespace or
+// the shared namespace. Enforcing it at template admission prevents admins from creating templates
+// that would make any referencing workspace fail its own admission webhook. This mirrors the
+// workspace-side coverage in workspace_namespace_scope_test.go.
+//
+// Note: the cross-namespace rejection here is distinct from the "access strategy does not exist"
+// rejection covered in template_access_strategy_test.go. To prove the scope rule (not the existence
+// check, which the mutating webhook applies first) is what rejects, BeforeAll creates the team-b
+// access strategy so the reference resolves and only the scope rule can fail it.
+var _ = Describe("Template Namespace Scope", Ordered, func() {
+	const (
+		groupDir           = "template"
+		subgroup           = "scope"
+		workspaceNamespace = "default"
+	)
+
+	BeforeAll(func() {
+		createNamespaceForTest("namespace-team-b", "template", "scope")
+		createAccessStrategyForTest("team-b-access-strategy", "access-strategy", "scope")
+	})
+
+	AfterAll(func() {
+		By("cleaning up team-b namespace")
+		cmd := exec.Command("kubectl", "delete", "ns", "scope-team-b",
+			"--ignore-not-found", "--wait=true", "--timeout=60s")
+		_, _ = utils.Run(cmd)
+	})
+
+	AfterEach(func() {
+		deleteResourcesForScopeTest()
+		deleteAccessStrategyResourcesForScopeTest()
+	})
+
+	It("should allow a template referencing an access strategy from its own namespace", func() {
+		createAccessStrategyForTest("local-access-strategy", "access-strategy", "scope")
+		createTemplateForTest("template-local-as", groupDir, subgroup)
+
+		Eventually(func(g Gomega) {
+			output, err := kubectlGet("workspacetemplate", "template-local-as", workspaceNamespace,
+				"{.metadata.name}")
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(output).To(Equal("template-local-as"))
+		}).WithTimeout(30 * time.Second).WithPolling(2 * time.Second).Should(Succeed())
+	})
+
+	It("should allow a template referencing an access strategy from the shared namespace", func() {
+		createAccessStrategyForTest("shared-access-strategy", "access-strategy", "scope")
+		createTemplateForTest("template-shared-as", groupDir, subgroup)
+
+		Eventually(func(g Gomega) {
+			output, err := kubectlGet("workspacetemplate", "template-shared-as", workspaceNamespace,
+				"{.metadata.name}")
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(output).To(Equal("template-shared-as"))
+		}).WithTimeout(30 * time.Second).WithPolling(2 * time.Second).Should(Succeed())
+	})
+
+	It("should reject a template referencing an access strategy from another team's namespace", func() {
+		path := BuildTestResourcePath("template-cross-ns-as-rejected", groupDir, subgroup)
+		cmd := exec.Command("kubectl", "apply", "-f", path)
+		_, err := utils.Run(cmd)
+		Expect(err).To(HaveOccurred(), "Expected webhook to reject cross-namespace access strategy reference")
+
+		cmd = exec.Command("kubectl", "get", "workspacetemplate", "template-cross-ns-as-rejected",
+			"-n", workspaceNamespace, "--ignore-not-found")
+		output, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(output).To(BeEmpty())
+	})
+})

--- a/test/e2e/template_namespace_scope_test.go
+++ b/test/e2e/template_namespace_scope_test.go
@@ -30,9 +30,9 @@ import (
 // access strategy so the reference resolves and only the scope rule can fail it.
 var _ = Describe("Template Namespace Scope", Ordered, func() {
 	const (
-		groupDir           = "template"
-		subgroup           = "scope"
-		workspaceNamespace = "default"
+		groupDir          = "template"
+		subgroup          = "scope"
+		templateNamespace = "default"
 	)
 
 	BeforeAll(func() {
@@ -57,7 +57,7 @@ var _ = Describe("Template Namespace Scope", Ordered, func() {
 		createTemplateForTest("template-local-as", groupDir, subgroup)
 
 		Eventually(func(g Gomega) {
-			output, err := kubectlGet("workspacetemplate", "template-local-as", workspaceNamespace,
+			output, err := kubectlGet("workspacetemplate", "template-local-as", templateNamespace,
 				"{.metadata.name}")
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(output).To(Equal("template-local-as"))
@@ -69,7 +69,7 @@ var _ = Describe("Template Namespace Scope", Ordered, func() {
 		createTemplateForTest("template-shared-as", groupDir, subgroup)
 
 		Eventually(func(g Gomega) {
-			output, err := kubectlGet("workspacetemplate", "template-shared-as", workspaceNamespace,
+			output, err := kubectlGet("workspacetemplate", "template-shared-as", templateNamespace,
 				"{.metadata.name}")
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(output).To(Equal("template-shared-as"))
@@ -83,7 +83,7 @@ var _ = Describe("Template Namespace Scope", Ordered, func() {
 		Expect(err).To(HaveOccurred(), "Expected webhook to reject cross-namespace access strategy reference")
 
 		cmd = exec.Command("kubectl", "get", "workspacetemplate", "template-cross-ns-as-rejected",
-			"-n", workspaceNamespace, "--ignore-not-found")
+			"-n", templateNamespace, "--ignore-not-found")
 		output, err := utils.Run(cmd)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(output).To(BeEmpty())


### PR DESCRIPTION
This PR adds the same namespace consistency rules to `Template.spec.defaultAccessStrategy` field as to `Workspace.spec.accessStrategy`, namely either a/ same namespace as the template or b/ shared namespace. If `Template.spec.defaultAccessStrategy.namespace` is omitted, then defaults to the template's namespace.

This consistency enforcement is necessary because a Template configures a workspace, and these same rules apply at workspace admission time. If a template in namespace A referenced an access strategy in namespace B (!= from the shared namespace), then any workspace that try to use it would fail at admission time.

Refer to #349 for workspace <-> access strategy related rules.

Fast-follow from #396 

### User experience

- no change, but same backward incompatibility risk if existing users already referenced cross-namespaces AccessStrategy (deemed acceptable)

### Implementation

1. on create Template:
    1.1. if spec.defaultAccessStrategy is Nil -> OK
    1.2. if spec.defaultAccessStrategy.namespace == "" -> OK (interpreted as template namespace)
    1.3. if spec.defaultAccessStrategy.namespace == metadata.namespace -> OK
    1.4. if spec.defaultAccessStrategy.namespace == shared-namespace -> OK
    1.5. otherwise deny
2. on update Template:
    2.1. always allow to remove a defaultAccessStrategy

### Testing
- added E2E test cases for `defaultAccessStrategy` admission flow in create Template


