### PR TITLE
feat: add WorkspaceIntegration builder (admission-time freeze)

### DIFF
--- a/internal/controller/workspaceintegration_builder.go
+++ b/internal/controller/workspaceintegration_builder.go
@@ -1,0 +1,172 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	workspacev1alpha1 "github.com/jupyter-infra/jupyter-k8s/api/v1alpha1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// BuildWorkspaceIntegration resolves a WorkspaceIntegration against the live referenced resources
+// and its templateRef parameters, freezing the resolved output directly onto the WorkspaceIntegration's
+// own spec fields (DeploymentModifications, ShareProcessNamespace, StatusProbe) with all template
+// expressions substituted to literal values. This mirrors how a Workspace carries its resolved
+// WorkspaceTemplate values on its own spec fields -- no bespoke "resolved" envelope.
+//
+// It is the admission-time entry point for the WorkspaceIntegration mutating webhook: the webhook
+// calls it once at the WorkspaceIntegration's own admission (CREATE/UPDATE). The workspace controller
+// never calls this at reconcile time -- it only reads the already-resolved child.
+//
+// Resolution is fail-closed: any resourceRef that cannot be resolved or fetched, or any template
+// expression that resolves to empty (e.g. a not-yet-ready RayCluster whose .status.head.serviceName
+// is blank), returns an error so admission rejects the request and the prior good state is
+// preserved. On error the wi spec fields are left unchanged.
+//
+// The template's deploymentModifications keeps its native PodModifications shape (MergeEnv stays
+// []AccessEnvTemplate, its ValueTemplate now holding a literal); the statusProbe is frozen as-is
+// (it carries no template expressions today).
+func BuildWorkspaceIntegration(
+	ctx context.Context,
+	c client.Client,
+	wi *workspacev1alpha1.WorkspaceIntegration,
+	template *workspacev1alpha1.WorkspaceIntegrationTemplate,
+) error {
+	if wi == nil {
+		return fmt.Errorf("cannot build nil WorkspaceIntegration")
+	}
+	if template == nil {
+		return fmt.Errorf("cannot build WorkspaceIntegration %q from nil template", wi.Name)
+	}
+
+	// A WorkspaceIntegration is always co-located with its Workspace (cross-namespace references
+	// are unsupported). Reject a workspaceRef.namespace that names a different namespace rather
+	// than silently resolving against the wrong (or a nonexistent) workspace. Empty is allowed and
+	// defaults to the WI's own namespace below.
+	if ns := wi.Spec.WorkspaceRef.Namespace; ns != "" && ns != wi.Namespace {
+		return fmt.Errorf(
+			"WorkspaceIntegration %q: workspaceRef.namespace %q must match the object's own namespace %q "+
+				"(cross-namespace references are not supported)", wi.Name, ns, wi.Namespace)
+	}
+
+	// shareProcessNamespace is a static pod-level toggle on the template (no resolution needed);
+	// carry it through. A template value of false (or unset) is intentionally frozen as nil, not
+	// *false: the controller OR-reduces this flag across all of a workspace's integrations when
+	// applying, so nil and *false are semantically equivalent and an integration never needs to
+	// force the pod-level flag back off on its own.
+	var shareProcessNamespace *bool
+	if template.Spec.ShareProcessNamespace != nil && *template.Spec.ShareProcessNamespace {
+		enabled := true
+		shareProcessNamespace = &enabled
+	}
+
+	// Resolve the deploymentModifications (if any) before mutating wi, so a failure leaves the
+	// prior good spec untouched.
+	var deploymentMods *workspacev1alpha1.DeploymentModifications
+	if template.Spec.DeploymentModifications != nil &&
+		template.Spec.DeploymentModifications.PodModifications != nil {
+
+		// Build template data: workspace identity (from the WI's workspaceRef) + the templateRef's
+		// flattened parameters. The workspace namespace defaults to the WI's own namespace.
+		workspaceNamespace := wi.Spec.WorkspaceRef.Namespace
+		if workspaceNamespace == "" {
+			workspaceNamespace = wi.Namespace
+		}
+		tmplData := IntegrationTemplateData{
+			Workspace: IntegrationWorkspaceData{
+				Name:      wi.Spec.WorkspaceRef.Name,
+				Namespace: workspaceNamespace,
+			},
+			Parameters: wi.Spec.TemplateRef.ParametersMap(),
+		}
+
+		resolver := NewIntegrationTemplateResolver()
+
+		// Resolve+fetch each referenced resource into a map keyed by ref id so
+		// {{ resource "<id>" "<jsonpath>" }} expressions can address them.
+		resources, err := fetchReferencedResources(ctx, c, template, tmplData, resolver)
+		if err != nil {
+			return fmt.Errorf("integration template %q: %w", template.Name, err)
+		}
+
+		// Resolve all template expressions in the pod modifications into literals, keeping the
+		// native PodModifications shape (including MergeEnv []AccessEnvTemplate).
+		mods, err := resolver.ResolvePodModifications(
+			template.Spec.DeploymentModifications.PodModifications,
+			tmplData,
+			resources,
+		)
+		if err != nil {
+			return fmt.Errorf("integration template %q: failed to resolve pod modifications: %w", template.Name, err)
+		}
+		if mods != nil {
+			deploymentMods = &workspacev1alpha1.DeploymentModifications{PodModifications: mods}
+		}
+	}
+
+	// Commit the resolved output onto the wi spec. Assign every output field unconditionally so a
+	// re-build (e.g. switching clusters) never leaves a stale value from a prior resolution.
+	wi.Spec.ShareProcessNamespace = shareProcessNamespace
+	wi.Spec.StatusProbe = template.Spec.StatusProbe.DeepCopy()
+	wi.Spec.DeploymentModifications = deploymentMods
+
+	return nil
+}
+
+// fetchReferencedResources resolves every resourceRef's name/namespace templates and fetches each
+// target resource via the unstructured client, returning a map keyed by the ref id. Fail-closed:
+// any ref that cannot be resolved or fetched aborts the whole build (so admission rejects).
+func fetchReferencedResources(
+	ctx context.Context,
+	c client.Client,
+	template *workspacev1alpha1.WorkspaceIntegrationTemplate,
+	tmplData IntegrationTemplateData,
+	resolver *IntegrationTemplateResolver,
+) (map[string]*unstructured.Unstructured, error) {
+	resources := make(map[string]*unstructured.Unstructured, len(template.Spec.ResourceRefs))
+
+	for i := range template.Spec.ResourceRefs {
+		ref := &template.Spec.ResourceRefs[i]
+
+		// Default the namespace template to the workspace namespace when unset.
+		effectiveRef := *ref
+		if effectiveRef.Namespace == "" {
+			effectiveRef.Namespace = tmplData.Workspace.Namespace
+		}
+
+		resolvedName, resolvedNamespace, err := resolver.ResolveResourceRef(&effectiveRef, tmplData)
+		if err != nil {
+			return nil, err
+		}
+
+		gvk := schema.FromAPIVersionAndKind(ref.APIVersion, ref.Kind)
+		resource := &unstructured.Unstructured{}
+		resource.SetGroupVersionKind(gvk)
+
+		err = c.Get(ctx, client.ObjectKey{Name: resolvedName, Namespace: resolvedNamespace}, resource)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil, fmt.Errorf("resourceRef %q: %s %q not found in namespace %q",
+					ref.ID, ref.Kind, resolvedName, resolvedNamespace)
+			}
+			if apierrors.IsForbidden(err) {
+				return nil, fmt.Errorf("resourceRef %q: insufficient permissions to get %s %q in namespace %q: %w",
+					ref.ID, ref.Kind, resolvedName, resolvedNamespace, err)
+			}
+			return nil, fmt.Errorf("resourceRef %q: failed to get %s %q in namespace %q: %w",
+				ref.ID, ref.Kind, resolvedName, resolvedNamespace, err)
+		}
+
+		resources[ref.ID] = resource
+	}
+
+	return resources, nil
+}

