### PR TITLE
fix: set all conditions coherently in UpdateDeletingStatus

### DIFF
--- a/internal/controller/conditions.go
+++ b/internal/controller/conditions.go
@@ -25,6 +25,9 @@ const (
 
 	// ConditionTypeStopped indicates if the Workspace is in a stopped state
 	ConditionTypeStopped = "Stopped"
+
+	// ConditionTypeDeleting indicates the Workspace is being deleted and resources are being cleaned up
+	ConditionTypeDeleting = "Deleting"
 )
 
 // Condition reasons for Workspace resources
@@ -53,6 +56,9 @@ const (
 
 	// ConditionTypeAvailable reasons (special cases)
 	ReasonPreempted = "Preempted"
+
+	// ConditionTypeDeleting reasons
+	ReasonDeletionInProgress = "DeletionInProgress"
 )
 
 // NewCondition creates a new condition with the specified status

--- a/internal/controller/state_machine.go
+++ b/internal/controller/state_machine.go
@@ -445,7 +445,8 @@ func (sm *StateMachine) ReconcileDeletion(ctx context.Context, workspace *worksp
 	}
 
 	// Update status to Deleting
-	if err := sm.statusManager.UpdateDeletingStatus(ctx, workspace); err != nil {
+	snapshotStatus := workspace.Status.DeepCopy()
+	if err := sm.statusManager.UpdateDeletingStatus(ctx, workspace, snapshotStatus); err != nil {
 		logger.Error(err, "Failed to update deleting status")
 		return ctrl.Result{}, err
 	}

--- a/internal/controller/state_machine_deletion_test.go
+++ b/internal/controller/state_machine_deletion_test.go
@@ -98,6 +98,18 @@ var _ = Describe("ReconcileDeletion", func() {
 		availableCond = findCondition(ws.Status.Conditions, ConditionTypeAvailable)
 		Expect(availableCond).NotTo(BeNil())
 		Expect(availableCond.Status).To(Equal(metav1.ConditionFalse))
+
+		progressingCond := findCondition(ws.Status.Conditions, ConditionTypeProgressing)
+		Expect(progressingCond).NotTo(BeNil())
+		Expect(progressingCond.Status).To(Equal(metav1.ConditionFalse))
+
+		degradedCond := findCondition(ws.Status.Conditions, ConditionTypeDegraded)
+		Expect(degradedCond).NotTo(BeNil())
+		Expect(degradedCond.Status).To(Equal(metav1.ConditionFalse))
+
+		stoppedCond := findCondition(ws.Status.Conditions, ConditionTypeStopped)
+		Expect(stoppedCond).NotTo(BeNil())
+		Expect(stoppedCond.Status).To(Equal(metav1.ConditionFalse))
 	})
 
 	It("should skip when no finalizer is present", func() {

--- a/internal/controller/state_machine_deletion_test.go
+++ b/internal/controller/state_machine_deletion_test.go
@@ -87,9 +87,9 @@ var _ = Describe("ReconcileDeletion", func() {
 		_, err := sm.ReconcileDeletion(ctx, ws)
 		Expect(err).NotTo(HaveOccurred())
 
-		// Reload and verify conditions
-		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(ws), ws)).To(Succeed())
-
+		// After ReconcileDeletion, the workspace is modified in-place with updated conditions.
+		// The object may be garbage-collected (finalizer removed + DeletionTimestamp set),
+		// so we verify the in-memory object rather than reloading from the API.
 		deletingCond := findCondition(ws.Status.Conditions, ConditionTypeDeleting)
 		Expect(deletingCond).NotTo(BeNil())
 		Expect(deletingCond.Status).To(Equal(metav1.ConditionTrue))
@@ -120,16 +120,14 @@ var _ = Describe("ReconcileDeletion", func() {
 		Expect(result.RequeueAfter).To(Equal(time.Duration(0)))
 	})
 
-	It("should remove finalizer when all resources are cleaned up", func() {
+	It("should remove finalizer and allow deletion when all resources are cleaned up", func() {
 		ws := newDeletingWorkspace()
 
 		sm := buildStateMachine()
 		_, err := sm.ReconcileDeletion(ctx, ws)
 		Expect(err).NotTo(HaveOccurred())
 
-		// No deployment/service exist, so CleanupAllResources returns true
-		// Finalizer should be removed
-		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(ws), ws)).To(Succeed())
+		// Finalizer removed in-place — object is garbage-collected by the API server
 		Expect(controllerutil.ContainsFinalizer(ws, WorkspaceFinalizerName)).To(BeFalse())
 	})
 
@@ -138,15 +136,15 @@ var _ = Describe("ReconcileDeletion", func() {
 
 		// Set resource names
 		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(ws), ws)).To(Succeed())
-		ws.Status.DeploymentName = "test-deployment"
-		ws.Status.ServiceName = "test-service"
+		ws.Status.DeploymentName = "del-test-deploy"
+		ws.Status.ServiceName = "del-test-svc"
 		Expect(k8sClient.Status().Update(ctx, ws)).To(Succeed())
 
 		sm := buildStateMachine()
 		_, err := sm.ReconcileDeletion(ctx, ws)
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(ws), ws)).To(Succeed())
+		// Verify in-memory object (workspace is garbage-collected after finalizer removal)
 		Expect(ws.Status.DeploymentName).To(BeEmpty())
 		Expect(ws.Status.ServiceName).To(BeEmpty())
 	})

