### PR TITLE
fix(extensionapi): disable admission policy plugins that require K8s 1.32+

### DIFF
--- a/internal/extensionapi/server.go
+++ b/internal/extensionapi/server.go
@@ -223,6 +223,17 @@ func createRecommendedOptions(config *ExtensionConfig) *genericoptions.Recommend
 	// turn off advanced priority and fairness features that require extra permissions
 	recommendedOptions.Features.EnablePriorityAndFairness = false
 
+	// Disable admission policy plugins that require K8s 1.32+ APIs.
+	// The extension API server serves custom endpoints (JWT tokens, workspace
+	// connections, bearer token reviews) and does not need admission policy
+	// evaluation. These plugins start informers for MutatingAdmissionPolicy
+	// and ValidatingAdmissionPolicy resources which don't exist on clusters
+	// running K8s < 1.32, causing infinite error loops in the reflector.
+	recommendedOptions.Admission.DisablePlugins = []string{
+		"MutatingAdmissionPolicy",
+		"ValidatingAdmissionPolicy",
+	}
+
 	return recommendedOptions
 }
 


### PR DESCRIPTION
## Summary

Disables `MutatingAdmissionPolicy` and `ValidatingAdmissionPolicy` admission plugins in the extension API server.

## Problem

After the Go 1.26 upgrade (#430), `k8s.io/apiserver` was bumped from v0.34.0 to v0.36.2. In v0.36.2, the `MutatingAdmissionPolicy` plugin is included in the default `RecommendedPluginOrder`. This plugin starts informers that list/watch `MutatingAdmissionPolicy` and `MutatingAdmissionPolicyBinding` resources from `admissionregistration.k8s.io/v1`.

On clusters running Kubernetes < 1.32 (where these resources do not exist), this causes infinite "the server could not find the requested resource" error loops in the reflector that spam controller logs.

## Root Cause

`internal/extensionapi/server.go` uses `genericoptions.NewRecommendedOptions()` → `ApplyTo()` which enables all default admission plugins. The extension API server only serves custom endpoints (JWT tokens, workspace connections, bearer token reviews) and does not need admission policy evaluation.

## Fix

Explicitly disable the two admission policy plugins:
```go
recommendedOptions.Admission.DisablePlugins = []string{
    "MutatingAdmissionPolicy",
    "ValidatingAdmissionPolicy",
}
```

This follows the same pattern as the existing `EnablePriorityAndFairness = false` line above it.

## Testing

- `go build ./...` passes
- Verified controller starts without MutatingAdmissionPolicy/MutatingAdmissionPolicyBinding reflector errors on K8s 1.30 cluster

## Impact

- Eliminates infinite error loop on K8s < 1.32 clusters
- Eliminates need for cluster-scoped ConfigMap list/watch permissions (used by admission plugins for parameter references)
- No functional change — these plugins were not serving any purpose for the extension API server

## For Context
The extension API server in jupyter-k8s serves:
- /healthz / readiness probes
- WorkspaceConnection resources
- ConnectionAccessReview resources
- BearerTokenReview resources
- These are all custom endpoints. It doesn't serve any resources that need admission policy evaluation — no one is submitting objects to it that should be intercepted by a MutatingAdmissionPolicy or ValidatingAdmissionPolicy.
- The admission plugins exist in RecommendedOptions because [k8s.io/apiserver](https://github.com/kubernetes/apiserver/blob/780b96ce5d0123503c4f00d16ca1ee855da23abb/pkg/server/options/recommended.go#L55) is designed for full-blown API servers (like kube-apiserver itself) where  incoming requests need to pass through admission. For a lightweight extension API server like this one, they're dead weight that just starts unnecessary informers