### PR TITLE
fix: doc inconsistencies, ws webhook validation-finalizer order

### DIFF
--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -34,6 +34,10 @@ Prefer active voice over passive. For example:
 - "The operator creates a Pod for each workspace" — correct
 - "A Pod is created for each workspace by the operator" — avoid
 
+### Style
+
+Do not use em-dashes (or spaced hyphens) as sentence punctuation in body text; rewrite with a comma, period, or parentheses.
+
 ### Headings
 
 Never embed bold (`**`), backticks (`` ` ``), or other inline formatting in

--- a/docs/source/dive-deeper/webhooks/workspace-validation.md
+++ b/docs/source/dive-deeper/webhooks/workspace-validation.md
@@ -7,7 +7,7 @@ The validating webhook enforces constraints on workspace create, update, and del
 | Check | Description |
 |-------|-------------|
 | Template constraints | Validates resources, images, storage size, and idle shutdown bounds against the template's constraint fields |
-| Access strategy namespace | Rejects references to access strategies outside the workspace's own namespace or the configured shared namespace |
+| Reference namespace scope | Rejects references to templates or access strategies outside the workspace's own namespace or the configured shared namespace |
 | Volume ownership | Rejects references to other workspaces' primary storage PVCs (secondary storage can be shared freely) |
 
 ## Bypassed for controller/admins
@@ -31,6 +31,12 @@ On `DELETE`, the webhook only checks ownership permission for `OwnerOnly` worksp
 
 ## Lazy constraint enforcement
 
-The webhook enforces template constraints at **admission time** — when a user creates or updates a workspace.
+The webhook enforces template constraints at **admission time**, when a user creates or updates a workspace.
 
 Changing constraints on a template does not immediately impact running workspaces. Instead, the template controller marks affected workspaces for compliance checking.
+
+## Protection finalizers on referenced resources
+
+The mutating webhook protects the resources a workspace depends on from being deleted while still in use. When a workspace references a template, the webhook stamps a `workspace.jupyter.org/template-protection` finalizer on that template; when it references an access strategy, it stamps a `workspace.jupyter.org/accessstrategy-protection` finalizer on that access strategy. These are added **lazily**, only once a referencing workspace exists. The webhook also rejects the workspace if the referenced resource does not exist.
+
+The webhook only adds finalizers; it never removes them. Removal stays with the template and access strategy controllers, which strip a protection finalizer once the last referring workspace (and, for access strategies, the last referring template) is gone.

--- a/docs/source/integrations/deployment-templates/aws-eks-oidc.md
+++ b/docs/source/integrations/deployment-templates/aws-eks-oidc.md
@@ -50,8 +50,8 @@ jd config
 jd up
 ```
 
-`jd config` walks you through the template's variables and installs any missing tools. Once the
-cluster is up, you create and manage workspaces as in any **Jupyter K8s** deployment — see
+`jd config` walks you through the template's variables and how to install any missing tools. Once the
+cluster is up, you create and manage workspaces as in any **Jupyter K8s** deployment. See
 [Run Workspaces](../../getting-started/run-workspaces).
 
 ## Learn more

--- a/internal/webhook/v1alpha1/template_validator.go
+++ b/internal/webhook/v1alpha1/template_validator.go
@@ -62,6 +62,18 @@ func (tv *TemplateValidator) validateTemplateNamespace(workspace *workspacev1alp
 	)
 }
 
