### PR TITLE
doc: ref eks-oidc template in operator docs

### DIFF
--- a/docs/source/getting-started/index.md
+++ b/docs/source/getting-started/index.md
@@ -1,5 +1,9 @@
 # Getting Started
 
+```{tip}
+Want a turnkey path? Use a [`jupyter-deploy`](../integrations/deployment-templates/index) template to provision your Kubernetes cluster, install the **Jupyter K8s** operator and the routing infrastructure.
+```
+
 Install **Jupyter K8s** into an existing Kubernetes cluster using Helm.
 
 ## Prerequisites

--- a/docs/source/integrations/deployment-templates/aws-eks-oidc.md
+++ b/docs/source/integrations/deployment-templates/aws-eks-oidc.md
@@ -1,0 +1,60 @@
+(template-aws-eks-oidc)=
+# AWS EKS OIDC
+
+The **AWS EKS OIDC** template provisions a complete multi-user **JupyterLab** platform on AWS:
+an EKS cluster, **Jupyter K8s**, and a browser access stack with HTTPS and GitHub OAuth. It is
+the `jupyter-deploy` equivalent of bringing your own cluster and installing the
+{ref}`AWS OIDC guided chart <chart-aws-oidc>` yourself.
+
+- **Provider:** AWS (EKS)
+- **Engine:** Terraform
+- **Access:** OIDC web access — GitHub identities federated through Dex
+
+It provisions an EKS cluster configured with OIDC access, installs the
+[**Jupyter K8s** operator chart](../../reference/helm-charts/operator), and layers on the
+{ref}`AWS OIDC guided chart <chart-aws-oidc>` for HTTPS ingress, GitHub OAuth, and browser access.
+The [AWS EKS OIDC Template](https://jupyter-deploy.readthedocs.io/en/latest/templates/aws-eks-oidc-template/index.html)
+documentation is the source of truth for its architecture, prerequisites, and configuration.
+
+## Getting started
+
+The template requires an AWS account, a domain registered with Amazon Route 53, and a GitHub OAuth app.
+See the [prerequisites](https://jupyter-deploy.readthedocs.io/en/latest/templates/aws-eks-oidc-template/prerequisites.html)
+for the details.
+
+Create a Python environment for the `jd` CLI and the template. We recommend
+[uv](https://github.com/astral-sh/uv):
+
+```bash
+# prepare a virtual environment
+uv init . --bare
+uv venv
+source .venv/bin/activate
+
+# install jupyter-deploy and the AWS EKS OIDC template
+uv add "jupyter-deploy[aws,k8s]" jupyter-deploy-tf-aws-eks-oidc
+```
+
+Or with `pip`:
+
+```bash
+pip install "jupyter-deploy[aws,k8s]" jupyter-deploy-tf-aws-eks-oidc
+```
+
+Then initialize, configure, and deploy a project:
+
+```bash
+mkdir my-eks-deployment && cd my-eks-deployment
+jd init . -E terraform -P aws -I eks -T oidc
+jd config
+jd up
+```
+
+`jd config` walks you through the template's variables and installs any missing tools. Once the
+cluster is up, you create and manage workspaces as in any **Jupyter K8s** deployment — see
+[Run Workspaces](../../getting-started/run-workspaces).
+
+## Learn more
+
+- [AWS EKS OIDC Template](https://jupyter-deploy.readthedocs.io/en/latest/templates/aws-eks-oidc-template/index.html)
+  — prerequisites, configuration, architecture, and the full user guide.

--- a/docs/source/integrations/deployment-templates/index.md
+++ b/docs/source/integrations/deployment-templates/index.md
@@ -1,0 +1,29 @@
+# Deployment Templates
+
+[`jupyter-deploy`](https://jupyter-deploy.readthedocs.io/en/latest/) (`jd`) is a vendor-neutral
+CLI that deploys interactive applications from scratch with the cloud provider and
+infrastructure-as-code engine of your choice.
+
+Each `jd` **template** bundles the infrastructure, configuration, and deployment logic into a
+project you drive with a few commands — `jd init`, `jd config`, `jd up`. Some templates provision
+a Kubernetes cluster and install **Jupyter K8s** along with a routing and identity layer, so `jd`
+becomes a turnkey way to stand up the operator and everything around it.
+
+Unlike a [guided chart](../guided-charts/index), which installs into a cluster you already run, a
+deployment template also creates the cluster and the surrounding cloud resources.
+
+## Templates that use Jupyter K8s
+
+| Template | Provider | Engine | What it deploys |
+|---|---|---|---|
+| [AWS EKS OIDC](aws-eks-oidc) | AWS (EKS) | Terraform | An EKS cluster, **Jupyter K8s**, and a guided HTTPS + GitHub OAuth (Dex) stack for multi-user **JupyterLab** workspaces. |
+
+See the [`jupyter-deploy` templates](https://jupyter-deploy.readthedocs.io/en/latest/templates/index.html)
+for the full list of officially supported templates. `jd init` also discovers and lets you choose
+templates interactively.
+
+```{toctree}
+:hidden:
+
+aws-eks-oidc
+```

--- a/docs/source/integrations/guided-charts/aws-charts.md
+++ b/docs/source/integrations/guided-charts/aws-charts.md
@@ -23,6 +23,11 @@ A full web-access stack for EKS clusters. Users access the applications running 
 | Package | `oci://ghcr.io/jupyter-infra/charts/jupyter-k8s-aws-oidc` |
 | Source | [charts/aws-oidc](https://github.com/jupyter-infra/jupyter-k8s-aws/tree/main/charts/aws-oidc) |
 
+```{tip}
+For a turnkey deployment that provisions an EKS cluster and installs this chart for you, see the
+{ref}`AWS EKS OIDC deployment template <template-aws-eks-oidc>`.
+```
+
 (chart-aws-hyperpod)=
 ## AWS-HyperPod
 

--- a/docs/source/integrations/index.md
+++ b/docs/source/integrations/index.md
@@ -34,10 +34,17 @@ The operator chart deploys the core controller, **Extension API** and CRDs, but 
 - **Integrate with cloud providers** — deploy cloud-specific plugins and resources (e.g. ALB ingress, SSM activations).
 - **Define access strategies** —integrate workspaces with the routing layer by creating access strategies.
 
+## Deployment templates
+
+For deployments that start from scratch — provisioning the cluster and surrounding cloud resources
+in addition to installing the operator — [`jupyter-deploy`](deployment-templates/index) offers
+turnkey templates that bundle **Jupyter K8s** with a routing and identity layer.
+
 ```{toctree}
 :hidden:
 
 web-ui/index
 plugins/index
 guided-charts/index
+deployment-templates/index
 ```


### PR DESCRIPTION
This PR adds documentation on how to use the `eks-oidc` Jupyter Deploy [template](https://jupyter-deploy.readthedocs.io/en/latest/templates/aws-eks-oidc-template/index.html) in the operator documentation.

Closes: #397 

### Testing
- built and served the docs

### Screenshots
**Getting started**
<img width="1455" height="805" alt="Screenshot 2026-06-25 at 6 49 47 PM" src="https://github.com/user-attachments/assets/1fbb869c-9b30-4f46-b2d5-909b4a397ce7" />

**Integration > Deployment Templates**
<img width="1438" height="913" alt="Screenshot 2026-06-25 at 6 50 25 PM" src="https://github.com/user-attachments/assets/631d635a-1bf6-4ba8-84f5-70db98fe98ea" />

**Integration > Deployment Templates > AWS EKS OIDC**
<img width="1420" height="935" alt="Screenshot 2026-06-25 at 6 51 15 PM" src="https://github.com/user-attachments/assets/66bf0649-0bf6-4c1e-88ec-d817fd649c17" />
