### PR TITLE
feat: watch and propagate integration strategy changes to workspaces

### DIFF
--- a/internal/controller/workspace_controller.go
+++ b/internal/controller/workspace_controller.go
@@ -202,6 +202,39 @@ func (r *WorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 	}
 
+	// Handle IntegrationStrategy labels
+	if workspace.Spec.IntegrationStrategy != nil && workspace.Spec.IntegrationStrategy.Name != "" {
+		// IntegrationStrategy is referenced - ensure both labels are set
+		integrationStrategyName := workspace.Spec.IntegrationStrategy.Name
+		integrationStrategyNamespace := workspace.Namespace
+		if workspace.Spec.IntegrationStrategy.Namespace != "" {
+			integrationStrategyNamespace = workspace.Spec.IntegrationStrategy.Namespace
+		}
+
+		if workspace.Labels[LabelIntegrationStrategyName] != integrationStrategyName {
+			workspace.Labels[LabelIntegrationStrategyName] = integrationStrategyName
+			labelsChanged[LabelIntegrationStrategyName] = integrationStrategyName
+			needsUpdate = true
+		}
+		if workspace.Labels[LabelIntegrationStrategyNamespace] != integrationStrategyNamespace {
+			workspace.Labels[LabelIntegrationStrategyNamespace] = integrationStrategyNamespace
+			labelsChanged[LabelIntegrationStrategyNamespace] = integrationStrategyNamespace
+			needsUpdate = true
+		}
+	} else {
+		// IntegrationStrategy is not referenced - ensure labels are removed
+		if _, hasLabel := workspace.Labels[LabelIntegrationStrategyName]; hasLabel {
+			delete(workspace.Labels, LabelIntegrationStrategyName)
+			labelsRemoved = append(labelsRemoved, LabelIntegrationStrategyName)
+			needsUpdate = true
+		}
+		if _, hasNamespaceLabel := workspace.Labels[LabelIntegrationStrategyNamespace]; hasNamespaceLabel {
+			delete(workspace.Labels, LabelIntegrationStrategyNamespace)
+			labelsRemoved = append(labelsRemoved, LabelIntegrationStrategyNamespace)
+			needsUpdate = true
+		}
+	}
+
 	// Perform a single update if any labels or finalizer have changed
 	if needsUpdate {
 		logger.Info("Updating workspace labels",
@@ -251,6 +284,13 @@ func (r *WorkspaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	builder.Watches(
 		&workspacev1alpha1.WorkspaceAccessStrategy{},
 		handler.EnqueueRequestsFromMapFunc(r.accessStrategyEventHandler),
+	)
+
+	// Watch for changes to IntegrationStrategy resources to trigger reconciliation
+	// of Workspaces that reference them
+	builder.Watches(
+		&workspacev1alpha1.WorkspaceIntegrationStrategy{},
+		handler.EnqueueRequestsFromMapFunc(r.integrationStrategyEventHandler),
 	)
 
 	// Conditionally watch pods based on configuration
@@ -409,6 +449,43 @@ func (r *WorkspaceReconciler) accessStrategyEventHandler(ctx context.Context, ob
 		logger.Info("Found no active workspace referencing access strategy",
 			"accessStrategy", accessStrategy.Name,
 			"namespace", accessStrategy.Namespace)
+	}
+
+	return requests
+}
+
+// integrationStrategyEventHandler maps IntegrationStrategy events to Workspace reconciliation requests
+func (r *WorkspaceReconciler) integrationStrategyEventHandler(ctx context.Context, obj client.Object) []reconcile.Request {
+	logger := logf.FromContext(ctx)
+	integrationStrategy, ok := obj.(*workspacev1alpha1.WorkspaceIntegrationStrategy)
+	if !ok {
+		// Not an IntegrationStrategy
+		return nil
+	}
+
+	logger.Info("Handling IntegrationStrategy event",
+		"integrationStrategy", integrationStrategy.Name,
+		"namespace", integrationStrategy.Namespace)
+
+	requests, listErr := workspaceutil.GetWorkspaceReconciliationRequestsForIntegrationStrategy(
+		ctx,
+		r.Client,
+		integrationStrategy.Name,
+		integrationStrategy.Namespace)
+	if listErr != nil {
+		logger.Error(
+			listErr,
+			"Failed to list Workspaces associated with integration strategy",
+			"integrationStrategy", integrationStrategy.Name,
+			"namespace", integrationStrategy.Namespace)
+		return nil
+	}
+
+	if len(requests) > 0 {
+		logger.Info("Found active workspaces referencing integration strategy",
+			"integrationStrategy", integrationStrategy.Name,
+			"namespace", integrationStrategy.Namespace,
+			"workspaceCount", len(requests))
 	}
 
 	return requests

--- a/internal/workspace/constants.go
+++ b/internal/workspace/constants.go
@@ -21,6 +21,12 @@ const (
 	// LabelAccessStrategyNamespace is the label key for access strategy namespace in the Workspace labels
 	LabelAccessStrategyNamespace = "workspace.jupyter.org/access-strategy-namespace"
 
+	// LabelIntegrationStrategyName is the label key for integration strategy name in the Workspace labels
+	LabelIntegrationStrategyName = "workspace.jupyter.org/integration-strategy-name"
+
+	// LabelIntegrationStrategyNamespace is the label key for integration strategy namespace in the Workspace labels
+	LabelIntegrationStrategyNamespace = "workspace.jupyter.org/integration-strategy-namespace"
+
 	// TemplateFinalizerName is the name of the finalizer placed on a template that is referenced by workspaces
 	TemplateFinalizerName = "workspace.jupyter.org/template-protection"
 

--- a/internal/workspace/integration_queries.go
+++ b/internal/workspace/integration_queries.go
@@ -1,0 +1,111 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package workspace
+
+import (
+	"context"
+	"fmt"
+
+	workspacev1alpha1 "github.com/jupyter-infra/jupyter-k8s/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// GetIntegrationStrategyRefNamespace returns the namespace for a workspace's integration
+// strategy reference, defaulting to the workspace's namespace if not specified.
+func GetIntegrationStrategyRefNamespace(ws *workspacev1alpha1.Workspace) string {
+	if ws.Spec.IntegrationStrategy == nil || ws.Spec.IntegrationStrategy.Namespace == "" {
+		return ws.Namespace
+	}
+	return ws.Spec.IntegrationStrategy.Namespace
+}
+
+// ListActiveWorkspacesByIntegrationStrategy returns all active (non-deleted) workspaces using
+// the specified WorkspaceIntegrationStrategy. Reads from the controller-runtime informer cache
+// and validates the IntegrationStrategy reference matches the label to guard against drift.
+func ListActiveWorkspacesByIntegrationStrategy(
+	ctx context.Context,
+	k8sClient client.Client,
+	integrationStrategyName string,
+	integrationStrategyNamespace string) ([]workspacev1alpha1.Workspace, error) {
+	logger := logf.FromContext(ctx)
+
+	workspaceList := &workspacev1alpha1.WorkspaceList{}
+
+	labels := map[string]string{
+		LabelIntegrationStrategyName:      integrationStrategyName,
+		LabelIntegrationStrategyNamespace: integrationStrategyNamespace,
+	}
+
+	if err := k8sClient.List(ctx, workspaceList, client.MatchingLabels(labels)); err != nil {
+		return nil, fmt.Errorf("failed to list workspaces by IntegrationStrategy label: %w", err)
+	}
+
+	activeWorkspaces := []workspacev1alpha1.Workspace{}
+	for _, ws := range workspaceList.Items {
+		if !ws.DeletionTimestamp.IsZero() {
+			continue // Skip workspaces being deleted
+		}
+
+		// Verify the IntegrationStrategy reference matches the label to guard against drift
+		if ws.Spec.IntegrationStrategy == nil {
+			logger.Info("Workspace has IntegrationStrategy label but nil reference - data integrity issue",
+				"workspace", ws.Name,
+				"workspaceNamespace", ws.Namespace,
+				"label", integrationStrategyName)
+			continue
+		}
+
+		if ws.Spec.IntegrationStrategy.Name != integrationStrategyName {
+			logger.Info("Workspace has IntegrationStrategy label but different name",
+				"workspace", ws.Name,
+				"workspaceNamespace", ws.Namespace,
+				"label", integrationStrategyName,
+				"spec", ws.Spec.IntegrationStrategy.Name)
+			continue
+		}
+
+		if integrationStrategyNamespace != "" {
+			actualNamespace := GetIntegrationStrategyRefNamespace(&ws)
+			if actualNamespace != integrationStrategyNamespace {
+				continue
+			}
+		}
+
+		activeWorkspaces = append(activeWorkspaces, ws)
+	}
+
+	return activeWorkspaces, nil
+}
+
+// GetWorkspaceReconciliationRequestsForIntegrationStrategy retrieves all active workspaces
+// using the specified IntegrationStrategy and returns them as reconcile requests.
+func GetWorkspaceReconciliationRequestsForIntegrationStrategy(
+	ctx context.Context,
+	k8sClient client.Client,
+	integrationStrategyName string,
+	integrationStrategyNamespace string) ([]reconcile.Request, error) {
+
+	workspaces, err := ListActiveWorkspacesByIntegrationStrategy(
+		ctx, k8sClient, integrationStrategyName, integrationStrategyNamespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list workspaces by integration strategy: %w", err)
+	}
+
+	allRequests := []reconcile.Request{}
+	for _, ws := range workspaces {
+		allRequests = append(allRequests, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      ws.Name,
+				Namespace: ws.Namespace,
+			},
+		})
+	}
+
+	return allRequests, nil
+}

--- a/internal/workspace/integration_queries_test.go
+++ b/internal/workspace/integration_queries_test.go
@@ -1,0 +1,215 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package workspace
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	workspacev1alpha1 "github.com/jupyter-infra/jupyter-k8s/api/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestGetIntegrationStrategyRefNamespace(t *testing.T) {
+	t.Run("returns workspace namespace when no integration strategy", func(t *testing.T) {
+		ws := &workspacev1alpha1.Workspace{
+			ObjectMeta: metav1.ObjectMeta{Name: "ws", Namespace: "ws-ns"},
+		}
+		assert.Equal(t, "ws-ns", GetIntegrationStrategyRefNamespace(ws))
+	})
+
+	t.Run("returns workspace namespace when ref namespace empty", func(t *testing.T) {
+		ws := &workspacev1alpha1.Workspace{
+			ObjectMeta: metav1.ObjectMeta{Name: "ws", Namespace: "ws-ns"},
+			Spec: workspacev1alpha1.WorkspaceSpec{
+				IntegrationStrategy: &workspacev1alpha1.IntegrationStrategyRef{Name: "strat"},
+			},
+		}
+		assert.Equal(t, "ws-ns", GetIntegrationStrategyRefNamespace(ws))
+	})
+
+	t.Run("returns ref namespace when set", func(t *testing.T) {
+		ws := &workspacev1alpha1.Workspace{
+			ObjectMeta: metav1.ObjectMeta{Name: "ws", Namespace: "ws-ns"},
+			Spec: workspacev1alpha1.WorkspaceSpec{
+				IntegrationStrategy: &workspacev1alpha1.IntegrationStrategyRef{
+					Name:      "strat",
+					Namespace: "strat-ns",
+				},
+			},
+		}
+		assert.Equal(t, "strat-ns", GetIntegrationStrategyRefNamespace(ws))
+	})
+}
+
+func TestListActiveWorkspacesByIntegrationStrategy_CallsListWithMatchLabels_ReturnWorkspaces(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = workspacev1alpha1.AddToScheme(scheme)
+
+	newWS := func(name, namespace string) *workspacev1alpha1.Workspace {
+		return &workspacev1alpha1.Workspace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+				Labels: map[string]string{
+					LabelIntegrationStrategyName:      "test-integration-strategy",
+					LabelIntegrationStrategyNamespace: "integration-strategy-namespace",
+				},
+			},
+			Spec: workspacev1alpha1.WorkspaceSpec{
+				IntegrationStrategy: &workspacev1alpha1.IntegrationStrategyRef{
+					Name:      "test-integration-strategy",
+					Namespace: "integration-strategy-namespace",
+				},
+			},
+		}
+	}
+
+	ws1 := newWS("test-workspace-1", "default")
+	ws2 := newWS("test-workspace-2", "default")
+
+	// A deleted workspace that should be skipped.
+	deletionTime := metav1.Now()
+	wsDeleted := newWS("test-workspace-deleted", "default")
+	wsDeleted.DeletionTimestamp = &deletionTime
+	wsDeleted.Finalizers = []string{"test-finalizer"}
+
+	// A workspace carrying the label but with a drifted spec reference - should be skipped.
+	wsDrift := newWS("test-workspace-drift", "default")
+	wsDrift.Spec.IntegrationStrategy.Name = "some-other-strategy"
+
+	// MockClient captures the list options to verify label filtering.
+	mockClient := &MockClient{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(ws1, ws2, wsDeleted, wsDrift).Build(),
+	}
+
+	_, err := ListActiveWorkspacesByIntegrationStrategy(
+		context.Background(),
+		mockClient,
+		"test-integration-strategy",
+		"integration-strategy-namespace")
+	assert.NoError(t, err)
+
+	assert.NotEmpty(t, mockClient.ListOptions, "List options should not be empty")
+	labels := make(map[string]string)
+	for _, opt := range mockClient.ListOptions {
+		optString := fmt.Sprintf("%v", opt)
+		if matches := getLabelsFromOption(optString); len(matches) > 0 {
+			for k, v := range matches {
+				labels[k] = v
+			}
+		}
+	}
+	assert.Equal(t, "test-integration-strategy", labels[LabelIntegrationStrategyName],
+		"Should filter by integration strategy name")
+	assert.Equal(t, "integration-strategy-namespace", labels[LabelIntegrationStrategyNamespace],
+		"Should filter by integration strategy namespace")
+
+	// Real client: verify filtering of deleted and drifted workspaces.
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ws1, ws2, wsDeleted, wsDrift).Build()
+	workspaces, err := ListActiveWorkspacesByIntegrationStrategy(
+		context.Background(),
+		fakeClient,
+		"test-integration-strategy",
+		"integration-strategy-namespace")
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(workspaces), "Expected 2 active, matching workspaces")
+
+	names := make(map[string]bool)
+	for _, ws := range workspaces {
+		names[ws.Name] = true
+	}
+	assert.True(t, names["test-workspace-1"])
+	assert.True(t, names["test-workspace-2"])
+	assert.False(t, names["test-workspace-deleted"], "Deleted workspace should be skipped")
+	assert.False(t, names["test-workspace-drift"], "Drifted workspace should be skipped")
+}
+
+func TestListActiveWorkspacesByIntegrationStrategy_OnListError_ReturnErrors(t *testing.T) {
+	mockClient := &MockClient{
+		ListError: fmt.Errorf("mock list error"),
+	}
+
+	workspaces, err := ListActiveWorkspacesByIntegrationStrategy(
+		context.Background(),
+		mockClient,
+		"test-integration-strategy",
+		"integration-strategy-namespace")
+
+	assert.Error(t, err)
+	assert.Nil(t, workspaces)
+	assert.Contains(t, err.Error(), "failed to list workspaces by IntegrationStrategy label: mock list error")
+}
+
+func TestGetWorkspaceReconciliationRequestsForIntegrationStrategy_ReturnRequests(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = workspacev1alpha1.AddToScheme(scheme)
+
+	newWS := func(name, namespace string) *workspacev1alpha1.Workspace {
+		return &workspacev1alpha1.Workspace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+				Labels: map[string]string{
+					LabelIntegrationStrategyName:      "test-integration-strategy",
+					LabelIntegrationStrategyNamespace: "integration-strategy-namespace",
+				},
+			},
+			Spec: workspacev1alpha1.WorkspaceSpec{
+				IntegrationStrategy: &workspacev1alpha1.IntegrationStrategyRef{
+					Name:      "test-integration-strategy",
+					Namespace: "integration-strategy-namespace",
+				},
+			},
+		}
+	}
+
+	ws1 := newWS("test-workspace-1", "default")
+	ws2 := newWS("test-workspace-2", "another-namespace")
+
+	deletionTime := metav1.Now()
+	wsDeleted := newWS("test-workspace-deleted", "default")
+	wsDeleted.DeletionTimestamp = &deletionTime
+	wsDeleted.Finalizers = []string{"test-finalizer"}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ws1, ws2, wsDeleted).Build()
+
+	requests, err := GetWorkspaceReconciliationRequestsForIntegrationStrategy(
+		context.Background(),
+		fakeClient,
+		"test-integration-strategy",
+		"integration-strategy-namespace")
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(requests), "Expected 2 reconciliation requests")
+
+	found := make(map[string]bool)
+	for _, req := range requests {
+		found[req.Namespace+"/"+req.Name] = true
+	}
+	assert.True(t, found["default/test-workspace-1"])
+	assert.True(t, found["another-namespace/test-workspace-2"])
+	assert.False(t, found["default/test-workspace-deleted"], "Deleted workspace should be skipped")
+}
+
+func TestGetWorkspaceReconciliationRequestsForIntegrationStrategy_OnListError_ReturnErrors(t *testing.T) {
+	mockClient := &MockClient{
+		ListError: fmt.Errorf("mock list error"),
+	}
+
+	requests, err := GetWorkspaceReconciliationRequestsForIntegrationStrategy(
+		context.Background(),
+		mockClient,
+		"test-integration-strategy",
+		"integration-strategy-namespace")
+
+	assert.Error(t, err)
+	assert.Nil(t, requests)
+	assert.Contains(t, err.Error(), "failed to list workspaces by integration strategy")
+}


### PR DESCRIPTION
## What

Adds the propagation half of the feature — keeping workspaces in sync when a
strategy changes:

- Workspace label sync in `Reconcile` (stamps/removes the
  integration-strategy-name/-namespace labels to match `Workspace.spec`)
- A watch on `WorkspaceIntegrationStrategy` + an event handler that maps a
  strategy change to reconcile requests for the workspaces referencing it
- `internal/workspace` reverse-lookup helpers
  (`ListActiveWorkspacesByIntegrationStrategy` /
  `GetWorkspaceReconciliationRequestsForIntegrationStrategy`) with
  deleted/drifted-workspace skip guards, mirroring the access-strategy queries
- Unit coverage for the query helpers

## Scope

The watch / propagation half of the controller.

## Dependencies

Depends on the API PR (#405) and apply PR (#407) — shares `workspace_controller.go`
and the label constants with apply. **CI will be red until those merge**; I'll
rebase and push a new revision then.

## Testing

- `go test ./internal/workspace/` (reverse-lookup query helpers)
- `make test` (controller suite)