+// ValidateNamespaceScope checks only that the workspace's templateRef targets an allowed
+// namespace, without fetching the template or evaluating its constraints. The mutating webhook
+// uses this to confirm the reference is in scope before stamping a protection finalizer on the
+// template, so a finalizer is never added to a template the workspace may not reference. This
+// mirrors how the template webhook namespace-checks an access strategy before finalizing it.
+func (tv *TemplateValidator) ValidateNamespaceScope(workspace *workspacev1alpha1.Workspace) error {
+	if workspace.Spec.TemplateRef == nil {
+		return nil
+	}
+	return tv.validateTemplateNamespace(workspace)
+}
+
 // ValidateCreateWorkspace validates workspace against template constraints
 func (tv *TemplateValidator) ValidateCreateWorkspace(ctx context.Context, workspace *workspacev1alpha1.Workspace) error {
 	if workspace.Spec.TemplateRef == nil {

--- a/internal/webhook/v1alpha1/template_validator_test.go
+++ b/internal/webhook/v1alpha1/template_validator_test.go
@@ -179,4 +179,91 @@ var _ = Describe("TemplateValidator", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
+
+	// ValidateNamespaceScope is the namespace-only gate the mutating webhook calls before stamping a
+	// protection finalizer. Unlike ValidateCreateWorkspace it must NOT fetch the template, so it
+	// enforces scope even when the template does not exist and never reports a missing-template error.
+	Context("ValidateNamespaceScope", func() {
+		It("should reject a disallowed namespace without fetching the template", func() {
+			// No template objects are seeded: the gate must reject on scope alone, never on existence.
+			validator := buildValidator("jupyter-k8s-shared")
+
+			workspace := &workspacev1alpha1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{Name: "ws", Namespace: "team-a"},
+				Spec: workspacev1alpha1.WorkspaceSpec{
+					TemplateRef: &workspacev1alpha1.TemplateRef{
+						Name:      "missing-template",
+						Namespace: "team-b",
+					},
+				},
+			}
+
+			err := validator.ValidateNamespaceScope(workspace)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("templateRef.namespace"))
+			Expect(err.Error()).To(ContainSubstring("team-b"))
+			// The error is about scope, not a missing template.
+			Expect(err.Error()).NotTo(ContainSubstring("not found"))
+		})
+
+		It("should allow an in-scope reference even when the template does not exist", func() {
+			// No template objects are seeded: an in-scope reference passes the gate; existence is the
+			// validating webhook's concern, not this gate's.
+			validator := buildValidator("jupyter-k8s-shared")
+
+			workspace := &workspacev1alpha1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{Name: "ws", Namespace: "team-a"},
+				Spec: workspacev1alpha1.WorkspaceSpec{
+					TemplateRef: &workspacev1alpha1.TemplateRef{
+						Name:      "missing-template",
+						Namespace: "team-a",
+					},
+				},
+			}
+
+			Expect(validator.ValidateNamespaceScope(workspace)).To(Succeed())
+		})
+
+		It("should allow the shared namespace", func() {
+			validator := buildValidator("jupyter-k8s-shared")
+
+			workspace := &workspacev1alpha1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{Name: "ws", Namespace: "team-a"},
+				Spec: workspacev1alpha1.WorkspaceSpec{
+					TemplateRef: &workspacev1alpha1.TemplateRef{
+						Name:      "shared-template",
+						Namespace: "jupyter-k8s-shared",
+					},
+				},
+			}
+
+			Expect(validator.ValidateNamespaceScope(workspace)).To(Succeed())
+		})
+
+		It("should allow an empty templateRef namespace", func() {
+			validator := buildValidator("jupyter-k8s-shared")
+
+			workspace := &workspacev1alpha1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{Name: "ws", Namespace: "team-a"},
+				Spec: workspacev1alpha1.WorkspaceSpec{
+					TemplateRef: &workspacev1alpha1.TemplateRef{
+						Name: "some-template",
+					},
+				},
+			}
+
+			Expect(validator.ValidateNamespaceScope(workspace)).To(Succeed())
+		})
+
+		It("should skip validation when workspace has no templateRef", func() {
+			validator := buildValidator("jupyter-k8s-shared")
+
+			workspace := &workspacev1alpha1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{Name: "ws", Namespace: "team-a"},
+				Spec:       workspacev1alpha1.WorkspaceSpec{},
+			}
+
+			Expect(validator.ValidateNamespaceScope(workspace)).To(Succeed())
+		})
+	})
 })

--- a/internal/webhook/v1alpha1/workspace_webhook.go
+++ b/internal/webhook/v1alpha1/workspace_webhook.go
@@ -230,6 +230,8 @@ func SetupWorkspaceWebhookWithManager(mgr ctrl.Manager, defaultTemplateNamespace
 			templateDefaulter:       templateDefaulter,
 			serviceAccountDefaulter: serviceAccountDefaulter,
 			templateGetter:          templateGetter,
+			templateValidator:       templateValidator,
+			accessStrategyValidator: accessStrategyValidator,
 			client:                  mgr.GetClient(),
 		}).
 		Complete()
@@ -246,6 +248,8 @@ type WorkspaceCustomDefaulter struct {
 	templateDefaulter       *TemplateDefaulter
 	serviceAccountDefaulter *ServiceAccountDefaulter
 	templateGetter          *TemplateGetter
+	templateValidator       *TemplateValidator
+	accessStrategyValidator *AccessStrategyValidator
 	client                  client.Client
 }
 
