### PR TITLE
fix: idle shutdown enforcement

### DIFF
--- a/docs/source/concepts/templates/bounds.md
+++ b/docs/source/concepts/templates/bounds.md
@@ -60,6 +60,12 @@ spec:
     maxIdleTimeoutInMinutes: 480
 ```
 
+`allow` controls whether workspace users may disable idle shutdown, and whether the `idleShutdown` field of a workspace may diverge from the template's defined defaults. It matters because the `idleShutdown.detection` settings are deeply tied to the application running in the workspace. Misconfiguring the `idleShutdown.detection` field of a workspace may prevent the operator from shutting down idle workspaces.
+
+The `minIdleTimeoutInMinutes` and `maxIdleTimeoutInMinutes` bounds are independent of `allow`: they cap `idleShutdown.idleTimeoutInMinutes` on any workspace with idle shutdown *enabled*, whether or not overrides are allowed. So even with `allow: false`, you can still permit users to tune the timeout within those bounds. If `allow: false` and `minIdleTimeoutInMinutes` is omitted, the enforced minimum falls back to the template's `spec.defaultIdleShutdown.idleTimeoutInMinutes`; `maxIdleTimeoutInMinutes` behaves the same way. When `allow: true`, an omitted bound simply leaves that side unbounded.
+
+A template with `allow: false` must define `defaultIdleShutdown`, or the template webhook rejects it.
+
 ## Environment and label requirements
 
 Templates can require specific environment variables or labels with regex validation:

--- a/docs/source/dive-deeper/webhooks/workspace-validation.md
+++ b/docs/source/dive-deeper/webhooks/workspace-validation.md
@@ -29,6 +29,10 @@ When a workspace has `ownershipType: OwnerOnly`:
 
 On `DELETE`, the webhook only checks ownership permission for `OwnerOnly` workspaces. All other deletes pass through (RBAC is the primary guard).
 
+## Idle shutdown override enforcement
+
+When the template sets `idleShutdownOverrides.allow: false`, the webhook requires the workspace's `idleShutdown` to match the template's `defaultIdleShutdown` on every field except `idleTimeoutInMinutes`. Declared `minIdleTimeoutInMinutes`/`maxIdleTimeoutInMinutes` bounds are enforced on any *enabled* idle shutdown regardless of `allow`; a disabled idle shutdown has no timeout to bound. See [idle shutdown bounds](../../concepts/templates/bounds.md) for the policy semantics.
+
 ## Lazy constraint enforcement
 
 The webhook enforces template constraints at **admission time**, when a user creates or updates a workspace.

--- a/internal/webhook/v1alpha1/idle_shutdown_validator.go
+++ b/internal/webhook/v1alpha1/idle_shutdown_validator.go
@@ -1,0 +1,143 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package v1alpha1
+
+import (
+	"fmt"
+	"reflect"
+
+	workspacev1alpha1 "github.com/jupyter-infra/jupyter-k8s/api/v1alpha1"
+)
+
+// validateIdleShutdownOverrides enforces the template's idleShutdownOverrides policy.
+//
+// The policy has two orthogonal knobs:
+//
+//   - Allow governs the STRUCTURE. When Allow=false, the workspace may not deviate from the
+//     template's defaultIdleShutdown: every field must match the default EXCEPT
+//     idleTimeoutInMinutes. When Allow is unset or true (the kubebuilder default), the
+//     workspace may freely choose its idle shutdown config, including disabling it.
+//
+//   - MinIdleTimeoutInMinutes/MaxIdleTimeoutInMinutes bound the timeout VALUE. Declared bounds
+//     are enforced whenever the workspace has idle shutdown enabled, regardless of Allow — so
+//     an admin can permit overrides yet still cap the timeout.
+//
+// Missing-bound fallback differs by intent:
+//
+//   - Allow=false (locked window): an unset bound falls back to the default timeout, pinning
+//     the unspecified side to the default ("the only wiggle room is what I explicitly granted").
+//   - Allow=true/unset (permissive): an unset bound means unbounded on that side.
+//
+// The structural lock requires a defaultIdleShutdown to compare against; without one there is
+// no baseline to match, so only the timeout bounds apply.
+func validateIdleShutdownOverrides(workspace *workspacev1alpha1.Workspace, template *workspacev1alpha1.WorkspaceTemplate) []TemplateViolation {
+	policy := template.Spec.IdleShutdownOverrides
+	if policy == nil {
+		return nil
+	}
+
+	allowOverride := policy.Allow == nil || *policy.Allow
+	def := template.Spec.DefaultIdleShutdown
+	ws := workspace.Spec.IdleShutdown
+
+	var violations []TemplateViolation
+
+	// Structural lock: when overrides are not allowed, the workspace must match the template
+	// default on every field except the timeout. Requires a default baseline to compare against.
+	if !allowOverride && def != nil {
+		if ws == nil {
+			// Overrides are not allowed but the workspace carries no idle shutdown config,
+			// which drops the template's policy entirely.
+			return []TemplateViolation{{
+				Type:    ViolationTypeIdleShutdownOverrideNotAllowed,
+				Field:   "spec.idleShutdown",
+				Message: fmt.Sprintf("Template '%s' does not allow overriding idle shutdown; idleShutdown must match the template default", template.Name),
+				Allowed: "match template defaultIdleShutdown",
+				Actual:  "unset",
+			}}
+		}
+
+		// Compare copies with the timeout zeroed so a permitted timeout difference doesn't trip
+		// the equality check.
+		wsCopy := ws.DeepCopy()
+		defCopy := def.DeepCopy()
+		wsCopy.IdleTimeoutInMinutes = 0
+		defCopy.IdleTimeoutInMinutes = 0
+		if !reflect.DeepEqual(wsCopy, defCopy) {
+			violations = append(violations, TemplateViolation{
+				Type:    ViolationTypeIdleShutdownOverrideNotAllowed,
+				Field:   "spec.idleShutdown",
+				Message: fmt.Sprintf("Template '%s' does not allow overriding idle shutdown; only idleTimeoutInMinutes may differ from the template default", template.Name),
+				Allowed: "match template defaultIdleShutdown (except idleTimeoutInMinutes)",
+				Actual:  "differs from template default",
+			})
+		}
+	}
+
+	// Timeout bounds apply whenever the workspace has idle shutdown enabled: a disabled or absent
+	// idle shutdown has no active timeout to bound.
+	if ws != nil && ws.Enabled {
+		if violation := validateIdleTimeoutBounds(ws.IdleTimeoutInMinutes, policy, def, allowOverride, template.Name); violation != nil {
+			violations = append(violations, *violation)
+		}
+	}
+
+	return violations
+}
+
+// validateIdleTimeoutBounds checks the workspace idle timeout against the policy's declared
+// bounds, applying the missing-bound fallback appropriate to the Allow setting. Returns nil when
+// the timeout is within bounds (or no bound applies to the relevant side).
+func validateIdleTimeoutBounds(
+	timeout int,
+	policy *workspacev1alpha1.IdleShutdownOverridePolicy,
+	def *workspacev1alpha1.IdleShutdownSpec,
+	allowOverride bool,
+	templateName string,
+) *TemplateViolation {
+	minTimeout, hasMin := 0, false
+	if policy.MinIdleTimeoutInMinutes != nil {
+		minTimeout, hasMin = *policy.MinIdleTimeoutInMinutes, true
+	}
+	maxTimeout, hasMax := 0, false
+	if policy.MaxIdleTimeoutInMinutes != nil {
+		maxTimeout, hasMax = *policy.MaxIdleTimeoutInMinutes, true
+	}
+
+	// When overrides are locked, an unset bound falls back to the default timeout, pinning the
+	// unspecified side to the default. When overrides are allowed, an unset bound stays unbounded.
+	if !allowOverride && def != nil {
+		if !hasMin {
+			minTimeout, hasMin = def.IdleTimeoutInMinutes, true
+		}
+		if !hasMax {
+			maxTimeout, hasMax = def.IdleTimeoutInMinutes, true
+		}
+	}
+
+	belowMin := hasMin && timeout < minTimeout
+	aboveMax := hasMax && timeout > maxTimeout
+	if !belowMin && !aboveMax {
+		return nil
+	}
+
+	minStr := "unbounded"
+	if hasMin {
+		minStr = fmt.Sprintf("%d", minTimeout)
+	}
+	maxStr := "unbounded"
+	if hasMax {
+		maxStr = fmt.Sprintf("%d", maxTimeout)
+	}
+
+	return &TemplateViolation{
+		Type:    ViolationTypeIdleShutdownTimeoutOutOfBounds,
+		Field:   "spec.idleShutdown.idleTimeoutInMinutes",
+		Message: fmt.Sprintf("Idle timeout %d minutes is outside the range [%s, %s] allowed by template '%s'", timeout, minStr, maxStr, templateName),
+		Allowed: fmt.Sprintf("min: %s, max: %s", minStr, maxStr),
+		Actual:  fmt.Sprintf("%d", timeout),
+	}
+}

--- a/internal/webhook/v1alpha1/idle_shutdown_validator_test.go
+++ b/internal/webhook/v1alpha1/idle_shutdown_validator_test.go
@@ -1,0 +1,244 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package v1alpha1
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	workspacev1alpha1 "github.com/jupyter-infra/jupyter-k8s/api/v1alpha1"
+)
+
+// transportPodExecValue is the non-default detection transport used to represent a divergence
+// from the template default in idle shutdown override tests.
+const transportPodExecValue = "podExec"
+
+var _ = Describe("Idle Shutdown Validator", func() {
+	var (
+		template  *workspacev1alpha1.WorkspaceTemplate
+		workspace *workspacev1alpha1.Workspace
+	)
+
+	boolPtr := func(b bool) *bool { return &b }
+	intPtr := func(i int) *int { return &i }
+
+	// defaultIdleShutdown returns a fresh idle shutdown config matching the template default.
+	defaultIdleShutdown := func() *workspacev1alpha1.IdleShutdownSpec {
+		return &workspacev1alpha1.IdleShutdownSpec{
+			Enabled:              true,
+			IdleTimeoutInMinutes: 30,
+			Detection: workspacev1alpha1.IdleDetectionSpec{
+				HTTPGet: &workspacev1alpha1.IdleHTTPGetAction{
+					Transport: "network",
+				},
+			},
+		}
+	}
+
+	BeforeEach(func() {
+		template = &workspacev1alpha1.WorkspaceTemplate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testTemplateName,
+				Namespace: testDefaultNamespace,
+			},
+			Spec: workspacev1alpha1.WorkspaceTemplateSpec{
+				DefaultIdleShutdown: defaultIdleShutdown(),
+				IdleShutdownOverrides: &workspacev1alpha1.IdleShutdownOverridePolicy{
+					Allow:                   boolPtr(false),
+					MinIdleTimeoutInMinutes: intPtr(15),
+					MaxIdleTimeoutInMinutes: intPtr(60),
+				},
+			},
+		}
+		workspace = &workspacev1alpha1.Workspace{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-ws", Namespace: testDefaultNamespace},
+			Spec: workspacev1alpha1.WorkspaceSpec{
+				IdleShutdown: defaultIdleShutdown(),
+			},
+		}
+	})
+
+	Context("when the policy is absent", func() {
+		It("should not enforce anything when the policy is nil", func() {
+			template.Spec.IdleShutdownOverrides = nil
+			workspace.Spec.IdleShutdown.Enabled = false
+			workspace.Spec.IdleShutdown.IdleTimeoutInMinutes = 999
+			Expect(validateIdleShutdownOverrides(workspace, template)).To(BeEmpty())
+		})
+	})
+
+	Context("when overrides are permitted (Allow true or unset)", func() {
+		BeforeEach(func() {
+			template.Spec.IdleShutdownOverrides.Allow = boolPtr(true)
+		})
+
+		It("should not enforce structure: disabling and diverging is allowed", func() {
+			workspace.Spec.IdleShutdown.Enabled = false
+			workspace.Spec.IdleShutdown.Detection.HTTPGet.Transport = transportPodExecValue
+			workspace.Spec.IdleShutdown.IdleTimeoutInMinutes = 999
+			Expect(validateIdleShutdownOverrides(workspace, template)).To(BeEmpty())
+		})
+
+		It("should treat unset Allow the same as true", func() {
+			template.Spec.IdleShutdownOverrides.Allow = nil
+			workspace.Spec.IdleShutdown.Enabled = false
+			workspace.Spec.IdleShutdown.Detection.HTTPGet.Transport = transportPodExecValue
+			Expect(validateIdleShutdownOverrides(workspace, template)).To(BeEmpty())
+		})
+
+		It("should still enforce declared timeout bounds when enabled", func() {
+			workspace.Spec.IdleShutdown.IdleTimeoutInMinutes = 45
+			Expect(validateIdleShutdownOverrides(workspace, template)).To(BeEmpty())
+
+			workspace.Spec.IdleShutdown.IdleTimeoutInMinutes = 5
+			violations := validateIdleShutdownOverrides(workspace, template)
+			Expect(violations).To(HaveLen(1))
+			Expect(violations[0].Type).To(Equal(ViolationTypeIdleShutdownTimeoutOutOfBounds))
+
+			workspace.Spec.IdleShutdown.IdleTimeoutInMinutes = 120
+			violations = validateIdleShutdownOverrides(workspace, template)
+			Expect(violations).To(HaveLen(1))
+			Expect(violations[0].Type).To(Equal(ViolationTypeIdleShutdownTimeoutOutOfBounds))
+		})
+
+		It("should skip timeout bounds when idle shutdown is disabled", func() {
+			workspace.Spec.IdleShutdown.Enabled = false
+			workspace.Spec.IdleShutdown.IdleTimeoutInMinutes = 999
+			Expect(validateIdleShutdownOverrides(workspace, template)).To(BeEmpty())
+		})
+
+		It("should leave a side unbounded when its bound is unset", func() {
+			template.Spec.IdleShutdownOverrides.MinIdleTimeoutInMinutes = nil
+			// No lower bound: a tiny timeout is fine; the upper bound still applies.
+			workspace.Spec.IdleShutdown.IdleTimeoutInMinutes = 1
+			Expect(validateIdleShutdownOverrides(workspace, template)).To(BeEmpty())
+
+			workspace.Spec.IdleShutdown.IdleTimeoutInMinutes = 120
+			Expect(validateIdleShutdownOverrides(workspace, template)).To(HaveLen(1))
+		})
+
+		It("should enforce nothing on the timeout when no bounds are declared", func() {
+			template.Spec.IdleShutdownOverrides.MinIdleTimeoutInMinutes = nil
+			template.Spec.IdleShutdownOverrides.MaxIdleTimeoutInMinutes = nil
+			workspace.Spec.IdleShutdown.IdleTimeoutInMinutes = 99999
+			Expect(validateIdleShutdownOverrides(workspace, template)).To(BeEmpty())
+		})
+	})
+
+	Context("when overrides are not allowed but there is no template default", func() {
+		It("should skip the structural lock but still enforce timeout bounds", func() {
+			template.Spec.DefaultIdleShutdown = nil
+			// Structure can't be checked without a baseline, but declared bounds still apply.
+			workspace.Spec.IdleShutdown.Enabled = false
+			workspace.Spec.IdleShutdown.Detection.HTTPGet.Transport = transportPodExecValue
+			workspace.Spec.IdleShutdown.IdleTimeoutInMinutes = 45
+			Expect(validateIdleShutdownOverrides(workspace, template)).To(BeEmpty())
+
+			workspace.Spec.IdleShutdown.Enabled = true
+			workspace.Spec.IdleShutdown.IdleTimeoutInMinutes = 120
+			violations := validateIdleShutdownOverrides(workspace, template)
+			Expect(violations).To(HaveLen(1))
+			Expect(violations[0].Type).To(Equal(ViolationTypeIdleShutdownTimeoutOutOfBounds))
+		})
+	})
+
+	Context("when overrides are not allowed", func() {
+		It("should allow a workspace matching the default with an in-bounds timeout", func() {
+			workspace.Spec.IdleShutdown.IdleTimeoutInMinutes = 45
+			Expect(validateIdleShutdownOverrides(workspace, template)).To(BeEmpty())
+		})
+
+		It("should allow a timeout equal to the default when it also equals bounds edges", func() {
+			workspace.Spec.IdleShutdown.IdleTimeoutInMinutes = 15
+			Expect(validateIdleShutdownOverrides(workspace, template)).To(BeEmpty())
+			workspace.Spec.IdleShutdown.IdleTimeoutInMinutes = 60
+			Expect(validateIdleShutdownOverrides(workspace, template)).To(BeEmpty())
+		})
+
+		It("should reject a workspace with no idle shutdown config", func() {
+			workspace.Spec.IdleShutdown = nil
+			violations := validateIdleShutdownOverrides(workspace, template)
+			Expect(violations).To(HaveLen(1))
+			Expect(violations[0].Type).To(Equal(ViolationTypeIdleShutdownOverrideNotAllowed))
+			Expect(violations[0].Field).To(Equal("spec.idleShutdown"))
+		})
+
+		It("should reject disabling idle shutdown", func() {
+			workspace.Spec.IdleShutdown.Enabled = false
+			violations := validateIdleShutdownOverrides(workspace, template)
+			Expect(violations).To(HaveLen(1))
+			Expect(violations[0].Type).To(Equal(ViolationTypeIdleShutdownOverrideNotAllowed))
+		})
+
+		It("should reject changing a non-timeout field like detection transport", func() {
+			workspace.Spec.IdleShutdown.Detection.HTTPGet.Transport = transportPodExecValue
+			violations := validateIdleShutdownOverrides(workspace, template)
+			Expect(violations).To(HaveLen(1))
+			Expect(violations[0].Type).To(Equal(ViolationTypeIdleShutdownOverrideNotAllowed))
+		})
+
+		It("should reject a timeout below the minimum", func() {
+			workspace.Spec.IdleShutdown.IdleTimeoutInMinutes = 5
+			violations := validateIdleShutdownOverrides(workspace, template)
+			Expect(violations).To(HaveLen(1))
+			Expect(violations[0].Type).To(Equal(ViolationTypeIdleShutdownTimeoutOutOfBounds))
+			Expect(violations[0].Field).To(Equal("spec.idleShutdown.idleTimeoutInMinutes"))
+		})
+
+		It("should reject a timeout above the maximum", func() {
+			workspace.Spec.IdleShutdown.IdleTimeoutInMinutes = 120
+			violations := validateIdleShutdownOverrides(workspace, template)
+			Expect(violations).To(HaveLen(1))
+			Expect(violations[0].Type).To(Equal(ViolationTypeIdleShutdownTimeoutOutOfBounds))
+		})
+
+		It("should report both an override and an out-of-bounds violation", func() {
+			// Enabled (so bounds apply) but a non-timeout field diverges and the timeout is
+			// out of range: both the structural lock and the bounds check fire.
+			workspace.Spec.IdleShutdown.Detection.HTTPGet.Transport = transportPodExecValue
+			workspace.Spec.IdleShutdown.IdleTimeoutInMinutes = 120
+			violations := validateIdleShutdownOverrides(workspace, template)
+			Expect(violations).To(HaveLen(2))
+		})
+	})
+
+	Context("bound fallbacks when min or max is unset", func() {
+		It("should use the default timeout as the min when min is unset", func() {
+			template.Spec.IdleShutdownOverrides.MinIdleTimeoutInMinutes = nil
+			// default timeout is 30, so anything below 30 must be rejected
+			workspace.Spec.IdleShutdown.IdleTimeoutInMinutes = 20
+			violations := validateIdleShutdownOverrides(workspace, template)
+			Expect(violations).To(HaveLen(1))
+			Expect(violations[0].Type).To(Equal(ViolationTypeIdleShutdownTimeoutOutOfBounds))
+
+			workspace.Spec.IdleShutdown.IdleTimeoutInMinutes = 45
+			Expect(validateIdleShutdownOverrides(workspace, template)).To(BeEmpty())
+		})
+
+		It("should use the default timeout as the max when max is unset", func() {
+			template.Spec.IdleShutdownOverrides.MaxIdleTimeoutInMinutes = nil
+			// default timeout is 30, so anything above 30 must be rejected
+			workspace.Spec.IdleShutdown.IdleTimeoutInMinutes = 45
+			violations := validateIdleShutdownOverrides(workspace, template)
+			Expect(violations).To(HaveLen(1))
+			Expect(violations[0].Type).To(Equal(ViolationTypeIdleShutdownTimeoutOutOfBounds))
+
+			workspace.Spec.IdleShutdown.IdleTimeoutInMinutes = 20
+			Expect(validateIdleShutdownOverrides(workspace, template)).To(BeEmpty())
+		})
+
+		It("should pin the timeout to the default when both bounds are unset", func() {
+			template.Spec.IdleShutdownOverrides.MinIdleTimeoutInMinutes = nil
+			template.Spec.IdleShutdownOverrides.MaxIdleTimeoutInMinutes = nil
+			workspace.Spec.IdleShutdown.IdleTimeoutInMinutes = 30
+			Expect(validateIdleShutdownOverrides(workspace, template)).To(BeEmpty())
+
+			workspace.Spec.IdleShutdown.IdleTimeoutInMinutes = 31
+			Expect(validateIdleShutdownOverrides(workspace, template)).To(HaveLen(1))
+		})
+	})
+})

--- a/internal/webhook/v1alpha1/template_validator.go
+++ b/internal/webhook/v1alpha1/template_validator.go
@@ -133,6 +133,11 @@ func (tv *TemplateValidator) ValidateCreateWorkspace(ctx context.Context, worksp
 		violations = append(violations, envViolations...)
 	}
 
+	// Validate idle shutdown against the template's override policy
+	if idleViolations := validateIdleShutdownOverrides(workspace, template); len(idleViolations) > 0 {
+		violations = append(violations, idleViolations...)
+	}
+
 	if len(violations) > 0 {
 		return fmt.Errorf("workspace violates template '%s' constraints: %s", workspace.Spec.TemplateRef.Name, formatViolations(violations))
 	}

--- a/internal/webhook/v1alpha1/template_validator_test.go
+++ b/internal/webhook/v1alpha1/template_validator_test.go
@@ -180,6 +180,105 @@ var _ = Describe("TemplateValidator", func() {
 		})
 	})
 
+	// These exercise the full ValidateCreateWorkspace/ValidateUpdateWorkspace path (template fetch +
+	// violation formatting) to confirm the idle shutdown override policy is wired into the webhook,
+	// not just the standalone validateIdleShutdownOverrides unit.
+	Context("Idle shutdown override enforcement", func() {
+		boolPtr := func(b bool) *bool { return &b }
+		intPtr := func(i int) *int { return &i }
+
+		templateIdleDefault := func() *workspacev1alpha1.IdleShutdownSpec {
+			return &workspacev1alpha1.IdleShutdownSpec{
+				Enabled:              true,
+				IdleTimeoutInMinutes: 30,
+				Detection: workspacev1alpha1.IdleDetectionSpec{
+					HTTPGet: &workspacev1alpha1.IdleHTTPGetAction{Transport: "network"},
+				},
+			}
+		}
+
+		// enforcingTemplate locks idle shutdown (allow: false) with a [15, 60] timeout window.
+		enforcingTemplate := func() *workspacev1alpha1.WorkspaceTemplate {
+			return &workspacev1alpha1.WorkspaceTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: testSharedTemplate, Namespace: testSharedNamespace},
+				Spec: workspacev1alpha1.WorkspaceTemplateSpec{
+					DefaultImage:        testValidBaseNotebook,
+					DisplayName:         "Idle Enforcing Template",
+					DefaultIdleShutdown: templateIdleDefault(),
+					IdleShutdownOverrides: &workspacev1alpha1.IdleShutdownOverridePolicy{
+						Allow:                   boolPtr(false),
+						MinIdleTimeoutInMinutes: intPtr(15),
+						MaxIdleTimeoutInMinutes: intPtr(60),
+					},
+				},
+			}
+		}
+
+		workspaceWithIdle := func(idle *workspacev1alpha1.IdleShutdownSpec) *workspacev1alpha1.Workspace {
+			return &workspacev1alpha1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{Name: "ws", Namespace: testNamespaceTeamA},
+				Spec: workspacev1alpha1.WorkspaceSpec{
+					TemplateRef: &workspacev1alpha1.TemplateRef{
+						Name:      testSharedTemplate,
+						Namespace: testSharedNamespace,
+					},
+					IdleShutdown: idle,
+				},
+			}
+		}
+
+		It("should accept a workspace whose timeout is within the enforced bounds", func() {
+			validator := buildValidator(testSharedNamespace, enforcingTemplate())
+
+			idle := templateIdleDefault()
+			idle.IdleTimeoutInMinutes = 45
+			workspace := workspaceWithIdle(idle)
+
+			Expect(validator.ValidateCreateWorkspace(ctx, workspace)).To(Succeed())
+		})
+
+		It("should reject a workspace that disables idle shutdown and surface the violation", func() {
+			validator := buildValidator(testSharedNamespace, enforcingTemplate())
+
+			idle := templateIdleDefault()
+			idle.Enabled = false
+			workspace := workspaceWithIdle(idle)
+
+			err := validator.ValidateCreateWorkspace(ctx, workspace)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(testSharedTemplate))
+			Expect(err.Error()).To(ContainSubstring("does not allow overriding idle shutdown"))
+		})
+
+		It("should reject a workspace whose timeout is outside the enforced bounds", func() {
+			validator := buildValidator(testSharedNamespace, enforcingTemplate())
+
+			idle := templateIdleDefault()
+			idle.IdleTimeoutInMinutes = 120
+			workspace := workspaceWithIdle(idle)
+
+			err := validator.ValidateCreateWorkspace(ctx, workspace)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("outside the range"))
+		})
+
+		It("should reject an update that pushes the timeout out of the enforced bounds", func() {
+			validator := buildValidator(testSharedNamespace, enforcingTemplate())
+
+			oldIdle := templateIdleDefault()
+			oldIdle.IdleTimeoutInMinutes = 45
+			oldWorkspace := workspaceWithIdle(oldIdle)
+
+			newIdle := templateIdleDefault()
+			newIdle.IdleTimeoutInMinutes = 120
+			newWorkspace := workspaceWithIdle(newIdle)
+
+			err := validator.ValidateUpdateWorkspace(ctx, oldWorkspace, newWorkspace)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("outside the range"))
+		})
+	})
+
 	// ValidateNamespaceScope is the namespace-only gate the mutating webhook calls before stamping a
 	// protection finalizer. Unlike ValidateCreateWorkspace it must NOT fetch the template, so it
 	// enforces scope even when the template does not exist and never reports a missing-template error.

--- a/internal/webhook/v1alpha1/template_webhook.go
+++ b/internal/webhook/v1alpha1/template_webhook.go
@@ -120,6 +120,11 @@ func (v *WorkspaceTemplateCustomValidator) ValidateCreate(ctx context.Context, t
 		return nil, err
 	}
 
+	// Enforce that an idle-shutdown-locking policy has a default to enforce against.
+	if err := validateIdleShutdownPolicyConsistency(template); err != nil {
+		return nil, err
+	}
+
 	return nil, nil
 }
 
@@ -130,6 +135,11 @@ func (v *WorkspaceTemplateCustomValidator) ValidateUpdate(ctx context.Context, o
 	// Enforce that the referenced access strategy is in an allowed namespace, so the template
 	// cannot make referencing workspaces fail their own admission webhook.
 	if err := v.accessStrategyValidator.ValidateUpdateTemplate(oldTemplate, newTemplate); err != nil {
+		return nil, err
+	}
+
+	// Enforce that an idle-shutdown-locking policy has a default to enforce against.
+	if err := validateIdleShutdownPolicyConsistency(newTemplate); err != nil {
 		return nil, err
 	}
 
@@ -240,6 +250,27 @@ func maxStorageSizeChanged(oldStorage, newStorage *workspacev1alpha1.StorageConf
 	}
 
 	return false
+}
+
+// validateIdleShutdownPolicyConsistency rejects a template whose idle shutdown policy locks
+// overrides (Allow=false) without a DefaultIdleShutdown baseline. Without a default there is
+// nothing for the workspace webhook to enforce the lock against, so the policy would silently
+// do nothing - a misconfiguration we surface at template admission instead.
+func validateIdleShutdownPolicyConsistency(template *workspacev1alpha1.WorkspaceTemplate) error {
+	policy := template.Spec.IdleShutdownOverrides
+	if policy == nil || policy.Allow == nil || *policy.Allow {
+		return nil
+	}
+
+	if template.Spec.DefaultIdleShutdown == nil {
+		return fmt.Errorf(
+			"idleShutdownOverrides.allow is false but defaultIdleShutdown is not set: "+
+				"a locked idle shutdown policy requires a defaultIdleShutdown for workspaces to match (template %q)",
+			template.GetName(),
+		)
+	}
+
+	return nil
 }
 
 // idleShutdownAllowOverrideChanged checks if Allow setting changed

--- a/internal/webhook/v1alpha1/template_webhook_test.go
+++ b/internal/webhook/v1alpha1/template_webhook_test.go
@@ -210,6 +210,59 @@ var _ = Describe("WorkspaceTemplate Validator", func() {
 
 	})
 
+	Context("Idle shutdown policy consistency", func() {
+		boolPtr := func(b bool) *bool { return &b }
+
+		lockingPolicy := func() *workspacev1alpha1.IdleShutdownOverridePolicy {
+			return &workspacev1alpha1.IdleShutdownOverridePolicy{Allow: boolPtr(false)}
+		}
+		idleDefault := func() *workspacev1alpha1.IdleShutdownSpec {
+			return &workspacev1alpha1.IdleShutdownSpec{Enabled: true, IdleTimeoutInMinutes: 30}
+		}
+		templateWithIdle := func(
+			policy *workspacev1alpha1.IdleShutdownOverridePolicy,
+			def *workspacev1alpha1.IdleShutdownSpec,
+		) *workspacev1alpha1.WorkspaceTemplate {
+			return &workspacev1alpha1.WorkspaceTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: testTemplateNameTmpl, Namespace: testNamespaceTeamA},
+				Spec: workspacev1alpha1.WorkspaceTemplateSpec{
+					IdleShutdownOverrides: policy,
+					DefaultIdleShutdown:   def,
+				},
+			}
+		}
+
+		It("rejects create when allow is false and defaultIdleShutdown is nil", func() {
+			_, err := validator.ValidateCreate(ctx, templateWithIdle(lockingPolicy(), nil))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("defaultIdleShutdown is not set"))
+		})
+
+		It("rejects update when allow is false and defaultIdleShutdown is nil", func() {
+			oldTemplate := templateWithIdle(lockingPolicy(), idleDefault())
+			newTemplate := templateWithIdle(lockingPolicy(), nil)
+			_, err := validator.ValidateUpdate(ctx, oldTemplate, newTemplate)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("defaultIdleShutdown is not set"))
+		})
+
+		It("allows allow: false when a defaultIdleShutdown is set", func() {
+			_, err := validator.ValidateCreate(ctx, templateWithIdle(lockingPolicy(), idleDefault()))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("allows allow: true without a defaultIdleShutdown", func() {
+			_, err := validator.ValidateCreate(ctx, templateWithIdle(
+				&workspacev1alpha1.IdleShutdownOverridePolicy{Allow: boolPtr(true)}, nil))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("allows a nil policy without a defaultIdleShutdown", func() {
+			_, err := validator.ValidateCreate(ctx, templateWithIdle(nil, nil))
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
 	Context("ValidateDelete", func() {
 		It("allows deletion and returns no warnings", func() {
 			warnings, err := validator.ValidateDelete(ctx, templateWithAS(testNamespaceTeamB))

--- a/test/e2e/static/template-enforce-idle-shutdown/allow-override-disabled-workspace.yaml
+++ b/test/e2e/static/template-enforce-idle-shutdown/allow-override-disabled-workspace.yaml
@@ -1,0 +1,19 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: Workspace
+metadata:
+  name: allow-override-disabled-workspace
+  namespace: default
+spec:
+  displayName: "Allow Override Disabled"
+  templateRef:
+    name: allow-override-idle-template
+    namespace: jupyter-k8s-shared
+  # Disabled: permitted because allow is true, and bounds don't apply when disabled.
+  idleShutdown:
+    enabled: false
+    idleTimeoutInMinutes: 999
+    detection:
+      httpGet:
+        path: /api/status
+        port: 8888
+        transport: network

--- a/test/e2e/static/template-enforce-idle-shutdown/allow-override-enabled-out-of-bounds-workspace.yaml
+++ b/test/e2e/static/template-enforce-idle-shutdown/allow-override-enabled-out-of-bounds-workspace.yaml
@@ -1,0 +1,20 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: Workspace
+metadata:
+  name: allow-override-enabled-out-of-bounds-workspace
+  namespace: default
+spec:
+  displayName: "Allow Override Enabled Out Of Bounds"
+  templateRef:
+    name: allow-override-idle-template
+    namespace: jupyter-k8s-shared
+  # allow: true lets the workspace diverge structurally, but declared bounds still cap the
+  # timeout when idle shutdown is enabled: 999 exceeds max 60, so this is rejected.
+  idleShutdown:
+    enabled: true
+    idleTimeoutInMinutes: 999
+    detection:
+      httpGet:
+        path: /custom/idle
+        port: 8888
+        transport: podExec

--- a/test/e2e/static/template-enforce-idle-shutdown/allow-override-idle-template.yaml
+++ b/test/e2e/static/template-enforce-idle-shutdown/allow-override-idle-template.yaml
@@ -1,0 +1,28 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: WorkspaceTemplate
+metadata:
+  name: allow-override-idle-template
+  namespace: jupyter-k8s-shared
+spec:
+  displayName: "Allow-Override Idle Shutdown Template"
+  defaultImage: jk8s-application-jupyter-uv:latest
+  defaultResources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  defaultIdleShutdown:
+    enabled: true
+    idleTimeoutInMinutes: 30
+    detection:
+      httpGet:
+        path: /api/status
+        port: 8888
+        transport: network
+  idleShutdownOverrides:
+    # allow: true means bounds are advisory only; workspaces may override freely.
+    allow: true
+    minIdleTimeoutInMinutes: 15
+    maxIdleTimeoutInMinutes: 60

--- a/test/e2e/static/template-enforce-idle-shutdown/enforce-idle-template.yaml
+++ b/test/e2e/static/template-enforce-idle-shutdown/enforce-idle-template.yaml
@@ -1,0 +1,27 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: WorkspaceTemplate
+metadata:
+  name: enforce-idle-template
+  namespace: jupyter-k8s-shared
+spec:
+  displayName: "Enforced Idle Shutdown Template"
+  defaultImage: jk8s-application-jupyter-uv:latest
+  defaultResources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  defaultIdleShutdown:
+    enabled: true
+    idleTimeoutInMinutes: 30
+    detection:
+      httpGet:
+        path: /api/status
+        port: 8888
+        transport: network
+  idleShutdownOverrides:
+    allow: false
+    minIdleTimeoutInMinutes: 15
+    maxIdleTimeoutInMinutes: 60

--- a/test/e2e/static/template-enforce-idle-shutdown/invalid-locking-no-default-template.yaml
+++ b/test/e2e/static/template-enforce-idle-shutdown/invalid-locking-no-default-template.yaml
@@ -1,0 +1,14 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: WorkspaceTemplate
+metadata:
+  name: invalid-locking-no-default-template
+  namespace: jupyter-k8s-shared
+spec:
+  displayName: "Invalid Locking Idle Shutdown Template"
+  defaultImage: jk8s-application-jupyter-uv:latest
+  # allow: false locks idle shutdown, but there is no defaultIdleShutdown to enforce against.
+  # The template admission webhook must reject this misconfiguration.
+  idleShutdownOverrides:
+    allow: false
+    minIdleTimeoutInMinutes: 15
+    maxIdleTimeoutInMinutes: 60

--- a/test/e2e/static/template-enforce-idle-shutdown/permissive-disable-idle-workspace.yaml
+++ b/test/e2e/static/template-enforce-idle-shutdown/permissive-disable-idle-workspace.yaml
@@ -1,0 +1,18 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: Workspace
+metadata:
+  name: permissive-disable-idle-workspace
+  namespace: default
+spec:
+  displayName: "Permissive Disable Idle"
+  templateRef:
+    name: permissive-idle-template
+    namespace: jupyter-k8s-shared
+  idleShutdown:
+    enabled: false
+    idleTimeoutInMinutes: 30
+    detection:
+      httpGet:
+        path: /api/status
+        port: 8888
+        transport: network

--- a/test/e2e/static/template-enforce-idle-shutdown/permissive-idle-template.yaml
+++ b/test/e2e/static/template-enforce-idle-shutdown/permissive-idle-template.yaml
@@ -1,0 +1,24 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: WorkspaceTemplate
+metadata:
+  name: permissive-idle-template
+  namespace: jupyter-k8s-shared
+spec:
+  displayName: "Permissive Idle Shutdown Template"
+  defaultImage: jk8s-application-jupyter-uv:latest
+  defaultResources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  defaultIdleShutdown:
+    enabled: true
+    idleTimeoutInMinutes: 30
+    detection:
+      httpGet:
+        path: /api/status
+        port: 8888
+        transport: network
+  # No idleShutdownOverrides policy: workspaces may freely override idle shutdown.

--- a/test/e2e/static/template-enforce-idle-shutdown/reject-disable-idle-workspace.yaml
+++ b/test/e2e/static/template-enforce-idle-shutdown/reject-disable-idle-workspace.yaml
@@ -1,0 +1,19 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: Workspace
+metadata:
+  name: reject-disable-idle-workspace
+  namespace: default
+spec:
+  displayName: "Reject Disable Idle"
+  templateRef:
+    name: enforce-idle-template
+    namespace: jupyter-k8s-shared
+  # enabled: false is a forbidden override when the template locks idle shutdown.
+  idleShutdown:
+    enabled: false
+    idleTimeoutInMinutes: 30
+    detection:
+      httpGet:
+        path: /api/status
+        port: 8888
+        transport: network

--- a/test/e2e/static/template-enforce-idle-shutdown/reject-modified-detection-workspace.yaml
+++ b/test/e2e/static/template-enforce-idle-shutdown/reject-modified-detection-workspace.yaml
@@ -1,0 +1,20 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: Workspace
+metadata:
+  name: reject-modified-detection-workspace
+  namespace: default
+spec:
+  displayName: "Reject Modified Detection"
+  templateRef:
+    name: enforce-idle-template
+    namespace: jupyter-k8s-shared
+  # Timeout is within bounds, but a non-timeout field (detection path/transport)
+  # diverges from the template default, which is a forbidden override.
+  idleShutdown:
+    enabled: true
+    idleTimeoutInMinutes: 45
+    detection:
+      httpGet:
+        path: /custom/idle
+        port: 8888
+        transport: podExec

--- a/test/e2e/static/template-enforce-idle-shutdown/reject-timeout-out-of-bounds-workspace.yaml
+++ b/test/e2e/static/template-enforce-idle-shutdown/reject-timeout-out-of-bounds-workspace.yaml
@@ -1,0 +1,19 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: Workspace
+metadata:
+  name: reject-timeout-out-of-bounds-workspace
+  namespace: default
+spec:
+  displayName: "Reject Timeout Out Of Bounds"
+  templateRef:
+    name: enforce-idle-template
+    namespace: jupyter-k8s-shared
+  # All fields match the default, but timeout 120 exceeds max 60.
+  idleShutdown:
+    enabled: true
+    idleTimeoutInMinutes: 120
+    detection:
+      httpGet:
+        path: /api/status
+        port: 8888
+        transport: network

--- a/test/e2e/static/template-enforce-idle-shutdown/valid-timeout-within-bounds-workspace.yaml
+++ b/test/e2e/static/template-enforce-idle-shutdown/valid-timeout-within-bounds-workspace.yaml
@@ -1,0 +1,18 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: Workspace
+metadata:
+  name: valid-timeout-within-bounds-workspace
+  namespace: default
+spec:
+  displayName: "Valid Timeout Within Bounds"
+  templateRef:
+    name: enforce-idle-template
+    namespace: jupyter-k8s-shared
+  idleShutdown:
+    enabled: true
+    idleTimeoutInMinutes: 45
+    detection:
+      httpGet:
+        path: /api/status
+        port: 8888
+        transport: network

--- a/test/e2e/template_enforce_idle_shutdown_test.go
+++ b/test/e2e/template_enforce_idle_shutdown_test.go
@@ -1,0 +1,202 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package e2e
+
+import (
+	"os/exec"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jupyter-infra/jupyter-k8s/internal/controller"
+	"github.com/jupyter-infra/jupyter-k8s/test/utils"
+)
+
+var _ = Describe("Template Idle Shutdown Enforcement", Ordered, func() {
+	const (
+		workspaceNamespace = "default"
+		groupDir           = "template-enforce-idle-shutdown"
+
+		enforceTemplate       = "enforce-idle-template"
+		permissiveTemplate    = "permissive-idle-template"
+		allowOverrideTemplate = "allow-override-idle-template"
+	)
+
+	AfterEach(func() {
+		deleteResourcesForTemplateEnforceIdleTest()
+	})
+
+	Context("when the template does not enforce idle shutdown", func() {
+		It("should accept a workspace disabling idle shutdown when no override policy is set", func() {
+			workspace := "permissive-disable-idle-workspace"
+
+			By("creating a template with defaultIdleShutdown but no idleShutdownOverrides policy")
+			createTemplateForTest(permissiveTemplate, groupDir, "")
+
+			By("creating a workspace that disables idle shutdown")
+			createWorkspaceForTest(workspace, groupDir, "")
+
+			By("verifying the workspace was accepted with idle shutdown disabled")
+			output, err := kubectlGet("workspace", workspace, workspaceNamespace, "{.spec.idleShutdown.enabled}")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).To(Equal("false"))
+		})
+
+		It("should accept a disabled override when allow is true (bounds skipped when disabled)", func() {
+			workspace := "allow-override-disabled-workspace"
+
+			By("creating a template with allow: true and timeout bounds")
+			createTemplateForTest(allowOverrideTemplate, groupDir, "")
+
+			By("creating a workspace that disables idle shutdown with an out-of-bounds timeout")
+			createWorkspaceForTest(workspace, groupDir, "")
+
+			By("verifying the workspace was accepted unchanged")
+			enabled, err := kubectlGet("workspace", workspace, workspaceNamespace, "{.spec.idleShutdown.enabled}")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(enabled).To(Equal("false"))
+
+			timeout, err := kubectlGet("workspace", workspace, workspaceNamespace,
+				"{.spec.idleShutdown.idleTimeoutInMinutes}")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(timeout).To(Equal("999"))
+		})
+	})
+
+	Context("when the template allows overrides but declares timeout bounds", func() {
+		It("should reject an enabled timeout outside the declared bounds even when allow is true", func() {
+			workspace := "allow-override-enabled-out-of-bounds-workspace"
+
+			By("creating a template with allow: true and bounds [15, 60]")
+			createTemplateForTest(allowOverrideTemplate, groupDir, "")
+
+			By("attempting to create an enabled workspace with a timeout of 999")
+			VerifyCreateWorkspaceRejectedByWebhook(workspace, groupDir, "", workspace, workspaceNamespace)
+		})
+	})
+
+	Context("when the template enforces idle shutdown (allow: false)", func() {
+		It("should accept a workspace that changes only the timeout within bounds", func() {
+			workspace := "valid-timeout-within-bounds-workspace"
+
+			By("creating a template with allow: false and bounds [15, 60]")
+			createTemplateForTest(enforceTemplate, groupDir, "")
+
+			By("creating a workspace matching the default with an in-bounds timeout of 45")
+			createWorkspaceForTest(workspace, groupDir, "")
+
+			By("verifying the workspace becomes available")
+			WaitForWorkspaceToReachCondition(
+				workspace,
+				workspaceNamespace,
+				controller.ConditionTypeAvailable,
+				ConditionTrue,
+			)
+
+			By("verifying the timeout override was accepted")
+			timeout, err := kubectlGet("workspace", workspace, workspaceNamespace,
+				"{.spec.idleShutdown.idleTimeoutInMinutes}")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(timeout).To(Equal("45"))
+		})
+
+		It("should reject a workspace that disables idle shutdown", func() {
+			workspace := "reject-disable-idle-workspace"
+
+			By("creating a template with allow: false")
+			createTemplateForTest(enforceTemplate, groupDir, "")
+
+			By("attempting to create a workspace with idle shutdown disabled")
+			VerifyCreateWorkspaceRejectedByWebhook(workspace, groupDir, "", workspace, workspaceNamespace)
+		})
+
+		It("should reject a workspace that modifies a non-timeout idle shutdown setting", func() {
+			workspace := "reject-modified-detection-workspace"
+
+			By("creating a template with allow: false")
+			createTemplateForTest(enforceTemplate, groupDir, "")
+
+			By("attempting to create a workspace that changes detection path/transport")
+			VerifyCreateWorkspaceRejectedByWebhook(workspace, groupDir, "", workspace, workspaceNamespace)
+		})
+
+		It("should reject a workspace whose timeout is outside the bounds", func() {
+			workspace := "reject-timeout-out-of-bounds-workspace"
+
+			By("creating a template with allow: false and bounds [15, 60]")
+			createTemplateForTest(enforceTemplate, groupDir, "")
+
+			By("attempting to create a workspace with a timeout of 120")
+			VerifyCreateWorkspaceRejectedByWebhook(workspace, groupDir, "", workspace, workspaceNamespace)
+		})
+
+		It("should reject an update that pushes the timeout out of bounds", func() {
+			workspace := "valid-timeout-within-bounds-workspace"
+
+			By("creating a template with allow: false and bounds [15, 60]")
+			createTemplateForTest(enforceTemplate, groupDir, "")
+
+			By("creating a valid workspace with an in-bounds timeout")
+			createWorkspaceForTest(workspace, groupDir, "")
+
+			By("verifying the workspace becomes available")
+			WaitForWorkspaceToReachCondition(
+				workspace,
+				workspaceNamespace,
+				controller.ConditionTypeAvailable,
+				ConditionTrue,
+			)
+
+			By("patching the workspace to a timeout above the maximum")
+			patchCmd := `{"spec":{"idleShutdown":{"idleTimeoutInMinutes":120}}}`
+			cmd := exec.Command("kubectl", "patch", "workspace", workspace,
+				"-n", workspaceNamespace, "--type=merge", "-p", patchCmd)
+			_, err := utils.Run(cmd)
+			Expect(err).To(HaveOccurred(), "expected webhook to reject out-of-bounds timeout update")
+		})
+	})
+
+	Context("template-level policy consistency", func() {
+		It("should reject a template that locks idle shutdown without a defaultIdleShutdown", func() {
+			templateFilename := "invalid-locking-no-default-template"
+			templateName := "invalid-locking-no-default-template"
+
+			By("attempting to create a template with allow: false and no defaultIdleShutdown")
+			path := BuildTestResourcePath(templateFilename, groupDir, "")
+			cmd := exec.Command("kubectl", "apply", "-f", path)
+			output, err := utils.Run(cmd)
+			Expect(err).To(HaveOccurred(), "template webhook should reject a locking policy with no default")
+			Expect(output).To(ContainSubstring("defaultIdleShutdown is not set"),
+				"rejection should explain the missing defaultIdleShutdown")
+
+			By("verifying the template was not created")
+			cmd = exec.Command("kubectl", verbGet, "workspacetemplate", templateName,
+				"-n", SharedNamespace, "--ignore-not-found")
+			output, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).To(BeEmpty(), "template should not exist after webhook rejection")
+		})
+	})
+})
+
+func deleteResourcesForTemplateEnforceIdleTest() {
+	By("cleaning up workspaces")
+	cmd := exec.Command("kubectl", "delete", "workspace", "--all", "-n", "default",
+		"--ignore-not-found", "--wait=true", "--timeout=120s")
+	_, _ = utils.Run(cmd)
+
+	By("cleaning up templates")
+	cmd = exec.Command("kubectl", "delete", "workspacetemplate", "--all", "-n", SharedNamespace,
+		"--ignore-not-found", "--wait=true", "--timeout=60s")
+	_, _ = utils.Run(cmd)
+
+	By("waiting an arbitrary fixed time for resources to be fully deleted")
+	time.Sleep(1 * time.Second)
+}


### PR DESCRIPTION
This PR wires up the `template.spec.idleShutdownOverrides` field to enforce bounds that users select for a `workspace.spec.idleShutdown` when referencing the template.

Closes: #437 

### User experience
- on create-workspace w/ `templateRef`
    - if `template.spec.idleShutdownOverrides.allow = False`:
        - `workspace.spec.idleShutdown` _must_ match exactly `template.spec.defaultIdleShutdown`
        - except that if `template.spec.idleShutdownOverrides.minIdleTimeoutInMinutes` or/and `.maxIdleTimeoutInMinutes` are set, then allow to override `workspace.spec.idleShutdown.idleTimeoutInMinutes`
        - if either of `minIdleTimeoutInMinutes` or `maxIdleTimeoutInMinutes` is _not_ set, uses default for that bound
    - if `template.spec.idleShutdownOverrides.allow = True`:
        - enforce only bounds on `idleTimeoutInMinutes` if `minIdleTimeoutInMinutes` and / or `maxIdleTimeoutInMinutes` are set AND workspace.spec enabled idleShutdown
- same logic on update workspace
- fail fast if template defines `template.spec.idleShutdownOverrides.allow = False` but omits `template.spec.defaultIdleShutdown`

### Implementation
1. add `idle_shutdown_validator` and wire-up in workspace validation webhook
2. add idleShutdown overrides <-> default consistency in template validation webhook
3. update documentation: `concepts/templates/bounds` and `dive-deeper/webhooks/workspace-validation`

### Testing
- added E2E tests for `idleShutdownOverrides` enforcement (+ve and -ve) on workspace admission
- added E2E tests for `idleShutdownOverrides` <-> `defaultIdleShutdown` on template admission