--- a/internal/controller/workspaceintegration_builder_test.go
+++ b/internal/controller/workspaceintegration_builder_test.go
@@ -1,0 +1,349 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	workspacev1alpha1 "github.com/jupyter-infra/jupyter-k8s/api/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// newUnstructured builds a fetchable unstructured object for the fake client.
+func newUnstructured(apiVersion, kind, name, namespace string, content map[string]interface{}) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": apiVersion,
+		"kind":       kind,
+		"metadata": map[string]interface{}{
+			"name":      name,
+			"namespace": namespace,
+		},
+	}}
+	for k, v := range content {
+		obj.Object[k] = v
+	}
+	return obj
+}
+
+// fakeClientWithObjects constructs a fake client seeded with the given unstructured objects,
+// registering their GVKs on the scheme.
+func fakeClientWithObjects(t *testing.T, gvks []schema.GroupVersionKind, objs ...*unstructured.Unstructured) client.Client {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, workspacev1alpha1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	for _, gvk := range gvks {
+		if scheme.Recognizes(gvk) {
+			continue
+		}
+		scheme.AddKnownTypeWithName(gvk, &unstructured.Unstructured{})
+		listGVK := gvk
+		listGVK.Kind = gvk.Kind + "List"
+		scheme.AddKnownTypeWithName(listGVK, &unstructured.UnstructuredList{})
+	}
+	builder := fake.NewClientBuilder().WithScheme(scheme)
+	for _, o := range objs {
+		builder = builder.WithObjects(o)
+	}
+	return builder.Build()
+}
+
+// newTestWI builds a WorkspaceIntegration shell (as the controller would create it) pointing at
+// the ray-integration template with the cluster-name parameter, owned by my-workspace in user-ns.
+func newTestWI() *workspacev1alpha1.WorkspaceIntegration {
+	return &workspacev1alpha1.WorkspaceIntegration{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-workspace-ray-integration", Namespace: "user-ns"},
+		Spec: workspacev1alpha1.WorkspaceIntegrationSpec{
+			TemplateRef: workspacev1alpha1.IntegrationTemplateRef{
+				Name: "ray-integration",
+				Parameters: []workspacev1alpha1.IntegrationParameter{
+					{Name: testParamClusterName, Value: "my-ray-cluster"},
+				},
+			},
+			WorkspaceRef: workspacev1alpha1.WorkspaceRef{Name: "my-workspace", Namespace: "user-ns"},
+		},
+	}
+}
+
+// firstMergeEnv returns the PrimaryContainerModifications.MergeEnv from a resolved WI spec, or nil.
+func firstMergeEnv(wi *workspacev1alpha1.WorkspaceIntegration) []workspacev1alpha1.AccessEnvTemplate {
+	if wi.Spec.DeploymentModifications == nil ||
+		wi.Spec.DeploymentModifications.PodModifications == nil ||
+		wi.Spec.DeploymentModifications.PodModifications.PrimaryContainerModifications == nil {
+		return nil
+	}
+	return wi.Spec.DeploymentModifications.PodModifications.PrimaryContainerModifications.MergeEnv
+}
+
+// firstAdditionalContainers returns the resolved additional containers, or nil.
+func firstAdditionalContainers(wi *workspacev1alpha1.WorkspaceIntegration) []corev1.Container {
+	if wi.Spec.DeploymentModifications == nil || wi.Spec.DeploymentModifications.PodModifications == nil {
+		return nil
+	}
+	return wi.Spec.DeploymentModifications.PodModifications.AdditionalContainers
+}
+
+// TestBuildWorkspaceIntegration_ResolvesToLiteralValues is the core admission-time behavior: the
+// builder fetches the referenced RayCluster, resolves the template expressions, and writes the
+// resolved output onto wi.Spec with env/sidecar fields holding literal values (no {{ }} remaining).
+func TestBuildWorkspaceIntegration_ResolvesToLiteralValues(t *testing.T) {
+	rayGVK := schema.GroupVersionKind{Group: "ray.io", Version: "v1", Kind: testKindRayCluster}
+	rayCluster := newUnstructured("ray.io/v1", testKindRayCluster, "my-ray-cluster", "user-ns",
+		map[string]interface{}{
+			"status": map[string]interface{}{
+				"head": map[string]interface{}{"serviceName": "my-ray-cluster-head-svc"},
+			},
+		})
+	c := fakeClientWithObjects(t, []schema.GroupVersionKind{rayGVK}, rayCluster)
+
+	template := &workspacev1alpha1.WorkspaceIntegrationTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "ray-integration", Namespace: "user-ns"},
+		Spec: workspacev1alpha1.WorkspaceIntegrationTemplateSpec{
+			DisplayName: "Ray Cluster Integration",
+			ResourceRefs: []workspacev1alpha1.ResourceRef{
+				{ID: testRefIDRayCluster, APIVersion: "ray.io/v1", Kind: testKindRayCluster, Name: "{{ .Parameters.clusterName }}"},
+			},
+			DeploymentModifications: &workspacev1alpha1.DeploymentModifications{
+				PodModifications: &workspacev1alpha1.PodModifications{
+					AdditionalContainers: []corev1.Container{
+						{Name: "ray-sidecar", Image: "ray:2.9"},
+					},
+					PrimaryContainerModifications: &workspacev1alpha1.PrimaryContainerModifications{
+						MergeEnv: []workspacev1alpha1.AccessEnvTemplate{
+							{Name: testEnvRayAddress, ValueTemplate: `{{ resource "rayCluster" "{.status.head.serviceName}" }}`},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	wi := newTestWI()
+	require.NoError(t, BuildWorkspaceIntegration(context.Background(), c, wi, template))
+
+	containers := firstAdditionalContainers(wi)
+	require.Len(t, containers, 1)
+	assert.Equal(t, "ray-sidecar", containers[0].Name)
+	env := firstMergeEnv(wi)
+	require.Len(t, env, 1)
+	assert.Equal(t, testEnvRayAddress, env[0].Name)
+	assert.Equal(t, "my-ray-cluster-head-svc", env[0].ValueTemplate,
+		"env value must be the resolved literal, not a {{ }} expression")
+}
+
+// TestBuildWorkspaceIntegration_FreezesStatusProbe verifies the template's statusProbe is frozen
+// onto wi.Spec.StatusProbe so the controller's liveness probe never re-reads the template.
+func TestBuildWorkspaceIntegration_FreezesStatusProbe(t *testing.T) {
+	c := fakeClientWithObjects(t, nil)
+	template := &workspacev1alpha1.WorkspaceIntegrationTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "ray-integration", Namespace: "user-ns"},
+		Spec: workspacev1alpha1.WorkspaceIntegrationTemplateSpec{
+			DisplayName: "Ray Cluster Integration",
+			StatusProbe: &workspacev1alpha1.IntegrationStatusProbe{
+				Exec:          &corev1.ExecAction{Command: []string{"ray", "status"}},
+				PeriodSeconds: 30,
+			},
+		},
+	}
+
+	wi := newTestWI()
+	require.NoError(t, BuildWorkspaceIntegration(context.Background(), c, wi, template))
+	require.NotNil(t, wi.Spec.StatusProbe, "statusProbe must be frozen onto the resolved spec")
+	require.NotNil(t, wi.Spec.StatusProbe.Exec)
+	assert.Equal(t, []string{"ray", "status"}, wi.Spec.StatusProbe.Exec.Command)
+	assert.Equal(t, int32(30), wi.Spec.StatusProbe.PeriodSeconds)
+
+	// Deep copy, not aliasing: mutating the built probe must not affect the template.
+	wi.Spec.StatusProbe.PeriodSeconds = 99
+	assert.Equal(t, int32(30), template.Spec.StatusProbe.PeriodSeconds, "built probe must be a deep copy of the template's")
+}
+
+// TestBuildWorkspaceIntegration_FreezesShareProcessNamespace verifies the template's pod-level
+// shareProcessNamespace toggle is carried onto the resolved spec.
+func TestBuildWorkspaceIntegration_FreezesShareProcessNamespace(t *testing.T) {
+	c := fakeClientWithObjects(t, nil)
+	enabled := true
+	template := &workspacev1alpha1.WorkspaceIntegrationTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "ray-integration", Namespace: "user-ns"},
+		Spec: workspacev1alpha1.WorkspaceIntegrationTemplateSpec{
+			DisplayName:           "Ray Cluster Integration",
+			ShareProcessNamespace: &enabled,
+		},
+	}
+
+	wi := newTestWI()
+	require.NoError(t, BuildWorkspaceIntegration(context.Background(), c, wi, template))
+	require.NotNil(t, wi.Spec.ShareProcessNamespace)
+	assert.True(t, *wi.Spec.ShareProcessNamespace)
+}
+
+// TestBuildWorkspaceIntegration_WorkspaceRefNamespaceDefaultsToWI verifies the workspace namespace
+// used for resolution context defaults to the WorkspaceIntegration's own namespace when
+// workspaceRef.namespace is empty, and that a resourceRef with no namespace is fetched there.
+func TestBuildWorkspaceIntegration_WorkspaceRefNamespaceDefaultsToWI(t *testing.T) {
+	rayGVK := schema.GroupVersionKind{Group: "ray.io", Version: "v1", Kind: testKindRayCluster}
+	rayCluster := newUnstructured("ray.io/v1", testKindRayCluster, "my-ray-cluster", "wi-ns",
+		map[string]interface{}{"spec": map[string]interface{}{"foo": "bar"}})
+	c := fakeClientWithObjects(t, []schema.GroupVersionKind{rayGVK}, rayCluster)
+
+	wi := newTestWI()
+	wi.Namespace = "wi-ns"
+	wi.Spec.WorkspaceRef.Namespace = "" // force defaulting to the WI's own namespace
+
+	template := &workspacev1alpha1.WorkspaceIntegrationTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "ray-integration", Namespace: "wi-ns"},
+		Spec: workspacev1alpha1.WorkspaceIntegrationTemplateSpec{
+			DisplayName: "Ray Cluster Integration",
+			ResourceRefs: []workspacev1alpha1.ResourceRef{
+				{ID: testRefIDRayCluster, APIVersion: "ray.io/v1", Kind: testKindRayCluster, Name: "{{ .Parameters.clusterName }}"},
+			},
+			DeploymentModifications: &workspacev1alpha1.DeploymentModifications{
+				PodModifications: &workspacev1alpha1.PodModifications{
+					PrimaryContainerModifications: &workspacev1alpha1.PrimaryContainerModifications{
+						MergeEnv: []workspacev1alpha1.AccessEnvTemplate{
+							{Name: "RAY_CLUSTER", ValueTemplate: "{{ .Parameters.clusterName }}"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	require.NoError(t, BuildWorkspaceIntegration(context.Background(), c, wi, template))
+	env := firstMergeEnv(wi)
+	require.Len(t, env, 1)
+	assert.Equal(t, "my-ray-cluster", env[0].ValueTemplate)
+}
+
+// TestBuildWorkspaceIntegration_NotFoundFailsClosed verifies the build fails (so admission rejects)
+// when the referenced resource does not exist, naming the failing ref, and leaves the wi spec
+// output fields untouched.
+func TestBuildWorkspaceIntegration_NotFoundFailsClosed(t *testing.T) {
+	rayGVK := schema.GroupVersionKind{Group: "ray.io", Version: "v1", Kind: testKindRayCluster}
+	c := fakeClientWithObjects(t, []schema.GroupVersionKind{rayGVK}) // nothing seeded
+
+	template := &workspacev1alpha1.WorkspaceIntegrationTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "ray-integration", Namespace: "user-ns"},
+		Spec: workspacev1alpha1.WorkspaceIntegrationTemplateSpec{
+			DisplayName: "Ray Cluster Integration",
+			ResourceRefs: []workspacev1alpha1.ResourceRef{
+				{ID: testRefIDRayCluster, APIVersion: "ray.io/v1", Kind: testKindRayCluster, Name: "{{ .Parameters.clusterName }}"},
+			},
+			DeploymentModifications: &workspacev1alpha1.DeploymentModifications{
+				PodModifications: &workspacev1alpha1.PodModifications{
+					AdditionalContainers: []corev1.Container{{Name: "ray-sidecar", Image: "ray:2.9"}},
+				},
+			},
+		},
+	}
+
+	wi := newTestWI()
+	err := BuildWorkspaceIntegration(context.Background(), c, wi, template)
+	require.Error(t, err)
+	assert.Nil(t, wi.Spec.DeploymentModifications, "failed build must leave the output spec untouched")
+	assert.Contains(t, err.Error(), `resourceRef "rayCluster"`)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// TestBuildWorkspaceIntegration_NoModifications verifies a template with no deployment
+// modifications resolves cleanly, leaving DeploymentModifications nil.
+func TestBuildWorkspaceIntegration_NoModifications(t *testing.T) {
+	c := fakeClientWithObjects(t, nil)
+	template := &workspacev1alpha1.WorkspaceIntegrationTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "ray-integration", Namespace: "user-ns"},
+		Spec:       workspacev1alpha1.WorkspaceIntegrationTemplateSpec{DisplayName: "Ray Cluster Integration"},
+	}
+
+	wi := newTestWI()
+	require.NoError(t, BuildWorkspaceIntegration(context.Background(), c, wi, template))
+	assert.Nil(t, wi.Spec.DeploymentModifications)
+	assert.Empty(t, firstAdditionalContainers(wi))
+	assert.Empty(t, firstMergeEnv(wi))
+}
+
+// TestBuildWorkspaceIntegration_RebuildClearsStaleOutput locks in the unconditional-assignment
+// contract: when a WorkspaceIntegration carrying output from a prior build is rebuilt against a
+// template that no longer specifies those fields (e.g. after switching to a bare template), every
+// output field is cleared rather than retaining a stale value.
+func TestBuildWorkspaceIntegration_RebuildClearsStaleOutput(t *testing.T) {
+	c := fakeClientWithObjects(t, nil)
+
+	// A WI as if a prior build had already frozen output onto it.
+	enabled := true
+	wi := newTestWI()
+	wi.Spec.ShareProcessNamespace = &enabled
+	wi.Spec.StatusProbe = &workspacev1alpha1.IntegrationStatusProbe{
+		Exec:          &corev1.ExecAction{Command: []string{"ray", "status"}},
+		PeriodSeconds: 30,
+	}
+	wi.Spec.DeploymentModifications = &workspacev1alpha1.DeploymentModifications{
+		PodModifications: &workspacev1alpha1.PodModifications{
+			AdditionalContainers: []corev1.Container{{Name: "stale-sidecar", Image: "ray:2.8"}},
+		},
+	}
+
+	// Rebuild against a template with no modifications, probe, or shareProcessNamespace.
+	template := &workspacev1alpha1.WorkspaceIntegrationTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "ray-integration", Namespace: "user-ns"},
+		Spec:       workspacev1alpha1.WorkspaceIntegrationTemplateSpec{DisplayName: "Ray Cluster Integration"},
+	}
+
+	require.NoError(t, BuildWorkspaceIntegration(context.Background(), c, wi, template))
+	assert.Nil(t, wi.Spec.ShareProcessNamespace, "stale shareProcessNamespace must be cleared on rebuild")
+	assert.Nil(t, wi.Spec.StatusProbe, "stale statusProbe must be cleared on rebuild")
+	assert.Nil(t, wi.Spec.DeploymentModifications, "stale deploymentModifications must be cleared on rebuild")
+}
+
+// TestBuildWorkspaceIntegration_NilGuards verifies the builder rejects nil inputs rather than
+// panicking.
+func TestBuildWorkspaceIntegration_NilGuards(t *testing.T) {
+	c := fakeClientWithObjects(t, nil)
+
+	err := BuildWorkspaceIntegration(context.Background(), c, nil, &workspacev1alpha1.WorkspaceIntegrationTemplate{})
+	require.Error(t, err)
+
+	err = BuildWorkspaceIntegration(context.Background(), c, newTestWI(), nil)
+	require.Error(t, err)
+}
+
+// TestBuildWorkspaceIntegration_RejectsCrossNamespaceWorkspaceRef verifies the builder rejects a
+// workspaceRef.namespace that differs from the WorkspaceIntegration's own namespace (cross-namespace
+// references are unsupported), while allowing an empty namespace (defaults to own) and an explicit
+// matching namespace.
+func TestBuildWorkspaceIntegration_RejectsCrossNamespaceWorkspaceRef(t *testing.T) {
+	c := fakeClientWithObjects(t, nil)
+	template := &workspacev1alpha1.WorkspaceIntegrationTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "ray-integration", Namespace: "user-ns"},
+		Spec:       workspacev1alpha1.WorkspaceIntegrationTemplateSpec{DisplayName: "Ray Cluster Integration"},
+	}
+
+	// Differing namespace -> rejected.
+	wi := newTestWI() // wi.Namespace == "user-ns"
+	wi.Spec.WorkspaceRef.Namespace = "other-ns"
+	err := BuildWorkspaceIntegration(context.Background(), c, wi, template)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cross-namespace references are not supported")
+	assert.Nil(t, wi.Spec.DeploymentModifications, "rejected build must not mutate output fields")
+
+	// Explicit matching namespace -> allowed.
+	wiMatch := newTestWI()
+	wiMatch.Spec.WorkspaceRef.Namespace = wiMatch.Namespace
+	require.NoError(t, BuildWorkspaceIntegration(context.Background(), c, wiMatch, template))
+
+	// Empty namespace -> allowed (defaults to own).
+	wiEmpty := newTestWI()
+	wiEmpty.Spec.WorkspaceRef.Namespace = ""
+	require.NoError(t, BuildWorkspaceIntegration(context.Background(), c, wiEmpty, template))
+}


