### PR TITLE
feat: add integration strategy template resolution engine

### DIFF
--- a/internal/controller/integration_resolver.go
+++ b/internal/controller/integration_resolver.go
@@ -1,0 +1,216 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package controller
+
+import (
+	"bytes"
+	"fmt"
+	"text/template"
+
+	workspacev1alpha1 "github.com/jupyter-infra/jupyter-k8s/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/util/jsonpath"
+)
+
+// IntegrationTemplateData provides the context for Go text/template resolution.
+type IntegrationTemplateData struct {
+	Workspace  IntegrationWorkspaceData
+	Parameters map[string]string
+}
+
+// IntegrationWorkspaceData holds workspace identity fields available in templates.
+type IntegrationWorkspaceData struct {
+	Name      string
+	Namespace string
+}
+
+// IntegrationResolver resolves template expressions in WorkspaceIntegrationStrategy fields.
+type IntegrationResolver struct{}
+
+// NewIntegrationResolver creates a new resolver.
+func NewIntegrationResolver() *IntegrationResolver {
+	return &IntegrationResolver{}
+}
+
+// ResolveField resolves all template expressions in a single string field in one pass.
+//
+// Two kinds of template expression are supported, both as ordinary Go text/template
+// constructs:
+//   - {{ .Workspace.Name }}, {{ .Workspace.Namespace }}, {{ .Parameters.X }} — workspace
+//     metadata and user-supplied parameters
+//   - {{ resource "{jsonpath}" }} — a value read from the fetched lookup resource via
+//     JSONPath. This is registered as a template function (like b32encode in the access
+//     strategy renderer), so the JSONPath string — including [N] indexing — is passed
+//     through untouched as a quoted function argument.
+//
+// Returns an error if: the template syntax is invalid, a referenced parameter key is
+// missing, a {{ resource }} expression is used without a fetched resource, the JSONPath
+// is invalid, or the JSONPath evaluates to an empty string.
+func (r *IntegrationResolver) ResolveField(field string, data IntegrationTemplateData, resource *unstructured.Unstructured) (string, error) {
+	tmpl, err := template.New("field").
+		Option("missingkey=error").
+		Funcs(template.FuncMap{
+			"resource": func(jsonPath string) (string, error) {
+				if resource == nil {
+					return "", fmt.Errorf("resource template %q used but no resource available (resourceLookup not defined or resource not fetched)", jsonPath)
+				}
+				return evaluateJSONPathExpression(resource, jsonPath)
+			},
+		}).
+		Parse(field)
+	if err != nil {
+		return "", fmt.Errorf("invalid template syntax %q: %w", field, err)
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return "", fmt.Errorf("template execution failed %q: %w", field, err)
+	}
+
+	return buf.String(), nil
+}
+
+// ResolveResourceLookup resolves template expressions in resourceLookup name/namespace fields
+// and validates they don't resolve to empty strings.
+func (r *IntegrationResolver) ResolveResourceLookup(lookup *workspacev1alpha1.ResourceLookup, data IntegrationTemplateData) (resolvedName, resolvedNamespace string, err error) {
+	if lookup == nil {
+		return "", "", fmt.Errorf("resourceLookup is nil")
+	}
+
+	resolvedName, err = r.ResolveField(lookup.Name, data, nil)
+	if err != nil {
+		return "", "", fmt.Errorf("resourceLookup name template: %w", err)
+	}
+	if resolvedName == "" {
+		return "", "", fmt.Errorf("resourceLookup name resolved to empty string (template: %q)", lookup.Name)
+	}
+
+	resolvedNamespace, err = r.ResolveField(lookup.Namespace, data, nil)
+	if err != nil {
+		return "", "", fmt.Errorf("resourceLookup namespace template: %w", err)
+	}
+	if resolvedNamespace == "" {
+		return "", "", fmt.Errorf("resourceLookup namespace resolved to empty string (template: %q)", lookup.Namespace)
+	}
+
+	return resolvedName, resolvedNamespace, nil
+}
+
+// ResolvePodModifications resolves all template expressions across all string fields
+// in the pod modifications. Fields to resolve in each container: image, command[], args[], env[].value.
+// Also resolves mergeEnv[].valueTemplate in primaryContainerModifications.
+// Deep-copies the input before mutating so the original CR data is not modified.
+func (r *IntegrationResolver) ResolvePodModifications(
+	mods *workspacev1alpha1.PodModifications,
+	data IntegrationTemplateData,
+	resource *unstructured.Unstructured,
+) (*workspacev1alpha1.PodModifications, error) {
+	if mods == nil {
+		return nil, nil
+	}
+
+	// Deep copy to avoid mutating the original CR data
+	resolved := mods.DeepCopy()
+
+	// Resolve additional containers
+	for i := range resolved.AdditionalContainers {
+		if err := r.resolveContainerFields(&resolved.AdditionalContainers[i], data, resource); err != nil {
+			return nil, fmt.Errorf("additionalContainers[%d] (container %q): %w",
+				i, resolved.AdditionalContainers[i].Name, err)
+		}
+	}
+
+	// Resolve init containers
+	for i := range resolved.InitContainers {
+		if err := r.resolveContainerFields(&resolved.InitContainers[i], data, resource); err != nil {
+			return nil, fmt.Errorf("initContainers[%d] (container %q): %w",
+				i, resolved.InitContainers[i].Name, err)
+		}
+	}
+
+	// Resolve primaryContainerModifications
+	if resolved.PrimaryContainerModifications != nil {
+		for i := range resolved.PrimaryContainerModifications.MergeEnv {
+			env := &resolved.PrimaryContainerModifications.MergeEnv[i]
+			val, err := r.ResolveField(env.ValueTemplate, data, resource)
+			if err != nil {
+				return nil, fmt.Errorf("primaryContainerModifications mergeEnv %q valueTemplate: %w", env.Name, err)
+			}
+			env.ValueTemplate = val
+		}
+	}
+
+	return resolved, nil
+}
+
+// resolveContainerFields resolves template expressions in a container's string fields:
+// image, command[], args[], env[].value.
+func (r *IntegrationResolver) resolveContainerFields(
+	container *corev1.Container,
+	data IntegrationTemplateData,
+	resource *unstructured.Unstructured,
+) error {
+	// Resolve image
+	if container.Image != "" {
+		val, err := r.ResolveField(container.Image, data, resource)
+		if err != nil {
+			return fmt.Errorf("image field: %w", err)
+		}
+		container.Image = val
+	}
+
+	// Resolve command
+	for i, cmd := range container.Command {
+		val, err := r.ResolveField(cmd, data, resource)
+		if err != nil {
+			return fmt.Errorf("command[%d]: %w", i, err)
+		}
+		container.Command[i] = val
+	}
+
+	// Resolve args
+	for i, arg := range container.Args {
+		val, err := r.ResolveField(arg, data, resource)
+		if err != nil {
+			return fmt.Errorf("args[%d]: %w", i, err)
+		}
+		container.Args[i] = val
+	}
+
+	// Resolve env values
+	for i := range container.Env {
+		if container.Env[i].Value != "" {
+			val, err := r.ResolveField(container.Env[i].Value, data, resource)
+			if err != nil {
+				return fmt.Errorf("env %q value: %w", container.Env[i].Name, err)
+			}
+			container.Env[i].Value = val
+		}
+	}
+
+	return nil
+}
+
+// evaluateJSONPathExpression evaluates a JSONPath expression against an unstructured resource.
+func evaluateJSONPathExpression(obj *unstructured.Unstructured, expression string) (string, error) {
+	jp := jsonpath.New("fieldPath")
+	if err := jp.Parse(expression); err != nil {
+		return "", fmt.Errorf("invalid JSONPath %q: %w", expression, err)
+	}
+
+	var buf bytes.Buffer
+	if err := jp.Execute(&buf, obj.Object); err != nil {
+		return "", fmt.Errorf("JSONPath %q evaluation failed: %w", expression, err)
+	}
+
+	result := buf.String()
+	if result == "" {
+		return "", fmt.Errorf("JSONPath %q returned empty result", expression)
+	}
+
+	return result, nil
+}