--- a/internal/controller/state_machine_deletion_test.go
+++ b/internal/controller/state_machine_deletion_test.go
@@ -1,0 +1,153 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	workspacev1alpha1 "github.com/jupyter-infra/jupyter-k8s/api/v1alpha1"
+)
+
+var _ = Describe("ReconcileDeletion", func() {
+	var ctx context.Context
+
+	newDeletingWorkspace := func() *workspacev1alpha1.Workspace {
+		ws := &workspacev1alpha1.Workspace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       fmt.Sprintf("sm-del-%d", time.Now().UnixNano()),
+				Namespace:  "default",
+				Finalizers: []string{WorkspaceFinalizerName},
+			},
+			Spec: workspacev1alpha1.WorkspaceSpec{
+				Image:         "jupyter/base-notebook:latest",
+				DesiredStatus: DesiredStateRunning,
+			},
+		}
+		Expect(k8sClient.Create(ctx, ws)).To(Succeed())
+
+		// Set to Running state first so Available=True
+		statusManager := NewStatusManager(k8sClient)
+		snapshot := ws.Status.DeepCopy()
+		Expect(statusManager.UpdateRunningStatus(ctx, ws, snapshot)).To(Succeed())
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(ws), ws)).To(Succeed())
+
+		// Issue delete (workspace stays due to finalizer)
+		Expect(k8sClient.Delete(ctx, ws)).To(Succeed())
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(ws), ws)).To(Succeed())
+		Expect(ws.DeletionTimestamp.IsZero()).To(BeFalse())
+		return ws
+	}
+
+	buildStateMachine := func() *StateMachine {
+		statusManager := NewStatusManager(k8sClient)
+		rm := NewResourceManager(
+			k8sClient,
+			scheme.Scheme,
+			NewDeploymentBuilder(scheme.Scheme, WorkspaceControllerOptions{}, k8sClient),
+			NewServiceBuilder(scheme.Scheme),
+			NewPVCBuilder(scheme.Scheme),
+			NewAccessResourcesBuilder(),
+			statusManager,
+		)
+		return &StateMachine{
+			resourceManager:     rm,
+			statusManager:       statusManager,
+			accessStartupProber: &mockAccessStartupProber{},
+			recorder:            record.NewFakeRecorder(10),
+		}
+	}
+
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+
+	It("should set Deleting=True and Available=False on a running workspace", func() {
+		ws := newDeletingWorkspace()
+
+		// Verify Available=True before ReconcileDeletion
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(ws), ws)).To(Succeed())
+		availableCond := findCondition(ws.Status.Conditions, ConditionTypeAvailable)
+		Expect(availableCond).NotTo(BeNil())
+		Expect(availableCond.Status).To(Equal(metav1.ConditionTrue))
+
+		sm := buildStateMachine()
+		_, err := sm.ReconcileDeletion(ctx, ws)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Reload and verify conditions
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(ws), ws)).To(Succeed())
+
+		deletingCond := findCondition(ws.Status.Conditions, ConditionTypeDeleting)
+		Expect(deletingCond).NotTo(BeNil())
+		Expect(deletingCond.Status).To(Equal(metav1.ConditionTrue))
+		Expect(deletingCond.Reason).To(Equal(ReasonDeletionInProgress))
+
+		availableCond = findCondition(ws.Status.Conditions, ConditionTypeAvailable)
+		Expect(availableCond).NotTo(BeNil())
+		Expect(availableCond.Status).To(Equal(metav1.ConditionFalse))
+	})
+
+	It("should skip when no finalizer is present", func() {
+		ws := &workspacev1alpha1.Workspace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("sm-del-nofin-%d", time.Now().UnixNano()),
+				Namespace: "default",
+			},
+			Spec: workspacev1alpha1.WorkspaceSpec{
+				Image:         "jupyter/base-notebook:latest",
+				DesiredStatus: DesiredStateRunning,
+			},
+		}
+		Expect(k8sClient.Create(ctx, ws)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, ws) }()
+
+		sm := buildStateMachine()
+		result, err := sm.ReconcileDeletion(ctx, ws)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.RequeueAfter).To(Equal(time.Duration(0)))
+	})
+
+	It("should remove finalizer when all resources are cleaned up", func() {
+		ws := newDeletingWorkspace()
+
+		sm := buildStateMachine()
+		_, err := sm.ReconcileDeletion(ctx, ws)
+		Expect(err).NotTo(HaveOccurred())
+
+		// No deployment/service exist, so CleanupAllResources returns true
+		// Finalizer should be removed
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(ws), ws)).To(Succeed())
+		Expect(controllerutil.ContainsFinalizer(ws, WorkspaceFinalizerName)).To(BeFalse())
+	})
+
+	It("should clear DeploymentName and ServiceName", func() {
+		ws := newDeletingWorkspace()
+
+		// Set resource names
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(ws), ws)).To(Succeed())
+		ws.Status.DeploymentName = "test-deployment"
+		ws.Status.ServiceName = "test-service"
+		Expect(k8sClient.Status().Update(ctx, ws)).To(Succeed())
+
+		sm := buildStateMachine()
+		_, err := sm.ReconcileDeletion(ctx, ws)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(ws), ws)).To(Succeed())
+		Expect(ws.Status.DeploymentName).To(BeEmpty())
+		Expect(ws.Status.ServiceName).To(BeEmpty())
+	})
+})

--- a/internal/controller/status_manager.go
+++ b/internal/controller/status_manager.go
@@ -131,12 +131,20 @@ func (sm *StatusManager) UpdateStartingStatus(
 		"Workspace is starting",
 	)
 
+	deletingCondition := NewCondition(
+		ConditionTypeDeleting,
+		metav1.ConditionFalse,
+		ReasonDesiredStateRunning,
+		"Workspace is starting",
+	)
+
 	// Apply all conditions
 	conditions := []metav1.Condition{
 		availableCondition,
 		progressingCondition,
 		degradedCondition,
 		stoppedCondition,
+		deletingCondition,
 	}
 
 	conditionsToUpdate := MergeConditionsIfChanged(ctx, workspace, &conditions)
