### PR TITLE
feat: support Authorization Bearer header in handleBearerAuth

### DIFF
--- a/internal/authmiddleware/serverroute_bearer_auth.go
+++ b/internal/authmiddleware/serverroute_bearer_auth.go
@@ -13,7 +13,7 @@ import (
 )
 
 // handleBearerAuth handles bearer token authentication requests
-// Takes short lived JWT tokens from URL parameter and exchanges them for 6-hour session cookies
+// Takes short lived JWT tokens from Authorization header or URL parameter and exchanges them for session cookies
 func (s *Server) handleBearerAuth(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
@@ -36,12 +36,23 @@ func (s *Server) handleBearerAuth(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Extract token from forwarded URI query parameters
-	token := parsedURL.Query().Get("token")
+	// Extract token: prefer Authorization header, fall back to URL query parameter
+	var token string
+	if authHeader := r.Header.Get(HeaderAuthorization); authHeader != "" {
+		extracted, err := ExtractBearerToken(authHeader)
+		if err != nil {
+			s.logger.Error("Invalid Authorization header", "error", err)
+			http.Error(w, "Invalid Authorization header", http.StatusBadRequest)
+			return
+		}
+		token = extracted
+	} else {
+		token = parsedURL.Query().Get("token")
+	}
+
 	if token == "" {
-		s.logger.Error("Missing token parameter",
-			"forwarded_uri", forwardedURI,
-			"query_params", parsedURL.Query())
+		s.logger.Error("Missing token: provide Authorization: Bearer header or ?token= query parameter",
+			"forwarded_uri", forwardedURI)
 		http.Error(w, "Missing token parameter", http.StatusBadRequest)
 		return
 	}

--- a/internal/authmiddleware/serverroute_bearer_auth_test.go
+++ b/internal/authmiddleware/serverroute_bearer_auth_test.go
@@ -84,6 +84,62 @@ func TestHandleBearerAuthMissingToken(t *testing.T) {
 	}
 }
 
+func TestHandleBearerAuthWithAuthorizationHeader(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	server := &Server{
+		logger: logger,
+		config: &Config{
+			PathRegexPattern:            DefaultPathRegexPattern,
+			RoutingMode:                 DefaultRoutingMode,
+			WorkspaceNamespacePathRegex: DefaultWorkspaceNamespacePathRegex,
+			WorkspaceNamePathRegex:      DefaultWorkspaceNamePathRegex,
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/bearer-auth", nil)
+	req.Header.Set(HeaderForwardedURI, "/workspaces/default/myworkspace/")
+	req.Header.Set(HeaderForwardedHost, "test.example.com")
+	req.Header.Set(HeaderAuthorization, "Bearer valid-token")
+	w := httptest.NewRecorder()
+
+	server.handleBearerAuth(w, req)
+
+	// Should proceed past token extraction — will fail later at BearerTokenReview
+	// because no k8s client is configured, but the point is it didn't fail at token extraction
+	assert.NotContains(t, w.Body.String(), "Missing token parameter")
+	assert.NotContains(t, w.Body.String(), "Invalid Authorization header")
+}
+
+func TestHandleBearerAuthInvalidAuthorizationHeader(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	server := &Server{logger: logger}
+
+	req := httptest.NewRequest(http.MethodGet, "/bearer-auth", nil)
+	req.Header.Set(HeaderForwardedURI, "/workspaces/default/workspace")
+	req.Header.Set(HeaderAuthorization, "Basic dXNlcjpwYXNz")
+	w := httptest.NewRecorder()
+
+	server.handleBearerAuth(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "Invalid Authorization header")
+}
+
+func TestHandleBearerAuthEmptyBearerToken(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	server := &Server{logger: logger}
+
+	req := httptest.NewRequest(http.MethodGet, "/bearer-auth", nil)
+	req.Header.Set(HeaderForwardedURI, "/workspaces/default/workspace")
+	req.Header.Set(HeaderAuthorization, "Bearer ")
+	w := httptest.NewRecorder()
+
+	server.handleBearerAuth(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "Invalid Authorization header")
+}
+
 func TestHandleBearerAuthMissingForwardedHost(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	server := &Server{


### PR DESCRIPTION
Adds support for extracting JWT tokens from the `Authorization: Bearer` header in the bearer auth middleware, alongside the existing URL query parameter (`?token=`) method.

   ## Motivation

   WebSocket connections via websocat pass the JWT token as an HTTP header (`-H "Authorization: Bearer <token>"`) rather than a URL query parameter. This avoids tokens appearing in Traefik/ALB access logs. 
   ## Changes

   - `serverroute_bearer_auth.go`: Check `Authorization: Bearer <token>` header first, fall back to `?token=` query param if header not present
   - `serverroute_bearer_auth_test.go`: 3 new tests (valid header, invalid header, empty bearer token)

   ## Backward Compatibility

   Fully backward compatible. Existing web UI flows using `?token=` in the URL continue working unchanged. The Authorization header is only used when present.


   **E2E testing for the Authorization header flow will be covered as part of the full WebSocket connection E2E test, which exercises the complete path: Extension API → websocat with -H "Authorization: Bearer" → Traefik ForwardAuth → proxy → remote access server.**