### PR TITLE
feat: create and GC WorkspaceIntegration child shells from the workspace controller

### DIFF
--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -169,6 +169,14 @@ func GeneratePVCName(workspaceName string) string {
 	return fmt.Sprintf("%s-%s-pvc", ResourcePrefix, workspaceName)
 }
 
+// GenerateWorkspaceIntegrationName creates a deterministic WorkspaceIntegration child name for a
+// given workspace + integrationRef. The 1:1 <workspace>-<ref> mapping makes the child name
+// predictable; identification at deployment-build time uses the LabelWorkspaceName label selector
+// (option B), with this name only ensuring a stable, collision-free child per ref.
+func GenerateWorkspaceIntegrationName(workspaceName, integrationRefName string) string {
+	return fmt.Sprintf("%s-%s-%s", ResourcePrefix, workspaceName, integrationRefName)
+}
+
 // GenerateLabels creates consistent labels for resources
 func GenerateLabels(workspaceName string) map[string]string {
 	return map[string]string{

--- a/internal/controller/state_machine.go
+++ b/internal/controller/state_machine.go
@@ -33,6 +33,10 @@ type StateMachine struct {
 	recorder            record.EventRecorder
 	idleChecker         *WorkspaceIdleChecker
 	accessStartupProber AccessStartupProberInterface
+	// integrationManager is always wired by SetupWorkspaceController. It is a pointer (and the
+	// reconcile path nil-guards it) only so unit tests can construct a StateMachine without the
+	// integration machinery; production code must never leave it nil.
+	integrationManager *WorkspaceIntegrationManager
 }
 
 // NewStateMachine creates a new StateMachine
@@ -42,6 +46,7 @@ func NewStateMachine(
 	recorder record.EventRecorder,
 	idleChecker *WorkspaceIdleChecker,
 	accessStartupProber AccessStartupProberInterface,
+	integrationManager *WorkspaceIntegrationManager,
 ) *StateMachine {
 	return &StateMachine{
 		resourceManager:     resourceManager,
@@ -49,6 +54,7 @@ func NewStateMachine(
 		recorder:            recorder,
 		idleChecker:         idleChecker,
 		accessStartupProber: accessStartupProber,
+		integrationManager:  integrationManager,
 	}
 }
 
@@ -211,6 +217,22 @@ func (sm *StateMachine) reconcileDesiredRunningStatus(
 	accessStrategy *workspacev1alpha1.WorkspaceAccessStrategy) (ctrl.Result, error) {
 	logger := logf.FromContext(ctx)
 	logger.Info("Attempting to bring Workspace status to 'Running'")
+
+	// Ensure the WorkspaceIntegration child shells exist (one per integrationRefs entry) before
+	// building the deployment. The shells are resolved (spec output fields frozen) by the
+	// WorkspaceIntegration mutating webhook at their own admission; the controller does NOT resolve
+	// here. The deployment builder reads the frozen children. Failing to create a shell fails the
+	// reconcile so we don't build a deployment missing its integration.
+	if sm.integrationManager != nil {
+		if _, err := sm.integrationManager.EnsureForWorkspace(ctx, workspace); err != nil {
+			integErr := fmt.Errorf("failed to ensure workspace integrations: %w", err)
+			if statusErr := sm.statusManager.UpdateErrorStatus(
+				ctx, workspace, ReasonDeploymentError, integErr.Error(), snapshotStatus); statusErr != nil {
+				logger.Error(statusErr, "Failed to update error status")
+			}
+			return ctrl.Result{}, integErr
+		}
+	}
 
 	// Ensure PVC exists first (if storage is configured)
 	_, err := sm.resourceManager.EnsurePVCExists(ctx, workspace)

--- a/internal/controller/workspace_controller.go
+++ b/internal/controller/workspace_controller.go
@@ -249,7 +249,10 @@ func (r *WorkspaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// Watch for standard Kubernetes resources
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
-		Owns(&corev1.PersistentVolumeClaim{})
+		Owns(&corev1.PersistentVolumeClaim{}).
+		// Watch owned WorkspaceIntegration children so a re-resolve (webhook updating the child's
+		// spec output) re-triggers the workspace reconcile and the deployment picks up the new values.
+		Owns(&workspacev1alpha1.WorkspaceIntegration{})
 
 	// Watch for changes to AccessStrategy resources to trigger reconciliation
 	// of Workspaces that reference them
@@ -346,7 +349,8 @@ func SetupWorkspaceController(mgr mngr.Manager, options WorkspaceControllerOptio
 	eventRecorder := mgr.GetEventRecorderFor("workspace-controller")
 	idleChecker := NewWorkspaceIdleChecker(k8sClient, options.IdleCheckInterval)
 	accessStartupProber := NewAccessStartupProber(NewAccessResourcesBuilder())
-	stateMachine := NewStateMachine(resourceManager, statusManager, eventRecorder, idleChecker, accessStartupProber)
+	integrationManager := NewWorkspaceIntegrationManager(k8sClient, scheme)
+	stateMachine := NewStateMachine(resourceManager, statusManager, eventRecorder, idleChecker, accessStartupProber, integrationManager)
 
 	// Create plugin clients for pod event handling (if configured)
 	pluginClients := map[string]plugin.RemoteAccessPluginApis{}

--- a/internal/controller/workspaceintegration_manager.go
+++ b/internal/controller/workspaceintegration_manager.go
@@ -1,0 +1,180 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	workspacev1alpha1 "github.com/jupyter-infra/jupyter-k8s/api/v1alpha1"
+	workspaceutil "github.com/jupyter-infra/jupyter-k8s/internal/workspace"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// WorkspaceIntegrationManager reconciles the set of WorkspaceIntegration child objects for a
+// workspace against workspace.spec.integrationRefs.
+//
+// It is the "operator pattern" half of the Option 2 model: the workspace controller creates one
+// WorkspaceIntegration SHELL per integrationRefs entry (templateRef + workspaceRef + ownerRef +
+// identification label), but performs NO resolution itself -- it never reads the
+// WorkspaceIntegrationTemplate or the referenced resources. The frozen spec output fields
+// (deploymentModifications/statusProbe/shareProcessNamespace) are produced by the
+// WorkspaceIntegration mutating webhook at the child's own admission. This keeps the workspace
+// reconcile loop free of reconcile-time RayCluster reads.
+//
+// ownerReferences point each child at the workspace so Kubernetes garbage-collects the children
+// when the workspace is deleted. Identification at deployment-build time is by the
+// LabelWorkspaceName label (option B): the deployment builder lists children with a label selector
+// rather than relying on the deterministic name.
+type WorkspaceIntegrationManager struct {
+	client client.Client
+	scheme *runtime.Scheme
+}
+
+// NewWorkspaceIntegrationManager creates a new WorkspaceIntegrationManager.
+func NewWorkspaceIntegrationManager(c client.Client, scheme *runtime.Scheme) *WorkspaceIntegrationManager {
+	return &WorkspaceIntegrationManager{client: c, scheme: scheme}
+}
+
+// ListForWorkspace returns the WorkspaceIntegration children owned by the given workspace, found by
+// the LabelWorkspaceName label in the workspace's namespace. This is the canonical identification
+// path (option B) used both for reconciling the set and for building the deployment.
+func (m *WorkspaceIntegrationManager) ListForWorkspace(
+	ctx context.Context,
+	workspace *workspacev1alpha1.Workspace,
+) ([]workspacev1alpha1.WorkspaceIntegration, error) {
+	list := &workspacev1alpha1.WorkspaceIntegrationList{}
+	if err := m.client.List(ctx, list,
+		client.InNamespace(workspace.Namespace),
+		client.MatchingLabels{workspaceutil.LabelWorkspaceName: workspace.Name},
+	); err != nil {
+		return nil, fmt.Errorf("failed to list WorkspaceIntegrations for workspace %q: %w", workspace.Name, err)
+	}
+	return list.Items, nil
+}
+
+// EnsureForWorkspace reconciles the WorkspaceIntegration children for the workspace: it creates a
+// shell for each integrationRefs entry that has none, updates a shell whose templateRef/workspaceRef
+// drifted from the workspace's intent (re-triggering the webhook bake), and deletes any child no
+// longer backed by an integrationRefs entry. It returns the reconciled set of children, assembled
+// locally as it goes (no trailing re-list).
+//
+// Creating/updating a shell deliberately leaves the resolved output fields untouched here -- the
+// mutating webhook fills them at admission. The manager only owns the shell's identity and references.
+func (m *WorkspaceIntegrationManager) EnsureForWorkspace(
+	ctx context.Context,
+	workspace *workspacev1alpha1.Workspace,
+) ([]workspacev1alpha1.WorkspaceIntegration, error) {
+	logger := logf.FromContext(ctx)
+
+	existing, err := m.ListForWorkspace(ctx, workspace)
+	if err != nil {
+		return nil, err
+	}
+
+	// Index existing children by name for quick lookup and stale detection.
+	existingByName := make(map[string]*workspacev1alpha1.WorkspaceIntegration, len(existing))
+	for i := range existing {
+		existingByName[existing[i].Name] = &existing[i]
+	}
+
+	// desiredNames tracks which child names the current integrationRefs require, so anything else
+	// owned by this workspace is stale and gets deleted.
+	desiredNames := make(map[string]struct{}, len(workspace.Spec.IntegrationRefs))
+
+	// Assemble the reconciled set as we go rather than re-listing at the end: the re-list was an
+	// extra API call the caller discards, and an informer-backed client may not yet reflect a
+	// just-created object. Each desired ref contributes exactly one child to the result.
+	result := make([]workspacev1alpha1.WorkspaceIntegration, 0, len(workspace.Spec.IntegrationRefs))
+
+	for i := range workspace.Spec.IntegrationRefs {
+		ref := &workspace.Spec.IntegrationRefs[i]
+		name := GenerateWorkspaceIntegrationName(workspace.Name, ref.Name)
+		desiredNames[name] = struct{}{}
+
+		desiredSpec := m.buildShellSpec(workspace, ref)
+
+		if current, ok := existingByName[name]; ok {
+			// Update only if the intent (templateRef/workspaceRef) drifted. We compare only the
+			// shell input fields, never the resolved output -- that is webhook-owned and updating it
+			// would fight the webhook. An update re-runs the webhook, re-resolving the output.
+			if !equality.Semantic.DeepEqual(current.Spec.TemplateRef, desiredSpec.TemplateRef) ||
+				!equality.Semantic.DeepEqual(current.Spec.WorkspaceRef, desiredSpec.WorkspaceRef) {
+				current.Spec.TemplateRef = desiredSpec.TemplateRef
+				current.Spec.WorkspaceRef = desiredSpec.WorkspaceRef
+				if err := m.client.Update(ctx, current); err != nil {
+					return nil, fmt.Errorf("failed to update WorkspaceIntegration %q: %w", name, err)
+				}
+				logger.Info("Updated WorkspaceIntegration shell", "workspaceintegration", name)
+			}
+			result = append(result, *current)
+			continue
+		}
+
+		// Create a new shell. ownerRef -> workspace (controller=true) for GC and re-enqueue.
+		wi := &workspacev1alpha1.WorkspaceIntegration{}
+		wi.Name = name
+		wi.Namespace = workspace.Namespace
+		wi.Labels = map[string]string{workspaceutil.LabelWorkspaceName: workspace.Name}
+		wi.Spec = desiredSpec
+		if err := controllerutil.SetControllerReference(workspace, wi, m.scheme); err != nil {
+			return nil, fmt.Errorf("failed to set owner reference on WorkspaceIntegration %q: %w", name, err)
+		}
+		if err := m.client.Create(ctx, wi); err != nil {
+			if apierrors.IsAlreadyExists(err) {
+				// Raced with another reconcile that created it. Fetch the winner so the returned set
+				// stays complete (one Get on the rare race path, not a blanket re-list every time).
+				logger.V(1).Info("WorkspaceIntegration already exists, fetching the existing child", "workspaceintegration", name)
+				raced := &workspacev1alpha1.WorkspaceIntegration{}
+				if getErr := m.client.Get(ctx, client.ObjectKey{Name: name, Namespace: workspace.Namespace}, raced); getErr != nil {
+					return nil, fmt.Errorf("failed to get raced WorkspaceIntegration %q: %w", name, getErr)
+				}
+				result = append(result, *raced)
+				continue
+			}
+			return nil, fmt.Errorf("failed to create WorkspaceIntegration %q: %w", name, err)
+		}
+		logger.Info("Created WorkspaceIntegration shell", "workspaceintegration", name, "template", ref.Name)
+		result = append(result, *wi)
+	}
+
+	// Delete stale children no longer backed by an integrationRefs entry.
+	for i := range existing {
+		child := &existing[i]
+		if _, wanted := desiredNames[child.Name]; wanted {
+			continue
+		}
+		if !child.DeletionTimestamp.IsZero() {
+			continue // already being deleted
+		}
+		if err := m.client.Delete(ctx, child); err != nil && !apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("failed to delete stale WorkspaceIntegration %q: %w", child.Name, err)
+		}
+		logger.Info("Deleted stale WorkspaceIntegration shell", "workspaceintegration", child.Name)
+	}
+
+	return result, nil
+}
+
+// buildShellSpec builds the desired shell spec (templateRef + workspaceRef) for an integrationRef.
+// It deliberately omits the resolved output fields -- the webhook owns those.
+func (m *WorkspaceIntegrationManager) buildShellSpec(
+	workspace *workspacev1alpha1.Workspace,
+	ref *workspacev1alpha1.IntegrationTemplateRef,
+) workspacev1alpha1.WorkspaceIntegrationSpec {
+	return workspacev1alpha1.WorkspaceIntegrationSpec{
+		TemplateRef: *ref.DeepCopy(),
+		WorkspaceRef: workspacev1alpha1.WorkspaceRef{
+			Name:      workspace.Name,
+			Namespace: workspace.Namespace,
+		},
+	}
+}

--- a/internal/controller/workspaceintegration_manager_test.go
+++ b/internal/controller/workspaceintegration_manager_test.go
@@ -1,0 +1,169 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	workspacev1alpha1 "github.com/jupyter-infra/jupyter-k8s/api/v1alpha1"
+	workspaceutil "github.com/jupyter-infra/jupyter-k8s/internal/workspace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func wiManagerTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, workspacev1alpha1.AddToScheme(scheme))
+	return scheme
+}
+
+func wiManagerTestWorkspace(refNames ...string) *workspacev1alpha1.Workspace {
+	refs := make([]workspacev1alpha1.IntegrationTemplateRef, 0, len(refNames))
+	for _, n := range refNames {
+		refs = append(refs, workspacev1alpha1.IntegrationTemplateRef{Name: n})
+	}
+	return &workspacev1alpha1.Workspace{
+		ObjectMeta: metav1.ObjectMeta{Name: "ws-foo", Namespace: "user-ns", UID: "ws-foo-uid"},
+		Spec:       workspacev1alpha1.WorkspaceSpec{IntegrationRefs: refs},
+	}
+}
+
+// TestEnsureForWorkspace_CreatesShellWithOwnerRefAndLabel verifies a missing child is created with
+// the workspace as controller owner, the identification label, and the right templateRef/workspaceRef
+// -- and that the resolved output fields are left for the webhook (not set by the manager).
+func TestEnsureForWorkspace_CreatesShellWithOwnerRefAndLabel(t *testing.T) {
+	scheme := wiManagerTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	m := NewWorkspaceIntegrationManager(c, scheme)
+	ws := wiManagerTestWorkspace("ray-integration")
+
+	result, err := m.EnsureForWorkspace(context.Background(), ws)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+
+	wi := result[0]
+	assert.Equal(t, "workspace-ws-foo-ray-integration", wi.Name)
+	assert.Equal(t, "user-ns", wi.Namespace)
+	assert.Equal(t, "ws-foo", wi.Labels[workspaceutil.LabelWorkspaceName], "identification label (option B)")
+	assert.Equal(t, "ray-integration", wi.Spec.TemplateRef.Name)
+	assert.Equal(t, "ws-foo", wi.Spec.WorkspaceRef.Name)
+	assert.Equal(t, "user-ns", wi.Spec.WorkspaceRef.Namespace)
+	assert.Nil(t, wi.Spec.DeploymentModifications, "manager must not set resolved output -- the webhook owns it")
+	assert.Nil(t, wi.Spec.StatusProbe, "manager must not set resolved output -- the webhook owns it")
+	assert.Nil(t, wi.Spec.ShareProcessNamespace, "manager must not set resolved output -- the webhook owns it")
+
+	require.Len(t, wi.OwnerReferences, 1)
+	owner := wi.OwnerReferences[0]
+	assert.Equal(t, "Workspace", owner.Kind)
+	assert.Equal(t, "ws-foo", owner.Name)
+	require.NotNil(t, owner.Controller)
+	assert.True(t, *owner.Controller, "ownerRef must be a controller ref for GC + re-enqueue")
+}
+
+// TestEnsureForWorkspace_Idempotent verifies a second reconcile with no spec change creates nothing
+// new and preserves the webhook-owned resolved output.
+func TestEnsureForWorkspace_Idempotent(t *testing.T) {
+	scheme := wiManagerTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	m := NewWorkspaceIntegrationManager(c, scheme)
+	ws := wiManagerTestWorkspace("ray-integration")
+
+	first, err := m.EnsureForWorkspace(context.Background(), ws)
+	require.NoError(t, err)
+	require.Len(t, first, 1)
+
+	// Simulate the webhook having resolved the output fields on the persisted child.
+	baked := first[0].DeepCopy()
+	baked.Spec.DeploymentModifications = &workspacev1alpha1.DeploymentModifications{
+		PodModifications: &workspacev1alpha1.PodModifications{
+			PrimaryContainerModifications: &workspacev1alpha1.PrimaryContainerModifications{
+				MergeEnv: []workspacev1alpha1.AccessEnvTemplate{{Name: "RAY_ADDRESS", ValueTemplate: "svc"}},
+			},
+		},
+	}
+	require.NoError(t, c.Update(context.Background(), baked))
+
+	second, err := m.EnsureForWorkspace(context.Background(), ws)
+	require.NoError(t, err)
+	require.Len(t, second, 1, "no duplicate child created")
+	require.NotNil(t, second[0].Spec.DeploymentModifications, "manager must not clobber webhook-resolved output")
+	assert.Equal(t, "svc",
+		second[0].Spec.DeploymentModifications.PodModifications.PrimaryContainerModifications.MergeEnv[0].ValueTemplate)
+}
+
+// TestEnsureForWorkspace_UpdatesOnTemplateDrift verifies that changing an integrationRef's template
+// updates the existing child's templateRef (re-triggering the webhook bake).
+func TestEnsureForWorkspace_UpdatesOnTemplateDrift(t *testing.T) {
+	scheme := wiManagerTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	m := NewWorkspaceIntegrationManager(c, scheme)
+
+	// First reconcile with a parameter value.
+	ws := wiManagerTestWorkspace("ray-integration")
+	ws.Spec.IntegrationRefs[0].Parameters = []workspacev1alpha1.IntegrationParameter{
+		{Name: "clusterName", Value: "old-cluster"},
+	}
+	_, err := m.EnsureForWorkspace(context.Background(), ws)
+	require.NoError(t, err)
+
+	// Change the parameter (e.g. switch clusters) and re-reconcile.
+	ws.Spec.IntegrationRefs[0].Parameters[0].Value = "new-cluster"
+	result, err := m.EnsureForWorkspace(context.Background(), ws)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	require.Len(t, result[0].Spec.TemplateRef.Parameters, 1)
+	assert.Equal(t, "new-cluster", result[0].Spec.TemplateRef.Parameters[0].Value,
+		"templateRef drift must be propagated to the child so the webhook re-bakes")
+}
+
+// TestEnsureForWorkspace_DeletesStale verifies a child whose integrationRef was removed is deleted.
+func TestEnsureForWorkspace_DeletesStale(t *testing.T) {
+	scheme := wiManagerTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	m := NewWorkspaceIntegrationManager(c, scheme)
+
+	// Start with one integration.
+	ws := wiManagerTestWorkspace("ray-integration")
+	_, err := m.EnsureForWorkspace(context.Background(), ws)
+	require.NoError(t, err)
+
+	// Remove all integrationRefs and re-reconcile -> the child should be deleted.
+	ws.Spec.IntegrationRefs = nil
+	result, err := m.EnsureForWorkspace(context.Background(), ws)
+	require.NoError(t, err)
+	assert.Empty(t, result, "stale child must be deleted when its integrationRef is removed")
+}
+
+// TestListForWorkspace_FiltersByLabel verifies listing returns only children labeled for the
+// workspace, not children of a different workspace in the same namespace.
+func TestListForWorkspace_FiltersByLabel(t *testing.T) {
+	scheme := wiManagerTestScheme(t)
+
+	mine := &workspacev1alpha1.WorkspaceIntegration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "workspace-ws-foo-ray", Namespace: "user-ns",
+			Labels: map[string]string{workspaceutil.LabelWorkspaceName: "ws-foo"},
+		},
+	}
+	other := &workspacev1alpha1.WorkspaceIntegration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "workspace-ws-bar-ray", Namespace: "user-ns",
+			Labels: map[string]string{workspaceutil.LabelWorkspaceName: "ws-bar"},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(mine, other).Build()
+	m := NewWorkspaceIntegrationManager(c, scheme)
+
+	result, err := m.ListForWorkspace(context.Background(), wiManagerTestWorkspace())
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, "workspace-ws-foo-ray", result[0].Name)
+}


### PR DESCRIPTION
## Summary

Wires the workspace controller to manage the `WorkspaceIntegration` child objects for a workspace. On each reconcile, the controller ensures one `WorkspaceIntegration` child exists per `workspace.spec.integrationRefs` entry, updates a child whose `templateRef`/`workspaceRef` has drifted, and deletes any child no longer backed by a ref. Children are owned by the workspace (controller `ownerReference`) so Kubernetes garbage-collects them when the workspace is deleted.

This is the operator half of the design: the controller owns each child's **identity and references**; it performs **no** resolution itself — it never reads the `WorkspaceIntegrationTemplate` or the referenced resources. The resolved output fields are produced separately at the child's own admission, which keeps the workspace reconcile loop free of reconcile-time resource reads.

## What this commit does

`WorkspaceIntegrationManager` (new) provides:

- **`EnsureForWorkspace`** — the reconcile entry point. For each `integrationRefs` entry it creates a child "shell" (`templateRef` + `workspaceRef` + identification label + ownerRef) if missing, updates it if the intent drifted, and deletes children whose ref was removed. It returns the reconciled set, assembled locally as it goes.
- **`ListForWorkspace`** — lists a workspace's children by the `workspace.jupyter.org/workspace-name` label (the canonical identification path), namespace-scoped.

The state machine calls `EnsureForWorkspace` on the running path before building the deployment; failing to ensure a child fails the reconcile so a workspace is never built missing an integration.

### Key properties

- **GC + re-enqueue:** `controllerutil.SetControllerReference(workspace, child, ...)` gives both garbage collection on workspace delete and re-enqueue of the workspace on child changes (via the `Owns(...)` watch).
- **No output clobbering:** create/update sets only the shell input fields (`templateRef`/`workspaceRef`); the resolved output fields are left untouched, so the controller never fights the component that fills them. The idempotency test verifies a re-reconcile preserves externally-resolved output.
- **Race-safe create:** `AlreadyExists` on create is handled by fetching the existing child, so a concurrent reconcile doesn't error the loop.

## Dependencies

> ⚠️ **This branch does not compile on its own** and is expected to show a red build until its dependency merges. It is published now so the child-lifecycle management can be reviewed in isolation.

This commit builds on the **API types commit**, which introduces the `WorkspaceIntegration` / `WorkspaceIntegrationList` types and the `workspace.spec.integrationRefs` field this manager reconciles against.

It does **not** depend on the resolver/builder/webhook commits — it only manages child identity and references and deliberately never touches resolved output. Once the API types land on `main`, this branch rebases onto `main` cleanly and compiles. The PR can be rebased in place at that point — same branch, same PR.

## Why this is a separate commit

The earlier commits in the series are the **resolution path** (turning a template into frozen output at the child's admission). This commit is the **lifecycle path** (creating, updating, GC-ing the right set of children from `integrationRefs`). They are orthogonal concerns with a clean boundary:

- This manager owns *which children exist and what they reference*.
- The admission path owns *what each child resolves to*.

Keeping them in separate commits means the controller's reconcile logic is reviewed and tested purely as set-reconciliation (create/update/delete/GC), with no resolution coupling — the manager's tests assert it never writes the output fields, proving the boundary holds.

## What's in this PR

| File | What |
|---|---|
| `internal/controller/workspaceintegration_manager.go` | `WorkspaceIntegrationManager` — `EnsureForWorkspace`, `ListForWorkspace`, shell builder. |
| `internal/controller/workspaceintegration_manager_test.go` | Unit tests against a fake client. |
| `internal/controller/state_machine.go` | Calls `EnsureForWorkspace` on the running path; wires the manager in. |
| `internal/controller/workspace_controller.go` | Constructs the manager in `SetupWorkspaceController`. |
| `internal/controller/constants.go` | `GenerateWorkspaceIntegrationName` (deterministic child name). |

## Testing

Unit tests against a fake client cover:

- Create a shell with the correct ownerRef, identification label, and references — and that the resolved output fields are left unset (owned elsewhere).
- Idempotency: a second reconcile creates nothing new and preserves externally-resolved output.
- Update on `templateRef` drift (e.g. switching the referenced cluster).
- Delete of a stale child when its `integrationRefs` entry is removed.
- Label-filtered listing (a workspace sees only its own children).

```
go test ./internal/controller/ -run 'TestEnsureForWorkspace|TestListForWorkspace' -count=1
```

## References

- controller-runtime owner references & GC: https://book.kubebuilder.io/reference/using-finalizers (and `controllerutil.SetControllerReference`)
- Kubernetes garbage collection (owner refs): https://kubernetes.io/docs/concepts/architecture/garbage-collection/