### PR DESCRIPTION
## Summary

Adds `BuildWorkspaceIntegration` — the admission-time function that resolves a `WorkspaceIntegration` against its referenced resources and template parameters, then freezes the fully-resolved, literal output directly onto the object's own spec fields (`deploymentModifications`, `shareProcessNamespace`, `statusProbe`).

It mirrors the existing `WorkspaceTemplate → Workspace` precedent: just as a `Workspace` carries its resolved template values on its own spec fields, a `WorkspaceIntegration` carries its resolved values, in place, on its own spec. There is no separate "resolved" envelope type. Once the output is frozen here, the workspace controller reads only the frozen child and never re-resolves the template at reconcile time.

## What this function does

Given a `WorkspaceIntegration` and its `WorkspaceIntegrationTemplate`, the builder:

1. Validates the co-location invariant — a `workspaceRef.namespace` that differs from the object's own namespace is rejected (cross-namespace references are unsupported); empty defaults to the object's own namespace.
2. Fetches each `resourceRef` target (e.g. a `RayCluster`) via the client, after resolving any template expressions in the ref's name/namespace.
3. Resolves every template expression in the template's pod modifications into literal values.
4. Commits the result onto the object's spec, assigning **every** output field unconditionally so a re-build (e.g. after switching the referenced cluster) never leaves a stale value behind.