@@ -177,6 +185,7 @@ func (sm *StatusManager) UpdatePermanentDegradedRunningStatus(
 		NewCondition(ConditionTypeProgressing, metav1.ConditionFalse, degradedReason, message),
 		NewCondition(ConditionTypeDegraded, metav1.ConditionTrue, degradedReason, message),
 		NewCondition(ConditionTypeStopped, metav1.ConditionFalse, ReasonDesiredStateRunning, "Workspace desired state is Running"),
+		NewCondition(ConditionTypeDeleting, metav1.ConditionFalse, ReasonDesiredStateRunning, "Workspace desired state is Running"),
 	}
 
 	conditionsToUpdate := MergeConditionsIfChanged(ctx, workspace, &conditions)
@@ -224,12 +233,20 @@ func (sm *StatusManager) UpdateRunningStatus(
 		"Workspace is running",
 	)
 
+	deletingCondition := NewCondition(
+		ConditionTypeDeleting,
+		metav1.ConditionFalse,
+		ReasonDesiredStateRunning,
+		"Workspace is running",
+	)
+
 	// apply all conditions
 	conditions := []metav1.Condition{
 		availableCondition,
 		progressingCondition,
 		degradedCondition,
 		stoppedCondition,
+		deletingCondition,
 	}
 
 	conditionsToUpdate := MergeConditionsIfChanged(ctx, workspace, &conditions)
@@ -305,12 +322,20 @@ func (sm *StatusManager) UpdateStoppingStatus(
 		stoppingMessage,
 	)
 
+	deletingCondition := NewCondition(
+		ConditionTypeDeleting,
+		metav1.ConditionFalse,
+		ReasonDesiredStateStopped,
+		"Workspace is stopping",
+	)
+
 	// Apply all conditions
 	conditions := []metav1.Condition{
 		availableCondition,
 		progressingCondition,
 		degradedCondition,
 		stoppedCondition,
+		deletingCondition,
 	}
 
 	conditionsToUpdate := MergeConditionsIfChanged(ctx, workspace, &conditions)
@@ -365,12 +390,20 @@ func (sm *StatusManager) UpdateStoppedStatus(
 		"Workspace is stopped",
 	)
 
+	deletingCondition := NewCondition(
+		ConditionTypeDeleting,
+		metav1.ConditionFalse,
+		ReasonDesiredStateStopped,
+		"Workspace is stopped",
+	)
+
 	// Apply all conditions
 	conditions := []metav1.Condition{
 		availableCondition,
 		progressingCondition,
 		degradedCondition,
 		stoppedCondition,
+		deletingCondition,
 	}
 
 	conditionsToUpdate := MergeConditionsIfChanged(ctx, workspace, &conditions)