--- a/internal/controller/integration_resolver_test.go
+++ b/internal/controller/integration_resolver_test.go
@@ -1,0 +1,332 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package controller
+
+import (
+	"testing"
+
+	workspacev1alpha1 "github.com/jupyter-infra/jupyter-k8s/api/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// Shared integration strategy test constants. Declared here (the first integration
+// test file) and referenced by the other integration test files in this package.
+const (
+	testParamClusterName = "clusterName"
+	testKindRayCluster   = "RayCluster"
+	testEnvRayAddress    = "RAY_ADDRESS"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func testResource() *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"headGroupSpec": map[string]interface{}{
+					"template": map[string]interface{}{
+						"spec": map[string]interface{}{
+							"containers": []interface{}{
+								map[string]interface{}{
+									"image": "rayproject/ray:2.9.0",
+								},
+							},
+						},
+					},
+				},
+			},
+			"status": map[string]interface{}{
+				"head": map[string]interface{}{
+					"serviceName": "my-cluster-head-svc",
+				},
+			},
+		},
+	}
+}
+
+func testTemplateData() IntegrationTemplateData {
+	return IntegrationTemplateData{
+		Workspace: IntegrationWorkspaceData{
+			Name:      "my-workspace",
+			Namespace: "user-ns",
+		},
+		Parameters: map[string]string{
+			testParamClusterName: "my-ray-cluster",
+			"region":             "us-west-2",
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ResolveField — table-driven
+// ---------------------------------------------------------------------------
+
+func TestResolveField(t *testing.T) {
+	resolver := NewIntegrationResolver()
+	resource := testResource()
+	data := testTemplateData()
+
+	tests := []struct {
+		name        string
+		field       string
+		data        IntegrationTemplateData
+		resource    *unstructured.Unstructured
+		expected    string
+		expectError bool
+		errorSubstr string
+	}{
+		// Identity / pass-through
+		{
+			name:     "plain string (no expressions)",
+			field:    "plain-string-no-templates",
+			data:     data,
+			resource: resource,
+			expected: "plain-string-no-templates",
+		},
+		{
+			name:     "empty string",
+			field:    "",
+			data:     data,
+			resource: resource,
+			expected: "",
+		},
+		{
+			name:     "string with special chars but no expressions",
+			field:    "127.0.0.1:6379/path?q=1",
+			data:     data,
+			resource: resource,
+			expected: "127.0.0.1:6379/path?q=1",
+		},
+		// Workspace expressions
+		{
+			name:     "workspace name substitution",
+			field:    "workspace-{{ .Workspace.Name }}",
+			data:     data,
+			resource: resource,
+			expected: "workspace-my-workspace",
+		},
+		{
+			name:     "workspace namespace substitution",
+			field:    "ns={{ .Workspace.Namespace }}",
+			data:     data,
+			resource: resource,
+			expected: "ns=user-ns",
+		},
+		// Parameter expressions
+		{
+			name:     "single parameter",
+			field:    "cluster-{{ .Parameters.clusterName }}",
+			data:     data,
+			resource: resource,
+			expected: "cluster-my-ray-cluster",
+		},
+		{
+			name:     "multiple parameters",
+			field:    "{{ .Parameters.clusterName }}-{{ .Parameters.region }}",
+			data:     data,
+			resource: resource,
+			expected: "my-ray-cluster-us-west-2",
+		},
+		// Resource expressions
+		{
+			name:     "resource JSONPath — image",
+			field:    `{{ resource "{.spec.headGroupSpec.template.spec.containers[0].image}" }}`,
+			data:     data,
+			resource: resource,
+			expected: "rayproject/ray:2.9.0",
+		},
+		{
+			name:     "resource JSONPath — service name",
+			field:    `svc={{ resource "{.status.head.serviceName}" }}`,
+			data:     data,
+			resource: resource,
+			expected: "svc=my-cluster-head-svc",
+		},
+		// Mixed (all expression types resolved in a single pass)
+		{
+			name:     "all three expression types in one field",
+			field:    `{{ .Workspace.Name }}-{{ .Parameters.clusterName }}-{{ resource "{.status.head.serviceName}" }}`,
+			data:     data,
+			resource: resource,
+			expected: "my-workspace-my-ray-cluster-my-cluster-head-svc",
+		},
+		{
+			name:     "resource expression between workspace expressions",
+			field:    `{{ .Workspace.Namespace }}/{{ resource "{.spec.headGroupSpec.template.spec.containers[0].image}" }}/end`,
+			data:     data,
+			resource: resource,
+			expected: "user-ns/rayproject/ray:2.9.0/end",
+		},
+		// Error cases
+		{
+			name:        "resource expression without resource object",
+			field:       `svc={{ resource "{.status.head.serviceName}" }}`,
+			data:        data,
+			resource:    nil,
+			expectError: true,
+			errorSubstr: "no resource available",
+		},
+		{
+			name:        "nonexistent JSONPath",
+			field:       `{{ resource "{.status.nonExistent}" }}`,
+			data:        data,
+			resource:    resource,
+			expectError: true,
+			errorSubstr: "nonExistent",
+		},
+		{
+			name:        "missing parameter key",
+			field:       `{{ .Parameters.doesNotExist }}`,
+			data:        data,
+			resource:    resource,
+			expectError: true,
+		},
+		{
+			name:        "invalid expression syntax",
+			field:       "{{ .Workspace.Name }",
+			data:        data,
+			resource:    resource,
+			expectError: true,
+			errorSubstr: "invalid template syntax",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := resolver.ResolveField(tt.field, tt.data, tt.resource)
+			if tt.expectError {
+				require.Error(t, err)
+				if tt.errorSubstr != "" {
+					assert.Contains(t, err.Error(), tt.errorSubstr)
+				}
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ResolveResourceLookup
+// ---------------------------------------------------------------------------
+
+func TestResolveResourceLookup(t *testing.T) {
+	resolver := NewIntegrationResolver()
+	data := testTemplateData()
+
+	tests := []struct {
+		name              string
+		lookup            *workspacev1alpha1.ResourceLookup
+		expectedName      string
+		expectedNamespace string
+		expectError       bool
+		errorSubstr       string
+	}{
+		{
+			name: "resolves name and namespace from expressions",
+			lookup: &workspacev1alpha1.ResourceLookup{
+				APIVersion: "ray.io/v1",
+				Kind:       testKindRayCluster,
+				Name:       "{{ .Parameters.clusterName }}",
+				Namespace:  "{{ .Workspace.Namespace }}",
+			},
+			expectedName:      "my-ray-cluster",
+			expectedNamespace: "user-ns",
+		},
+		{
+			name: "missing parameter in name → error",
+			lookup: &workspacev1alpha1.ResourceLookup{
+				APIVersion: "ray.io/v1",
+				Kind:       testKindRayCluster,
+				Name:       "{{ .Parameters.nonexistent }}",
+				Namespace:  "{{ .Workspace.Namespace }}",
+			},
+			expectError: true,
+			errorSubstr: "resourceLookup name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			name, namespace, err := resolver.ResolveResourceLookup(tt.lookup, data)
+			if tt.expectError {
+				require.Error(t, err)
+				if tt.errorSubstr != "" {
+					assert.Contains(t, err.Error(), tt.errorSubstr)
+				}
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedName, name)
+				assert.Equal(t, tt.expectedNamespace, namespace)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ResolvePodModifications
+// ---------------------------------------------------------------------------
+
+func TestResolvePodModifications(t *testing.T) {
+	resolver := NewIntegrationResolver()
+	resource := testResource()
+	data := testTemplateData()
+
+	t.Run("resolves container image, args, and env", func(t *testing.T) {
+		mods := &workspacev1alpha1.PodModifications{
+			AdditionalContainers: []corev1.Container{
+				{
+					Name:  "sidecar",
+					Image: `{{ resource "{.spec.headGroupSpec.template.spec.containers[0].image}" }}`,
+					Args:  []string{`ray start --address={{ resource "{.status.head.serviceName}" }}:6379`},
+					Env:   []corev1.EnvVar{{Name: "CLUSTER_NAME", Value: "{{ .Parameters.clusterName }}"}},
+				},
+			},
+			PrimaryContainerModifications: &workspacev1alpha1.PrimaryContainerModifications{
+				MergeEnv: []workspacev1alpha1.AccessEnvTemplate{
+					{Name: testEnvRayAddress, ValueTemplate: `{{ resource "{.status.head.serviceName}" }}:10001`},
+				},
+			},
+		}
+
+		resolved, err := resolver.ResolvePodModifications(mods, data, resource)
+		require.NoError(t, err)
+		require.NotNil(t, resolved)
+
+		container := resolved.AdditionalContainers[0]
+		assert.Equal(t, "rayproject/ray:2.9.0", container.Image)
+		assert.Equal(t, "ray start --address=my-cluster-head-svc:6379", container.Args[0])
+		assert.Equal(t, "my-ray-cluster", container.Env[0].Value)
+
+		assert.Equal(t, "my-cluster-head-svc:10001",
+			resolved.PrimaryContainerModifications.MergeEnv[0].ValueTemplate)
+	})
+
+	t.Run("nil input returns nil", func(t *testing.T) {
+		resolved, err := resolver.ResolvePodModifications(nil, data, resource)
+		require.NoError(t, err)
+		assert.Nil(t, resolved)
+	})
+
+	t.Run("does not mutate original input", func(t *testing.T) {
+		originalImage := `{{ resource "{.spec.headGroupSpec.template.spec.containers[0].image}" }}`
+		mods := &workspacev1alpha1.PodModifications{
+			AdditionalContainers: []corev1.Container{{Name: "sidecar", Image: originalImage}},
+		}
+
+		resolved, err := resolver.ResolvePodModifications(mods, data, resource)
+		require.NoError(t, err)
+		assert.Equal(t, "rayproject/ray:2.9.0", resolved.AdditionalContainers[0].Image)
+		assert.Equal(t, originalImage, mods.AdditionalContainers[0].Image,
+			"original input must not be mutated")
+	})
+}


### PR DESCRIPTION
## What

Adds the `IntegrationResolver`: a two-pass template resolution engine for
`WorkspaceIntegrationStrategy` fields. Supports:

- `{{ .Workspace.* }}` and `{{ .Parameters.* }}` — workspace metadata and
  user-supplied parameters
- `{{ resource "{jsonpath}" }}` — values read from the looked-up resource via
  JSONPath

Includes unit tests covering field resolution, resource-lookup resolution, and
pod-modification resolution.

## Scope

Resolver logic + tests only.

## Dependencies

Depends on the API PR (#405) — uses `workspacev1alpha1.ResourceLookup`. **CI will
be red until #405 merges**; I'll rebase and push a new revision then.

## Testing

- `go test ./internal/controller/ -run TestResolve`