**Fail-closed:** any referenced resource that is missing, not yet ready, or resolves to an empty value returns an error so admission rejects the write and the prior good output is preserved. On error, the object's spec fields are left untouched.

## Dependencies

> ⚠️ **This branch does not compile on its own** and is expected to show a red build until its dependencies merge. It is published now for review of the resolution/freeze logic in isolation.

This commit builds on two earlier commits in the same series and references symbols introduced by each:

- **The API types commit** — provides the `WorkspaceIntegration` / `WorkspaceIntegrationTemplate` types and their `deploymentModifications` / `shareProcessNamespace` / `statusProbe` spec fields.
- **The template-resolver commit** — provides `IntegrationTemplateResolver` (`ResolveResourceRef`, `ResolvePodModifications`) and the `IntegrationTemplateData` context. This commit is purely the *consumer* of that resolver; it adds the fetch-and-freeze orchestration around it.

Once both of those land on `main`, this branch rebases onto `main` cleanly and compiles. The PR can be rebased in place at that point — same branch, same PR.

## Why this is a separate commit

The resolver (previous commit) is a **pure function**: given inputs, it substitutes template expressions into literals. It performs no Kubernetes I/O and holds no opinion about *where* the output is stored or *when* resolution happens.

This commit adds exactly the orchestration the resolver deliberately omits:

- **Kubernetes reads** — fetching the referenced resources the resolver needs as inputs.
- **A storage decision** — freezing the resolved output onto the object's own spec fields.
- **Admission-time policy** — fail-closed semantics, the namespace co-location check, and unconditional re-write on update.

Keeping these concerns in their own commit means the resolver stays small, side-effect-free, and trivially unit-testable, while the fetch/freeze/policy layer is reviewed and tested on its own terms. The next commit (the mutating webhook) wires this function into the admission path; logging and event recording live there, not here.

## What's in this PR

| File | What |
|---|---|
| `internal/controller/workspaceintegration_builder.go` | `BuildWorkspaceIntegration` + the `fetchReferencedResources` helper. |
| `internal/controller/workspaceintegration_builder_test.go` | Unit tests against a fake client. |

The GVK lookup uses [`schema.FromAPIVersionAndKind`](https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime/schema#FromAPIVersionAndKind) from apimachinery rather than a hand-rolled parser.

## Testing

Unit tests against a fake client (no control plane required), covering:

- Resolve-to-literal-values (env/sidecar fields hold resolved literals, no `{{ }}` remaining).
- Freezing `statusProbe` (deep-copied, not aliased) and `shareProcessNamespace`.
- Workspace-namespace defaulting to the object's own namespace.
- Fail-closed on a missing referenced resource (named in the error, output spec left untouched).
- Re-build clearing stale output from a prior resolution.
- Nil-input guards and cross-namespace `workspaceRef` rejection.

```
go test ./internal/controller/ -run 'TestBuildWorkspaceIntegration' -count=1
```

## References

- Go `text/template` (the expression engine the resolver uses): https://pkg.go.dev/text/template
- `client-go` JSONPath (resource-field reads): https://pkg.go.dev/k8s.io/client-go/util/jsonpath
- KubeRay / `RayCluster` (an example referenced resource): https://docs.ray.io/en/latest/cluster/kubernetes/index.html