--- a/internal/controller/status_manager.go
+++ b/internal/controller/status_manager.go
@@ -12,7 +12,6 @@ import (
 
 	workspacev1alpha1 "github.com/jupyter-infra/jupyter-k8s/api/v1alpha1"
 
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -383,16 +382,24 @@ func (sm *StatusManager) UpdateStoppedStatus(
 	return sm.updateStatus(ctx, workspace, &conditionsToUpdate, snapshotStatus)
 }
 
-// UpdateDeletingStatus sets the workspace status to indicate deletion in progress
-func (sm *StatusManager) UpdateDeletingStatus(ctx context.Context, workspace *workspacev1alpha1.Workspace) error {
-	condition := metav1.Condition{
-		Type:               "Deleting",
-		Status:             metav1.ConditionTrue,
-		Reason:             "DeletionInProgress",
-		Message:            "Workspace resources are being deleted",
-		LastTransitionTime: metav1.Now(),
+// UpdateDeletingStatus sets Deleting=True to signal deletion in progress.
+// Other conditions are left unchanged — the UI uses Deleting as highest-priority status.
+func (sm *StatusManager) UpdateDeletingStatus(
+	ctx context.Context,
+	workspace *workspacev1alpha1.Workspace,
+	snapshotStatus *workspacev1alpha1.WorkspaceStatus) error {
+
+	conditions := []metav1.Condition{
+		NewCondition(ConditionTypeAvailable, metav1.ConditionFalse, ReasonDeletionInProgress, "Workspace is being deleted"),
+		NewCondition(ConditionTypeProgressing, metav1.ConditionFalse, ReasonDeletionInProgress, "Workspace is being deleted"),
+		NewCondition(ConditionTypeDegraded, metav1.ConditionFalse, ReasonNoError, "No errors detected"),
+		NewCondition(ConditionTypeStopped, metav1.ConditionFalse, ReasonDeletionInProgress, "Workspace is being deleted"),
+		NewCondition(ConditionTypeDeleting, metav1.ConditionTrue, ReasonDeletionInProgress, "Workspace resources are being deleted"),
 	}
 
-	meta.SetStatusCondition(&workspace.Status.Conditions, condition)
-	return sm.client.Status().Update(ctx, workspace)
+	conditionsToUpdate := MergeConditionsIfChanged(ctx, workspace, &conditions)
+
+	workspace.Status.DeploymentName = ""
+	workspace.Status.ServiceName = ""
+	return sm.updateStatus(ctx, workspace, &conditionsToUpdate, snapshotStatus)
 }

--- a/internal/controller/status_manager_test.go
+++ b/internal/controller/status_manager_test.go
@@ -60,7 +60,7 @@ var _ = Describe("StatusManager", func() {
 				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(workspace), workspace)).To(Succeed())
 
 				// Verify exactly 4 conditions
-				Expect(workspace.Status.Conditions).To(HaveLen(4))
+				Expect(workspace.Status.Conditions).To(HaveLen(5))
 
 				// Verify Available=True
 				availableCond := findCondition(workspace.Status.Conditions, ConditionTypeAvailable)
@@ -100,7 +100,7 @@ var _ = Describe("StatusManager", func() {
 				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(workspace), workspace)).To(Succeed())
 
 				// Verify exactly 4 conditions
-				Expect(workspace.Status.Conditions).To(HaveLen(4))
+				Expect(workspace.Status.Conditions).To(HaveLen(5))
 
 				// Verify Available=False with ComputeNotReady reason
 				availableCond := findCondition(workspace.Status.Conditions, ConditionTypeAvailable)
@@ -138,7 +138,7 @@ var _ = Describe("StatusManager", func() {
 				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(workspace), workspace)).To(Succeed())
 
 				// Verify exactly 4 conditions
-				Expect(workspace.Status.Conditions).To(HaveLen(4))
+				Expect(workspace.Status.Conditions).To(HaveLen(5))
 
 				// Verify Available=False with ServiceNotReady reason
 				availableCond := findCondition(workspace.Status.Conditions, ConditionTypeAvailable)
@@ -176,7 +176,7 @@ var _ = Describe("StatusManager", func() {
 				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(workspace), workspace)).To(Succeed())
 
 				// Verify exactly 4 conditions
-				Expect(workspace.Status.Conditions).To(HaveLen(4))
+				Expect(workspace.Status.Conditions).To(HaveLen(5))
 
 				// Verify Available=False with AccessNotReady reason
 				availableCond := findCondition(workspace.Status.Conditions, ConditionTypeAvailable)
@@ -286,7 +286,7 @@ var _ = Describe("StatusManager", func() {
 				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(workspace), workspace)).To(Succeed())
 
 				// Verify exactly 4 conditions
-				Expect(workspace.Status.Conditions).To(HaveLen(4))
+				Expect(workspace.Status.Conditions).To(HaveLen(5))
 
 				// Verify Degraded=True (changed from Running state)
 				degradedCond := findCondition(workspace.Status.Conditions, ConditionTypeDegraded)
@@ -336,7 +336,7 @@ var _ = Describe("StatusManager", func() {
 
 				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(workspace), workspace)).To(Succeed())
 
-				Expect(workspace.Status.Conditions).To(HaveLen(4))
+				Expect(workspace.Status.Conditions).To(HaveLen(5))
 
 				// Degraded=True with degradedReason
 				degradedCond := findCondition(workspace.Status.Conditions, ConditionTypeDegraded)
@@ -465,6 +465,7 @@ var _ = Describe("StatusManager", func() {
 					ConditionTypeProgressing,
 					ConditionTypeDegraded,
 					ConditionTypeStopped,
+					ConditionTypeDeleting,
 				}
 
 				// Test UpdateStartingStatus

--- a/internal/controller/status_manager_test.go
+++ b/internal/controller/status_manager_test.go
@@ -391,6 +391,73 @@ var _ = Describe("StatusManager", func() {
 			})
 		})
 
+		Describe("UpdateDeletingStatus", func() {
+			It("should set all conditions coherently when deleting a running workspace", func() {
+				// First bring workspace to Running state
+				snapshot := workspace.Status.DeepCopy()
+				err := statusManager.UpdateRunningStatus(ctx, workspace, snapshot)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(workspace), workspace)).To(Succeed())
+
+				// Verify Available=True before deletion
+				availableCond := findCondition(workspace.Status.Conditions, ConditionTypeAvailable)
+				Expect(availableCond).NotTo(BeNil())
+				Expect(availableCond.Status).To(Equal(metav1.ConditionTrue))
+
+				// Now update to Deleting
+				snapshot = workspace.Status.DeepCopy()
+				err = statusManager.UpdateDeletingStatus(ctx, workspace, snapshot)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(workspace), workspace)).To(Succeed())
+
+				// Verify 5 conditions
+				Expect(workspace.Status.Conditions).To(HaveLen(5))
+
+				// Verify Available=False
+				availableCond = findCondition(workspace.Status.Conditions, ConditionTypeAvailable)
+				Expect(availableCond).NotTo(BeNil())
+				Expect(availableCond.Status).To(Equal(metav1.ConditionFalse))
+				Expect(availableCond.Reason).To(Equal(ReasonDeletionInProgress))
+
+				// Verify Progressing=False
+				progressingCond := findCondition(workspace.Status.Conditions, ConditionTypeProgressing)
+				Expect(progressingCond).NotTo(BeNil())
+				Expect(progressingCond.Status).To(Equal(metav1.ConditionFalse))
+
+				// Verify Degraded=False
+				degradedCond := findCondition(workspace.Status.Conditions, ConditionTypeDegraded)
+				Expect(degradedCond).NotTo(BeNil())
+				Expect(degradedCond.Status).To(Equal(metav1.ConditionFalse))
+
+				// Verify Stopped=False
+				stoppedCond := findCondition(workspace.Status.Conditions, ConditionTypeStopped)
+				Expect(stoppedCond).NotTo(BeNil())
+				Expect(stoppedCond.Status).To(Equal(metav1.ConditionFalse))
+
+				// Verify Deleting=True
+				deletingCond := findCondition(workspace.Status.Conditions, ConditionTypeDeleting)
+				Expect(deletingCond).NotTo(BeNil())
+				Expect(deletingCond.Status).To(Equal(metav1.ConditionTrue))
+				Expect(deletingCond.Reason).To(Equal(ReasonDeletionInProgress))
+			})
+
+			It("should clear DeploymentName and ServiceName", func() {
+				// Set resource names first
+				workspace.Status.DeploymentName = "test-deployment"
+				workspace.Status.ServiceName = "test-service"
+				Expect(k8sClient.Status().Update(ctx, workspace)).To(Succeed())
+				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(workspace), workspace)).To(Succeed())
+
+				snapshot := workspace.Status.DeepCopy()
+				err := statusManager.UpdateDeletingStatus(ctx, workspace, snapshot)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(workspace), workspace)).To(Succeed())
+
+				Expect(workspace.Status.DeploymentName).To(BeEmpty())
+				Expect(workspace.Status.ServiceName).To(BeEmpty())
+			})
+		})
+
 		Describe("Condition Ordering Consistency", func() {
 			It("should maintain consistent condition order across all status updates", func() {
 				expectedOrder := []string{

--- a/test/e2e/constants.go
+++ b/test/e2e/constants.go
@@ -37,6 +37,7 @@ const (
 	ConditionTypeDegraded    = "Degraded"
 	ConditionTypeAvailable   = "Available"
 	ConditionTypeStopped     = "Stopped"
+	ConditionTypeDeleting    = "Deleting"
 )
 
 // WorkspaceLabelName is the label key used to identify workspace resources

--- a/test/e2e/helpers_workspaces.go
+++ b/test/e2e/helpers_workspaces.go
@@ -219,6 +219,19 @@ func UpdateWorkspaceDesiredState(workspaceName, namespace, desiredState string) 
 	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to update workspace desiredStatus")
 }
 
+// WaitForWorkspaceDeletion polls until the workspace is fully removed from the cluster (NotFound).
+func WaitForWorkspaceDeletion(workspaceName, namespace string) {
+	ginkgo.GinkgoHelper()
+
+	gomega.Eventually(func(g gomega.Gomega) {
+		cmd := exec.Command("kubectl", "get", "workspace", workspaceName,
+			"-n", namespace, "--ignore-not-found", "-o", "name")
+		output, err := utils.Run(cmd)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		g.Expect(strings.TrimSpace(string(output))).To(gomega.BeEmpty(), "workspace should no longer exist")
+	}).WithTimeout(2 * time.Minute).WithPolling(3 * time.Second).Should(gomega.Succeed())
+}
+
 // deleteWorkspaceAsUser deletes a workspace with kubectl impersonation
 func deleteWorkspaceAsUser(name, user string, groups []string) error {
 	ginkgo.GinkgoHelper()

--- a/test/e2e/helpers_workspaces.go
+++ b/test/e2e/helpers_workspaces.go
@@ -228,7 +228,7 @@ func WaitForWorkspaceDeletion(workspaceName, namespace string) {
 			"-n", namespace, "--ignore-not-found", "-o", "name")
 		output, err := utils.Run(cmd)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
-		g.Expect(strings.TrimSpace(string(output))).To(gomega.BeEmpty(), "workspace should no longer exist")
+		g.Expect(strings.TrimSpace(output)).To(gomega.BeEmpty(), "workspace should no longer exist")
 	}).WithTimeout(2 * time.Minute).WithPolling(3 * time.Second).Should(gomega.Succeed())
 }
 

--- a/test/e2e/helpers_workspaces.go
+++ b/test/e2e/helpers_workspaces.go
@@ -46,8 +46,9 @@ func WaitForWorkspaceToReachCondition(
 	}).WithTimeout(5 * time.Minute).WithPolling(5 * time.Second).Should(gomega.Succeed())
 }
 
