### PR TITLE
fix: use ClusterRole for extension-apiserver-authentication access

### DIFF
--- a/config/rbac/extension_api_auth_binding.yaml
+++ b/config/rbac/extension_api_auth_binding.yaml
@@ -1,16 +1,27 @@
-## This RoleBinding is applied separately from kustomize because it must live
-## in kube-system, and kustomize's global namespace transform would override that.
-## See Makefile deploy/undeploy targets.
+## ClusterRole/ClusterRoleBinding for reading extension-apiserver-authentication
+## configmap. Uses cluster-scoped resources instead of a kube-system RoleBinding
+## for compatibility with environments that lack cross-namespace permissions
+## (e.g., EKS addon framework).
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRole
 metadata:
-  name: jupyter-k8s-extension-api-auth
-  namespace: kube-system
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: extension-apiserver-authentication-reader
+  name: jupyter-k8s-read-auth-configmap
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["extension-apiserver-authentication"]
+    verbs: ["get", "list", "watch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: jupyter-k8s-read-auth-configmap
 subjects:
-- kind: ServiceAccount
-  name: jupyter-k8s-controller-manager
-  namespace: jupyter-k8s-system
+  - kind: ServiceAccount
+    name: jupyter-k8s-controller-manager
+    namespace: jupyter-k8s-system
+roleRef:
+  kind: ClusterRole
+  name: jupyter-k8s-read-auth-configmap
+  apiGroup: rbac.authorization.k8s.io

--- a/dist/chart/templates/rbac/extension-api-auth-binding.yaml
+++ b/dist/chart/templates/rbac/extension-api-auth-binding.yaml
@@ -1,20 +1,34 @@
 {{- if .Values.extensionApi.enable }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/name: {{ include "jupyter-k8s.name" . }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-  name: jupyter-k8s-extension-api-auth
-  namespace: kube-system
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: extension-apiserver-authentication-reader
+  name: {{ include "jupyter-k8s.resourceName" (dict "suffix" "read-auth-configmap" "context" $) }}
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["extension-apiserver-authentication"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "jupyter-k8s.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "jupyter-k8s.resourceName" (dict "suffix" "read-auth-configmap" "context" $) }}
 subjects:
-- kind: ServiceAccount
-  name: {{ include "jupyter-k8s.resourceName" (dict "suffix" "controller-manager" "context" $) }}
-  namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: {{ include "jupyter-k8s.resourceName" (dict "suffix" "controller-manager" "context" $) }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "jupyter-k8s.resourceName" (dict "suffix" "read-auth-configmap" "context" $) }}
+  apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/hack/apply-helm-patches.sh
+++ b/hack/apply-helm-patches.sh
@@ -325,28 +325,45 @@ if [ -f "${APISERVICE_YAML}" ]; then
     sed -i 's|{{ .Release.Namespace }}/jupyter-k8s-extension-server-cert|{{ .Release.Namespace }}/{{ include "jupyter-k8s.resourceName" (dict "suffix" "extension-server-cert" "context" $) }}|' "${APISERVICE_YAML}"
 fi
 
-# --- Create extension API auth RoleBinding in kube-system ---
-echo "Creating extension API auth RoleBinding template..."
+# --- Create extension API auth ClusterRole/ClusterRoleBinding ---
+# Uses cluster-scoped resources instead of a kube-system RoleBinding for
+# compatibility with environments that lack cross-namespace permissions
+# (e.g., EKS addon framework).
+echo "Creating extension API auth ClusterRole/ClusterRoleBinding template..."
 cat > "${CHART_DIR}/templates/rbac/extension-api-auth-binding.yaml" << 'AUTHEOF'
 {{- if .Values.extensionApi.enable }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/name: {{ include "jupyter-k8s.name" . }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-  name: jupyter-k8s-extension-api-auth
-  namespace: kube-system
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: extension-apiserver-authentication-reader
+  name: {{ include "jupyter-k8s.resourceName" (dict "suffix" "read-auth-configmap" "context" $) }}
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["extension-apiserver-authentication"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "jupyter-k8s.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "jupyter-k8s.resourceName" (dict "suffix" "read-auth-configmap" "context" $) }}
 subjects:
-- kind: ServiceAccount
-  name: {{ include "jupyter-k8s.resourceName" (dict "suffix" "controller-manager" "context" $) }}
-  namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: {{ include "jupyter-k8s.resourceName" (dict "suffix" "controller-manager" "context" $) }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "jupyter-k8s.resourceName" (dict "suffix" "read-auth-configmap" "context" $) }}
+  apiGroup: rbac.authorization.k8s.io
 {{- end }}
 AUTHEOF
 

--- a/test/helm/crd-only/extension_api_auth_test.go
+++ b/test/helm/crd-only/extension_api_auth_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package crdonly_test
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Extension API Auth RBAC", func() {
+
+	It("should use ClusterRole and ClusterRoleBinding instead of kube-system RoleBinding", func() {
+		rootDir, err := filepath.Abs("../../..")
+		Expect(err).NotTo(HaveOccurred())
+
+		templatePath := filepath.Join(rootDir, "dist", "chart", "templates", "rbac", "extension-api-auth-binding.yaml")
+		data, err := os.ReadFile(templatePath)
+		Expect(err).NotTo(HaveOccurred(), "Failed to read extension-api-auth-binding.yaml")
+
+		content := string(data)
+
+		By("not creating resources in kube-system namespace")
+		Expect(content).NotTo(ContainSubstring("namespace: kube-system"),
+			"extension-api-auth-binding should not create resources in kube-system; "+
+				"EKS addon framework cannot create cross-namespace resources")
+
+		By("using ClusterRole for configmap access")
+		Expect(content).To(ContainSubstring("kind: ClusterRole"),
+			"should use ClusterRole instead of referencing kube-system Role")
+
+		By("using ClusterRoleBinding")
+		Expect(content).To(ContainSubstring("kind: ClusterRoleBinding"),
+			"should use ClusterRoleBinding instead of RoleBinding in kube-system")
+
+		By("granting read access to extension-apiserver-authentication configmap")
+		Expect(content).To(ContainSubstring("extension-apiserver-authentication"),
+			"should reference the extension-apiserver-authentication configmap")
+
+		By("being gated on extensionApi.enable")
+		Expect(content).To(ContainSubstring(".Values.extensionApi.enable"),
+			"should be conditional on extensionApi.enable")
+	})
+})


### PR DESCRIPTION
**Description**

Replace the `kube-system` RoleBinding with a ClusterRole/ClusterRoleBinding for `extension-apiserver-authentication` configmap access.

**Motivation**

The controller reads the extension-apiserver-authentication configmap from kube-system at startup — both the aggregated API server `(RecommendedOptions.ApplyTo())` and the secure metrics server require it. Without access, the controller-manager crashes on startup with:
- configmaps "extension-apiserver-authentication" is forbidden: User
- "system:serviceaccount:jupyter-k8s-system:jupyter-k8s-controller-manager"
- cannot get resource "configmaps" in API group "" in the namespace "kube-system"

The current fix uses a RoleBinding in kube-system, which requires the installer to have cross-namespace permissions. This fails for any namespace-scoped deployment tool — EKS addons, ArgoCD with restricted RBAC, OLM, fleet managers, etc.
A ClusterRole/ClusterRoleBinding with resourceNames: ["extension-apiserver-authentication"] grants the same least-privilege access using cluster-scoped resources, without assuming the installer can write to kube-system. This is compatible with all deployment scenarios.

**Testing Done**
- Added helm test verifying no kube-system references and ClusterRole/ ClusterRoleBinding presence
- Confirmed on two fresh HyperPod quick-create clusters that the RoleBinding approach fails and ClusterRole approach succeeds
- helm lint passes

**Backwards Compatibility Criteria**
Same effective permissions (read configmaps/extension-apiserver-authentication). Existing clusters with the old RoleBinding will continue working; new installs will use the ClusterRole approach. The old RoleBinding becomes orphaned on upgrade but is harmless (read-only permission).