@@ -313,7 +317,21 @@ func (d *WorkspaceCustomDefaulter) Default(ctx context.Context, obj runtime.Obje
 	// Set workspace defaults for OwnershipType and AccessType
 	setWorkspaceSharingDefaults(workspace)
 
-	// Ensure template has finalizer to prevent deletion while in use
+	// Validate the namespace scope of BOTH referenced resources before stamping ANY protection
+	// finalizer. Stamping a finalizer is a side effect on another object that the API server will
+	// not roll back when this admission is later rejected. Reordering to validate-all then act-all
+	// ensures an out-of-scope access strategy reference can never leave a finalizer behind on the
+	// template (and vice versa). Existence and constraint checks still run in the validating webhook.
+	if workspace.Spec.TemplateRef != nil && workspace.Spec.TemplateRef.Name != "" {
+		if err := d.templateValidator.ValidateNamespaceScope(workspace); err != nil {
+			return err
+		}
+	}
+	if err := d.accessStrategyValidator.ValidateCreateWorkspace(workspace); err != nil {
+		return err
+	}
+
+	// Ensure template has finalizer to prevent deletion while in use.
 	if workspace.Spec.TemplateRef != nil && workspace.Spec.TemplateRef.Name != "" {
 		templateNamespace := workspaceutil.GetTemplateRefNamespace(workspace)
 		if err := ensureTemplateFinalizer(ctx, d.client, workspace.Spec.TemplateRef.Name, templateNamespace); err != nil {
@@ -322,7 +340,7 @@ func (d *WorkspaceCustomDefaulter) Default(ctx context.Context, obj runtime.Obje
 		}
 	}
 
-	// Ensure AccessStrategy has finalizer to prevent deletion while in use
+	// Ensure AccessStrategy has finalizer to prevent deletion while in use.
 	if err := ensureAccessStrategyFinalizer(ctx, d.client, workspace); err != nil {
 		workspacelog.Error(err, "Failed to add finalizer to AccessStrategy", "workspace", workspace.GetName())
 		return fmt.Errorf("failed to add finalizer to AccessStrategy: %w", err)

--- a/internal/webhook/v1alpha1/workspace_webhook_finalizer_test.go
+++ b/internal/webhook/v1alpha1/workspace_webhook_finalizer_test.go
@@ -11,6 +11,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -78,6 +79,7 @@ var _ = Describe("Lazy Finalizer Logic", func() {
 		ctx = context.Background()
 		scheme = runtime.NewScheme()
 		Expect(workspacev1alpha1.AddToScheme(scheme)).To(Succeed())
+		Expect(corev1.AddToScheme(scheme)).To(Succeed())
 	})
 
 	Context("ensureTemplateFinalizer", func() {
@@ -794,6 +796,171 @@ var _ = Describe("Lazy Finalizer Logic", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("failed to add finalizer to AccessStrategy"))
 			Expect(err.Error()).To(ContainSubstring("update failed"))
+		})
+	})
+
+	// The mutating webhook must namespace-check a reference before stamping a protection finalizer,
+	// so it never finalizes a template or access strategy the workspace is not allowed to reference
+	// (the validating webhook would reject such a workspace anyway). sharedNamespace is empty here,
+	// so any cross-namespace reference is out of scope.
+	Context("Default namespace-scope gate before finalizing", func() {
+		var defaulter WorkspaceCustomDefaulter
+
+		newDefaulter := func(k8sClient client.Client) WorkspaceCustomDefaulter {
+			return WorkspaceCustomDefaulter{
+				templateDefaulter:       NewTemplateDefaulter(k8sClient, ""),
+				serviceAccountDefaulter: NewServiceAccountDefaulter(k8sClient),
+				templateGetter:          NewTemplateGetter(k8sClient, ""),
+				templateValidator:       NewTemplateValidator(k8sClient, ""),
+				accessStrategyValidator: NewAccessStrategyValidator(""),
+				client:                  k8sClient,
+			}
+		}
+
+		It("should reject and not finalize a template in a disallowed namespace", func() {
+			template := &workspacev1alpha1.WorkspaceTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-template",
+					Namespace: "other-ns",
+				},
+				Spec: workspacev1alpha1.WorkspaceTemplateSpec{
+					DisplayName:  "Test Template",
+					DefaultImage: "test:latest",
+				},
+			}
+			workspace := &workspacev1alpha1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-workspace",
+					Namespace: "default",
+				},
+				Spec: workspacev1alpha1.WorkspaceSpec{
+					DisplayName:   "Test Workspace",
+					Image:         "test:latest",
+					DesiredStatus: "Running",
+					TemplateRef: &workspacev1alpha1.TemplateRef{
+						Name:      "test-template",
+						Namespace: "other-ns",
+					},
+				},
+			}
+
+			k8sClient = fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(template, workspace).
+				Build()
+			defaulter = newDefaulter(k8sClient)
+
+			err := defaulter.Default(ctx, workspace)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("templateRef.namespace"))
+
+			// Verify the finalizer was NOT stamped on the out-of-scope template
+			updatedTemplate := &workspacev1alpha1.WorkspaceTemplate{}
+			Expect(k8sClient.Get(ctx, client.ObjectKey{Name: "test-template", Namespace: "other-ns"}, updatedTemplate)).To(Succeed())
+			Expect(controllerutil.ContainsFinalizer(updatedTemplate, workspaceutil.TemplateFinalizerName)).To(BeFalse())
+		})
+
+		It("should reject and not finalize an access strategy in a disallowed namespace", func() {
+			accessStrategy := &workspacev1alpha1.WorkspaceAccessStrategy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-strategy",
+					Namespace: "other-ns",
+				},
+				Spec: workspacev1alpha1.WorkspaceAccessStrategySpec{
+					DisplayName: "Test Strategy",
+				},
+			}
+			workspace := &workspacev1alpha1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-workspace",
+					Namespace: "default",
+				},
+				Spec: workspacev1alpha1.WorkspaceSpec{
+					DisplayName:   "Test Workspace",
+					Image:         "test:latest",
+					DesiredStatus: "Running",
+					AccessStrategy: &workspacev1alpha1.AccessStrategyRef{
+						Name:      "test-strategy",
+						Namespace: "other-ns",
+					},
+				},
+			}
+
+			k8sClient = fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(accessStrategy, workspace).
+				Build()
+			defaulter = newDefaulter(k8sClient)
+
+			err := defaulter.Default(ctx, workspace)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("accessStrategy.namespace"))
+
+			// Verify the finalizer was NOT stamped on the out-of-scope access strategy
+			updatedStrategy := &workspacev1alpha1.WorkspaceAccessStrategy{}
+			Expect(k8sClient.Get(ctx, client.ObjectKey{Name: "test-strategy", Namespace: "other-ns"}, updatedStrategy)).To(Succeed())
+			Expect(controllerutil.ContainsFinalizer(updatedStrategy, workspaceutil.AccessStrategyFinalizerName)).To(BeFalse())
+		})
+
+		It("should not finalize an in-scope template when the access strategy namespace is disallowed", func() {
+			// Both references are present: the template is in-scope (workspace's own namespace) but
+			// the access strategy is out of scope. Because both namespace checks run before any
+			// finalizer is stamped, the rejected access strategy must not leave a finalizer behind
+			// on the otherwise-valid template.
+			template := &workspacev1alpha1.WorkspaceTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-template",
+					Namespace: "default",
+				},
+				Spec: workspacev1alpha1.WorkspaceTemplateSpec{
+					DisplayName:  "Test Template",
+					DefaultImage: "test:latest",
+				},
+			}
+			accessStrategy := &workspacev1alpha1.WorkspaceAccessStrategy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-strategy",
+					Namespace: "other-ns",
+				},
+				Spec: workspacev1alpha1.WorkspaceAccessStrategySpec{
+					DisplayName: "Test Strategy",
+				},
+			}
+			workspace := &workspacev1alpha1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-workspace",
+					Namespace: "default",
+				},
+				Spec: workspacev1alpha1.WorkspaceSpec{
+					DisplayName:   "Test Workspace",
+					Image:         "test:latest",
+					DesiredStatus: "Running",
+					TemplateRef: &workspacev1alpha1.TemplateRef{
+						Name:      "test-template",
+						Namespace: "default",
+					},
+					AccessStrategy: &workspacev1alpha1.AccessStrategyRef{
+						Name:      "test-strategy",
+						Namespace: "other-ns",
+					},
+				},
+			}
+
+			k8sClient = fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(template, accessStrategy, workspace).
+				Build()
+			defaulter = newDefaulter(k8sClient)
+
+			err := defaulter.Default(ctx, workspace)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("accessStrategy.namespace"))
+
+			// The in-scope template must NOT carry a protection finalizer: the access strategy
+			// namespace check runs before any finalizer is stamped.
+			updatedTemplate := &workspacev1alpha1.WorkspaceTemplate{}
+			Expect(k8sClient.Get(ctx, client.ObjectKey{Name: "test-template", Namespace: "default"}, updatedTemplate)).To(Succeed())
+			Expect(controllerutil.ContainsFinalizer(updatedTemplate, workspaceutil.TemplateFinalizerName)).To(BeFalse())
 		})
 	})
 })

--- a/internal/webhook/v1alpha1/workspace_webhook_test.go
+++ b/internal/webhook/v1alpha1/workspace_webhook_test.go
@@ -71,6 +71,8 @@ var _ = Describe("Workspace Webhook", func() {
 			templateDefaulter:       NewTemplateDefaulter(mockClient, ""),
 			serviceAccountDefaulter: NewServiceAccountDefaulter(mockClient),
 			templateGetter:          NewTemplateGetter(mockClient, ""),
+			templateValidator:       NewTemplateValidator(mockClient, ""),
+			accessStrategyValidator: NewAccessStrategyValidator(""),
 			client:                  mockClient, // Add client field for testing
 		}
 		validator = WorkspaceCustomValidator{


### PR DESCRIPTION
This PR a/ fixes doc description of JD behavior following comments on #426, b/ expands documentation on workspace webhook, c/ fixes validation-finalizer order in workspace admission webhook to ensure validation is performed _before_ adding a finalizer.

### Testing
- rely on e2e tests