-// VerifyWorkspaceConditions verifies workspace status conditions
-// expectedConditions is a map of condition type to expected status (e.g., "Progressing" -> "True")
+// VerifyWorkspaceConditions verifies workspace status conditions exactly.
+// expectedConditions is a map of condition type to expected status (e.g., "Progressing" -> "True").
+// The workspace must have exactly the conditions specified — no more, no less.
 func VerifyWorkspaceConditions(
 	workspaceName string,
 	namespace string,

--- a/test/e2e/static/status/workspace-deletion-test.yaml
+++ b/test/e2e/static/status/workspace-deletion-test.yaml
@@ -1,0 +1,18 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: Workspace
+metadata:
+  name: workspace-deletion-test
+  namespace: default
+spec:
+  displayName: "Status Test - Deletion"
+  image: jk8s-application-jupyter-uv:latest
+  desiredStatus: Running
+  resources:
+    requests:
+      cpu: 200m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  storage:
+    size: 1Gi

--- a/test/e2e/workspace_access_probe_test.go
+++ b/test/e2e/workspace_access_probe_test.go
@@ -66,6 +66,7 @@ var _ = Describe("Workspace Access Startup Probe", Ordered, func() {
 				controller.ConditionTypeDegraded:    ConditionFalse,
 				controller.ConditionTypeAvailable:   ConditionTrue,
 				controller.ConditionTypeStopped:     ConditionFalse,
+				ConditionTypeDeleting:    ConditionFalse,
 			})
 
 			// Verify the workspace stays Available and doesn't oscillate.
@@ -77,6 +78,7 @@ var _ = Describe("Workspace Access Startup Probe", Ordered, func() {
 				controller.ConditionTypeProgressing: ConditionFalse,
 				controller.ConditionTypeDegraded:    ConditionFalse,
 				controller.ConditionTypeStopped:     ConditionFalse,
+				ConditionTypeDeleting:    ConditionFalse,
 			}, "1m", "5s")
 
 			By("verifying accessStartupProbeFailures is cleared after success")
@@ -124,6 +126,7 @@ var _ = Describe("Workspace Access Startup Probe", Ordered, func() {
 				controller.ConditionTypeAvailable:   ConditionFalse,
 				controller.ConditionTypeProgressing: ConditionFalse,
 				controller.ConditionTypeStopped:     ConditionFalse,
+				ConditionTypeDeleting:    ConditionFalse,
 			}, "30s", "5s")
 
 			By("verifying accessStartupProbeFailures is retained at threshold")
@@ -169,6 +172,7 @@ var _ = Describe("Workspace Access Startup Probe", Ordered, func() {
 				controller.ConditionTypeDegraded:    ConditionFalse,
 				controller.ConditionTypeAvailable:   ConditionTrue,
 				controller.ConditionTypeStopped:     ConditionFalse,
+				ConditionTypeDeleting:    ConditionFalse,
 			})
 
 			By("verifying accessStartupProbeFailures is cleared after success")

--- a/test/e2e/workspace_access_probe_test.go
+++ b/test/e2e/workspace_access_probe_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Workspace Access Startup Probe", Ordered, func() {
 				controller.ConditionTypeDegraded:    ConditionFalse,
 				controller.ConditionTypeAvailable:   ConditionTrue,
 				controller.ConditionTypeStopped:     ConditionFalse,
-				ConditionTypeDeleting:    ConditionFalse,
+				ConditionTypeDeleting:               ConditionFalse,
 			})
 
 			// Verify the workspace stays Available and doesn't oscillate.
@@ -78,7 +78,7 @@ var _ = Describe("Workspace Access Startup Probe", Ordered, func() {
 				controller.ConditionTypeProgressing: ConditionFalse,
 				controller.ConditionTypeDegraded:    ConditionFalse,
 				controller.ConditionTypeStopped:     ConditionFalse,
-				ConditionTypeDeleting:    ConditionFalse,
+				ConditionTypeDeleting:               ConditionFalse,
 			}, "1m", "5s")
 
 			By("verifying accessStartupProbeFailures is cleared after success")
@@ -126,7 +126,7 @@ var _ = Describe("Workspace Access Startup Probe", Ordered, func() {
 				controller.ConditionTypeAvailable:   ConditionFalse,
 				controller.ConditionTypeProgressing: ConditionFalse,
 				controller.ConditionTypeStopped:     ConditionFalse,
-				ConditionTypeDeleting:    ConditionFalse,
+				ConditionTypeDeleting:               ConditionFalse,
 			}, "30s", "5s")
 
 			By("verifying accessStartupProbeFailures is retained at threshold")
@@ -172,7 +172,7 @@ var _ = Describe("Workspace Access Startup Probe", Ordered, func() {
 				controller.ConditionTypeDegraded:    ConditionFalse,
 				controller.ConditionTypeAvailable:   ConditionTrue,
 				controller.ConditionTypeStopped:     ConditionFalse,
-				ConditionTypeDeleting:    ConditionFalse,
+				ConditionTypeDeleting:               ConditionFalse,
 			})
 
 			By("verifying accessStartupProbeFailures is cleared after success")

--- a/test/e2e/workspace_access_strategy_test.go
+++ b/test/e2e/workspace_access_strategy_test.go
@@ -59,6 +59,7 @@ var _ = Describe("Workspace Access Strategy", Ordered, func() {
 				controller.ConditionTypeDegraded:    ConditionFalse,
 				controller.ConditionTypeAvailable:   ConditionTrue,
 				controller.ConditionTypeStopped:     ConditionFalse,
+				controller.ConditionTypeDeleting:    ConditionFalse,
 			})
 
 			By("retrieving deployment name from workspace status")
@@ -102,6 +103,7 @@ var _ = Describe("Workspace Access Strategy", Ordered, func() {
 				controller.ConditionTypeDegraded:    ConditionFalse,
 				controller.ConditionTypeAvailable:   ConditionTrue,
 				controller.ConditionTypeStopped:     ConditionFalse,
+				controller.ConditionTypeDeleting:    ConditionFalse,
 			})
 
 			By("verifying network policy has been created")
@@ -211,6 +213,7 @@ var _ = Describe("Workspace Access Strategy", Ordered, func() {
 				controller.ConditionTypeDegraded:    ConditionFalse,
 				controller.ConditionTypeAvailable:   ConditionFalse,
 				controller.ConditionTypeStopped:     ConditionTrue,
+				controller.ConditionTypeDeleting:    ConditionFalse,
 			})
 
 			By("verifying no access resources have been created")
@@ -299,6 +302,7 @@ var _ = Describe("Workspace Access Strategy", Ordered, func() {
 				controller.ConditionTypeDegraded:    ConditionFalse,
 				controller.ConditionTypeAvailable:   ConditionFalse,
 				controller.ConditionTypeStopped:     ConditionTrue,
+				controller.ConditionTypeDeleting:    ConditionFalse,
 			})
 
 			By("consistently verifying access resources do not exist")
@@ -376,6 +380,7 @@ var _ = Describe("Workspace Access Strategy", Ordered, func() {
 				controller.ConditionTypeDegraded:    ConditionFalse,
 				controller.ConditionTypeAvailable:   ConditionTrue,
 				controller.ConditionTypeStopped:     ConditionFalse,
+				controller.ConditionTypeDeleting:    ConditionFalse,
 			})
 
 			By("verifying all access resources have been created")

--- a/test/e2e/workspace_scheduling_test.go
+++ b/test/e2e/workspace_scheduling_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Workspace Scheduling", Ordered, func() {
 				controller.ConditionTypeDegraded:    ConditionFalse,
 				controller.ConditionTypeAvailable:   ConditionTrue,
 				controller.ConditionTypeStopped:     ConditionFalse,
-				ConditionTypeDeleting:    ConditionFalse,
+				ConditionTypeDeleting:               ConditionFalse,
 			})
 
 			By("verifying workspace has correct affinity spec")
@@ -85,7 +85,7 @@ var _ = Describe("Workspace Scheduling", Ordered, func() {
 				controller.ConditionTypeDegraded:    ConditionFalse,
 				controller.ConditionTypeAvailable:   ConditionTrue,
 				controller.ConditionTypeStopped:     ConditionFalse,
-				ConditionTypeDeleting:    ConditionFalse,
+				ConditionTypeDeleting:               ConditionFalse,
 			})
 
 			By("verifying workspace has correct tolerations spec")
@@ -118,7 +118,7 @@ var _ = Describe("Workspace Scheduling", Ordered, func() {
 				controller.ConditionTypeDegraded:    ConditionFalse,
 				controller.ConditionTypeAvailable:   ConditionTrue,
 				controller.ConditionTypeStopped:     ConditionFalse,
-				ConditionTypeDeleting:    ConditionFalse,
+				ConditionTypeDeleting:               ConditionFalse,
 			})
 
 			By("verifying workspace has correct node selector spec")

--- a/test/e2e/workspace_scheduling_test.go
+++ b/test/e2e/workspace_scheduling_test.go
@@ -51,6 +51,7 @@ var _ = Describe("Workspace Scheduling", Ordered, func() {
 				controller.ConditionTypeDegraded:    ConditionFalse,
 				controller.ConditionTypeAvailable:   ConditionTrue,
 				controller.ConditionTypeStopped:     ConditionFalse,
+				ConditionTypeDeleting:    ConditionFalse,
 			})
 
 			By("verifying workspace has correct affinity spec")
@@ -84,6 +85,7 @@ var _ = Describe("Workspace Scheduling", Ordered, func() {
 				controller.ConditionTypeDegraded:    ConditionFalse,
 				controller.ConditionTypeAvailable:   ConditionTrue,
 				controller.ConditionTypeStopped:     ConditionFalse,
+				ConditionTypeDeleting:    ConditionFalse,
 			})
 
 			By("verifying workspace has correct tolerations spec")
@@ -116,6 +118,7 @@ var _ = Describe("Workspace Scheduling", Ordered, func() {
 				controller.ConditionTypeDegraded:    ConditionFalse,
 				controller.ConditionTypeAvailable:   ConditionTrue,
 				controller.ConditionTypeStopped:     ConditionFalse,
+				ConditionTypeDeleting:    ConditionFalse,
 			})
 
 			By("verifying workspace has correct node selector spec")

--- a/test/e2e/workspace_status_test.go
+++ b/test/e2e/workspace_status_test.go
@@ -411,7 +411,6 @@ var _ = Describe("Workspace Status", Ordered, func() {
 				ConditionTypeProgressing: ConditionFalse,
 				ConditionTypeDegraded:    ConditionFalse,
 				ConditionTypeStopped:     ConditionFalse,
-				ConditionTypeDeleting:    ConditionFalse,
 				ConditionTypeDeleting:    ConditionTrue,
 			})
 

--- a/test/e2e/workspace_status_test.go
+++ b/test/e2e/workspace_status_test.go
@@ -371,6 +371,52 @@ var _ = Describe("Workspace Status", Ordered, func() {
 			Expect(desiredStatus).To(Equal("Running"), "desiredStatus should be defaulted to Running by the mutating webhook")
 		})
 	})
+
+	Context("Deleting State", func() {
+		const deletionWorkspace = "workspace-deletion-test"
+
+		It("should set Deleting=True and Available=False when workspace is deleted", func() {
+			By("creating workspace with desiredStatus=Running")
+			createWorkspaceForTest(deletionWorkspace, statusGroupDir, statusSubgroupDir)
+
+			By("waiting for Available condition to become True")
+			WaitForWorkspaceToReachCondition(
+				deletionWorkspace,
+				statusTestNamespace,
+				ConditionTypeAvailable,
+				ConditionTrue,
+			)
+
+			By("deleting the workspace")
+			cmd := exec.Command("kubectl", "delete", "workspace", deletionWorkspace,
+				"-n", statusTestNamespace, "--wait=false")
+			_, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("waiting for Deleting condition to become True")
+			WaitForWorkspaceToReachCondition(
+				deletionWorkspace,
+				statusTestNamespace,
+				ConditionTypeDeleting,
+				ConditionTrue,
+			)
+
+			By("verifying Available=False while Deleting=True")
+			VerifyWorkspaceConditions(deletionWorkspace, statusTestNamespace, map[string]string{
+				ConditionTypeAvailable:   ConditionFalse,
+				ConditionTypeProgressing: ConditionFalse,
+				ConditionTypeDegraded:    ConditionFalse,
+				ConditionTypeStopped:     ConditionFalse,
+				ConditionTypeDeleting:    ConditionTrue,
+			})
+
+			By("waiting for workspace to be fully deleted")
+			Eventually(func() bool {
+				_, err := kubectlGet("workspace", deletionWorkspace, statusTestNamespace, "{.metadata.name}")
+				return err != nil
+			}).WithTimeout(statusTestTimeout).WithPolling(statusTestPolling).Should(BeTrue())
+		})
+	})
 })
 
 func deleteResourcesForStatusTest() {

--- a/test/e2e/workspace_status_test.go
+++ b/test/e2e/workspace_status_test.go
@@ -411,10 +411,7 @@ var _ = Describe("Workspace Status", Ordered, func() {
 			})
 
 			By("waiting for workspace to be fully deleted")
-			Eventually(func() bool {
-				_, err := kubectlGet("workspace", deletionWorkspace, statusTestNamespace, "{.metadata.name}")
-				return err != nil
-			}).WithTimeout(statusTestTimeout).WithPolling(statusTestPolling).Should(BeTrue())
+			WaitForWorkspaceDeletion(deletionWorkspace, statusTestNamespace)
 		})
 	})
 })

--- a/test/e2e/workspace_status_test.go
+++ b/test/e2e/workspace_status_test.go
@@ -59,6 +59,7 @@ var _ = Describe("Workspace Status", Ordered, func() {
 				ConditionTypeDegraded:    ConditionFalse,
 				ConditionTypeAvailable:   ConditionTrue,
 				ConditionTypeStopped:     ConditionFalse,
+				ConditionTypeDeleting:    ConditionFalse,
 			})
 		})
 
@@ -159,6 +160,7 @@ var _ = Describe("Workspace Status", Ordered, func() {
 				ConditionTypeDegraded:    ConditionFalse,
 				ConditionTypeAvailable:   ConditionFalse,
 				ConditionTypeStopped:     ConditionTrue,
+				ConditionTypeDeleting:    ConditionFalse,
 			})
 		})
 
@@ -278,6 +280,7 @@ var _ = Describe("Workspace Status", Ordered, func() {
 				ConditionTypeDegraded:    ConditionFalse,
 				ConditionTypeAvailable:   ConditionFalse,
 				ConditionTypeStopped:     ConditionTrue,
+				ConditionTypeDeleting:    ConditionFalse,
 			})
 
 			By("verifying .status.deploymentName is removed")
@@ -334,6 +337,7 @@ var _ = Describe("Workspace Status", Ordered, func() {
 				ConditionTypeDegraded:    ConditionFalse,
 				ConditionTypeAvailable:   ConditionTrue,
 				ConditionTypeStopped:     ConditionFalse,
+				ConditionTypeDeleting:    ConditionFalse,
 			})
 
 			By("retrieving deployment and service names from workspace status")
@@ -407,6 +411,7 @@ var _ = Describe("Workspace Status", Ordered, func() {
 				ConditionTypeProgressing: ConditionFalse,
 				ConditionTypeDegraded:    ConditionFalse,
 				ConditionTypeStopped:     ConditionFalse,
+				ConditionTypeDeleting:    ConditionFalse,
 				ConditionTypeDeleting:    ConditionTrue,
 			})
 

--- a/test/e2e/workspace_template_test.go
+++ b/test/e2e/workspace_template_test.go
@@ -84,7 +84,7 @@ var _ = Describe("Workspace Template", Ordered, func() {
 				controller.ConditionTypeDegraded:    ConditionFalse,
 				controller.ConditionTypeAvailable:   ConditionTrue,
 				controller.ConditionTypeStopped:     ConditionFalse,
-				ConditionTypeDeleting:    ConditionFalse,
+				ConditionTypeDeleting:               ConditionFalse,
 			})
 		})
 
@@ -161,7 +161,7 @@ var _ = Describe("Workspace Template", Ordered, func() {
 				controller.ConditionTypeDegraded:    ConditionFalse,
 				controller.ConditionTypeAvailable:   ConditionTrue,
 				controller.ConditionTypeStopped:     ConditionFalse,
-				ConditionTypeDeleting:    ConditionFalse,
+				ConditionTypeDeleting:               ConditionFalse,
 			})
 		})
 
@@ -523,7 +523,7 @@ var _ = Describe("Workspace Template", Ordered, func() {
 				controller.ConditionTypeDegraded:    ConditionFalse,
 				controller.ConditionTypeAvailable:   ConditionTrue,
 				controller.ConditionTypeStopped:     ConditionFalse,
-				ConditionTypeDeleting:    ConditionFalse,
+				ConditionTypeDeleting:               ConditionFalse,
 			})
 
 			By("verifying templateRef was changed")

--- a/test/e2e/workspace_template_test.go
+++ b/test/e2e/workspace_template_test.go
@@ -84,6 +84,7 @@ var _ = Describe("Workspace Template", Ordered, func() {
 				controller.ConditionTypeDegraded:    ConditionFalse,
 				controller.ConditionTypeAvailable:   ConditionTrue,
 				controller.ConditionTypeStopped:     ConditionFalse,
+				ConditionTypeDeleting:    ConditionFalse,
 			})
 		})
 
@@ -160,6 +161,7 @@ var _ = Describe("Workspace Template", Ordered, func() {
 				controller.ConditionTypeDegraded:    ConditionFalse,
 				controller.ConditionTypeAvailable:   ConditionTrue,
 				controller.ConditionTypeStopped:     ConditionFalse,
+				ConditionTypeDeleting:    ConditionFalse,
 			})
 		})
 
@@ -521,6 +523,7 @@ var _ = Describe("Workspace Template", Ordered, func() {
 				controller.ConditionTypeDegraded:    ConditionFalse,
 				controller.ConditionTypeAvailable:   ConditionTrue,
 				controller.ConditionTypeStopped:     ConditionFalse,
+				ConditionTypeDeleting:    ConditionFalse,
 			})
 
 			By("verifying templateRef was changed")


### PR DESCRIPTION
## Summary

- Add `ConditionTypeDeleting` and `ReasonDeletionInProgress` constants to `conditions.go`
- Rewrite `UpdateDeletingStatus` to set all 5 conditions coherently (matching the pattern used by `UpdateRunningStatus`, `UpdateStoppedStatus`, etc.)
- Remove direct `meta.SetStatusCondition` usage which only appended `Deleting=True` without clearing `Available=True`

## Problem

When deleting a workspace, the controller set `Deleting=True` via `meta.SetStatusCondition` without touching other conditions. This left `Available=True` alongside `Deleting=True`, causing the UI to display both "Running" and "Deleting" simultaneously.

## Fix

`UpdateDeletingStatus` now follows the same pattern as other status methods — explicitly sets all conditions with appropriate reasons:
- `Available=False` (reason: DeletionInProgress)
- `Progressing=False` (reason: DeletionInProgress)
- `Degraded=False` (reason: NoError)
- `Stopped=False` (reason: DeletionInProgress)
- `Deleting=True` (reason: DeletionInProgress)

## Test plan

- [x] Deploy updated controller to EKS cluster
- [x] Create workspace, wait for Running, delete it
- [x] Verify `kubectl get workspace <name> -o json` shows coherent conditions (Available=False, Deleting=True)
- [x] Verify UI shows "Deleting" status (not "Running")