### PR TITLE
fix: template admission

### DIFF
--- a/api/v1alpha1/workspacetemplate_types.go
+++ b/api/v1alpha1/workspacetemplate_types.go
@@ -240,7 +240,7 @@ type ResourceBounds struct {
 
 // ResourceRange defines min and max for a resource
 // NOTE: CEL validation for min <= max is not possible due to resource.Quantity type limitations
-// Validation is enforced at runtime in the template resolver
+// Consistency (min <= max) is enforced by the WorkspaceTemplate validating webhook
 type ResourceRange struct {
 	// Min is the minimum allowed value
 	// +kubebuilder:validation:Required
@@ -253,7 +253,7 @@ type ResourceRange struct {
 
 // StorageConfig defines storage settings
 // NOTE: CEL validation for minSize <= maxSize is not possible due to resource.Quantity type limitations
-// Validation is enforced at runtime in the template resolver
+// Consistency (minSize <= maxSize) is enforced by the WorkspaceTemplate validating webhook
 type StorageConfig struct {
 	// DefaultSize is the default storage size
 	// +kubebuilder:default="10Gi"

--- a/config/crd/bases/workspace.jupyter.org_workspacetemplates.yaml
+++ b/config/crd/bases/workspace.jupyter.org_workspacetemplates.yaml
@@ -3919,7 +3919,7 @@ spec:
                       description: |-
                         ResourceRange defines min and max for a resource
                         NOTE: CEL validation for min <= max is not possible due to resource.Quantity type limitations
-                        Validation is enforced at runtime in the template resolver
+                        Consistency (min <= max) is enforced by the WorkspaceTemplate validating webhook
                       properties:
                         max:
                           anyOf:

--- a/dist/chart/templates/crd/workspacetemplates.workspace.jupyter.org.yaml
+++ b/dist/chart/templates/crd/workspacetemplates.workspace.jupyter.org.yaml
@@ -3922,7 +3922,7 @@ spec:
                       description: |-
                         ResourceRange defines min and max for a resource
                         NOTE: CEL validation for min <= max is not possible due to resource.Quantity type limitations
-                        Validation is enforced at runtime in the template resolver
+                        Consistency (min <= max) is enforced by the WorkspaceTemplate validating webhook
                       properties:
                         max:
                           anyOf:

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -13245,7 +13245,7 @@ spec:
                       description: |-
                         ResourceRange defines min and max for a resource
                         NOTE: CEL validation for min <= max is not possible due to resource.Quantity type limitations
-                        Validation is enforced at runtime in the template resolver
+                        Consistency (min <= max) is enforced by the WorkspaceTemplate validating webhook
                       properties:
                         max:
                           anyOf:

--- a/docs/source/concepts/templates/bounds.md
+++ b/docs/source/concepts/templates/bounds.md
@@ -60,11 +60,17 @@ spec:
     maxIdleTimeoutInMinutes: 480
 ```
 
-`allow` controls whether workspace users may disable idle shutdown, and whether the `idleShutdown` field of a workspace may diverge from the template's defined defaults. It matters because the `idleShutdown.detection` settings are deeply tied to the application running in the workspace. Misconfiguring the `idleShutdown.detection` field of a workspace may prevent the operator from shutting down idle workspaces.
+`allow` controls whether workspace users may disable idle shutdown.
+- when set to `false`: the workspace idle shutdown config must match the template's defaults exactly, except that `idleTimeoutInMinutes` may vary within certain bounds (see below).
+- when set to `true`: workspaces may disable idle shutdown, or vary any field of `idleShutdown`.
 
-The `minIdleTimeoutInMinutes` and `maxIdleTimeoutInMinutes` bounds are independent of `allow`: they cap `idleShutdown.idleTimeoutInMinutes` on any workspace with idle shutdown *enabled*, whether or not overrides are allowed. So even with `allow: false`, you can still permit users to tune the timeout within those bounds. If `allow: false` and `minIdleTimeoutInMinutes` is omitted, the enforced minimum falls back to the template's `spec.defaultIdleShutdown.idleTimeoutInMinutes`; `maxIdleTimeoutInMinutes` behaves the same way. When `allow: true`, an omitted bound simply leaves that side unbounded.
+```{note}
+`idleShutdown.detection` settings are deeply tied to the application running in the workspace. Misconfiguring the `idleShutdown.detection` field of a workspace may prevent the operator from shutting down idle workspaces. If workspace users are not familiar with such settings, it is safer to set `allow: false`.
+```
 
-A template with `allow: false` must define `defaultIdleShutdown`, or the template webhook rejects it.
+The `minIdleTimeoutInMinutes` and `maxIdleTimeoutInMinutes` are always enforced:
+- with `allow: false`: a workspace may set its own idle timeout within these bounds; if `min` and/or `max` is omitted, the implicit lower or upper bound is the template's default.
+- with `allow: true`: a workspace that enables idle shutdown must set its timeout within these bounds; if `min` and/or `max` is omitted, that side is unbounded.
 
 ## Environment and label requirements
 

--- a/docs/source/dive-deeper/webhooks/template-validation.md
+++ b/docs/source/dive-deeper/webhooks/template-validation.md
@@ -17,6 +17,7 @@ On **create and update**, the webhook rejects a template whose own constraints a
 - `resourceBounds` `min` must not exceed `max` for any resource.
 - `idleShutdownOverrides.minIdleTimeoutInMinutes` must not exceed `maxIdleTimeoutInMinutes`.
 - `idleShutdownOverrides.allow: false` requires a `defaultIdleShutdown` for workspaces to match against.
+- an enabled `defaultIdleShutdown.idleTimeoutInMinutes` must fall within the `idleShutdownOverrides` timeout bounds.
 
 ## Constraint fields
 

--- a/docs/source/dive-deeper/webhooks/template-validation.md
+++ b/docs/source/dive-deeper/webhooks/template-validation.md
@@ -8,6 +8,16 @@ On **create and update**, the webhook rejects templates whose `defaultAccessStra
 
 On **update**, when constraint fields change, the webhook returns a **warning** telling the user that the template controller will re-validate affected workspaces.
 
+## Self-consistency
+
+On **create and update**, the webhook rejects a template whose own constraints are internally inconsistent:
+
+- `defaultImage` must be a member of `allowedImages` when that list is non-empty and `allowCustomImages` is false.
+- `primaryStorage.minSize` must not exceed `primaryStorage.maxSize`.
+- `resourceBounds` `min` must not exceed `max` for any resource.
+- `idleShutdownOverrides.minIdleTimeoutInMinutes` must not exceed `maxIdleTimeoutInMinutes`.
+- `idleShutdownOverrides.allow: false` requires a `defaultIdleShutdown` for workspaces to match against.
+
 ## Constraint fields
 
 Changes to any of the following fields trigger the warning:

--- a/docs/source/dive-deeper/webhooks/workspace-validation.md
+++ b/docs/source/dive-deeper/webhooks/workspace-validation.md
@@ -7,6 +7,7 @@ The validating webhook enforces constraints on workspace create, update, and del
 | Check | Description |
 |-------|-------------|
 | Template constraints | Validates resources, images, storage size, and idle shutdown bounds against the template's constraint fields |
+| Storage size shrink | On update, rejects a decrease of `spec.storage.size` below the workspace's provisioned PVC size |
 | Reference namespace scope | Rejects references to templates or access strategies outside the workspace's own namespace or the configured shared namespace |
 | Volume ownership | Rejects references to other workspaces' primary storage PVCs (secondary storage can be shared freely) |
 
@@ -29,9 +30,13 @@ When a workspace has `ownershipType: OwnerOnly`:
 
 On `DELETE`, the webhook only checks ownership permission for `OwnerOnly` workspaces. All other deletes pass through (RBAC is the primary guard).
 
-## Idle shutdown override enforcement
+## Storage size changes
 
-When the template sets `idleShutdownOverrides.allow: false`, the webhook requires the workspace's `idleShutdown` to match the template's `defaultIdleShutdown` on every field except `idleTimeoutInMinutes`. Declared `minIdleTimeoutInMinutes`/`maxIdleTimeoutInMinutes` bounds are enforced on any *enabled* idle shutdown regardless of `allow`; a disabled idle shutdown has no timeout to bound. See [idle shutdown bounds](../../concepts/templates/bounds.md) for the policy semantics.
+On update, the webhook rejects shrinking `spec.storage.size` below the size the workspace's PVC already requests. Kubernetes does not support shrinking a volume below its current size, so a resize-down would otherwise pass admission but fail to reconcile.
+
+```{note}
+The webhook does not block a size increase at admission: whether it succeeds at reconciliation depends on the StorageClass's `allowVolumeExpansion`.
+```
 
 ## Lazy constraint enforcement
 

--- a/docs/source/reference/custom-resources/workspacetemplate.md
+++ b/docs/source/reference/custom-resources/workspacetemplate.md
@@ -91,7 +91,7 @@ _Appears in:_
 
 ResourceRange defines min and max for a resource
 NOTE: CEL validation for min <= max is not possible due to resource.Quantity type limitations
-Validation is enforced at runtime in the template resolver
+Consistency (min <= max) is enforced by the WorkspaceTemplate validating webhook
 
 _Appears in:_
 - [ResourceBounds](#resourcebounds)
@@ -109,7 +109,7 @@ _Appears in:_
 
 StorageConfig defines storage settings
 NOTE: CEL validation for minSize <= maxSize is not possible due to resource.Quantity type limitations
-Validation is enforced at runtime in the template resolver
+Consistency (minSize <= maxSize) is enforced by the WorkspaceTemplate validating webhook
 
 _Appears in:_
 - [WorkspaceTemplateSpec](#workspacetemplatespec)

--- a/internal/webhook/v1alpha1/image_validator.go
+++ b/internal/webhook/v1alpha1/image_validator.go
@@ -37,3 +37,33 @@ func validateImageAllowed(image string, template *workspacev1alpha1.WorkspaceTem
 		Actual:  image,
 	}
 }
+
+// validateTemplateImageConsistency rejects a template whose own defaultImage would be
+// un-creatable under its own image policy. When allowedImages is non-empty and custom images
+// are not allowed, defaultImage must be a member of allowedImages: otherwise the workspace
+// defaulter fills image=defaultImage for a workspace that omits one, and validateImageAllowed
+// then rejects that same image, making the template's default impossible to use (see #440).
+//
+// When allowedImages is empty, validateImageAllowed falls back to [defaultImage], so the
+// default is always creatable and no consistency check is needed.
+func validateTemplateImageConsistency(template *workspacev1alpha1.WorkspaceTemplate) error {
+	if template.Spec.AllowCustomImages != nil && *template.Spec.AllowCustomImages {
+		return nil
+	}
+
+	if len(template.Spec.AllowedImages) == 0 {
+		return nil
+	}
+
+	for _, allowed := range template.Spec.AllowedImages {
+		if template.Spec.DefaultImage == allowed {
+			return nil
+		}
+	}
+
+	return fmt.Errorf(
+		"defaultImage %q is not in allowedImages %v: the template default would be rejected by its own "+
+			"image policy, making it un-creatable (template %q)",
+		template.Spec.DefaultImage, template.Spec.AllowedImages, template.GetName(),
+	)
+}

--- a/internal/webhook/v1alpha1/resource_validator.go
+++ b/internal/webhook/v1alpha1/resource_validator.go
@@ -103,6 +103,28 @@ func validateResourceListBounds(
 	return violations
 }
 
+// validateTemplateResourceBoundsConsistency rejects a template whose resource bounds are
+// self-contradictory (min > max for any resource). Such a bound can never admit any workspace
+// value for that resource. CEL cannot express this on resource.Quantity, so it is enforced at
+// template admission.
+func validateTemplateResourceBoundsConsistency(template *workspacev1alpha1.WorkspaceTemplate) error {
+	bounds := template.Spec.ResourceBounds
+	if bounds == nil || bounds.Resources == nil {
+		return nil
+	}
+
+	for resourceName, resourceRange := range bounds.Resources {
+		if resourceRange.Min.Cmp(resourceRange.Max) > 0 {
+			return fmt.Errorf(
+				"resourceBounds for %q has min %s greater than max %s: no value can satisfy these bounds (template %q)",
+				resourceName, resourceRange.Min.String(), resourceRange.Max.String(), template.GetName(),
+			)
+		}
+	}
+
+	return nil
+}
+
 // resourcesEqual compares two ResourceRequirements for equality
 func resourcesEqual(old, new *corev1.ResourceRequirements) bool {
 	if old == nil && new == nil {

--- a/internal/webhook/v1alpha1/storage_validator.go
+++ b/internal/webhook/v1alpha1/storage_validator.go
@@ -6,12 +6,102 @@ Distributed under the terms of the MIT license
 package v1alpha1
 
 import (
+	"context"
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	workspacev1alpha1 "github.com/jupyter-infra/jupyter-k8s/api/v1alpha1"
+	"github.com/jupyter-infra/jupyter-k8s/internal/controller"
 )
+
+// StorageValidator handles storage validation that needs cluster state (the workspace's PVC).
+type StorageValidator struct {
+	client client.Client
+}
+
+// NewStorageValidator creates a new StorageValidator.
+func NewStorageValidator(k8sClient client.Client) *StorageValidator {
+	return &StorageValidator{
+		client: k8sClient,
+	}
+}
+
+// ValidateStorageSizeNotShrinking rejects a storage size decrease below what the workspace's PVC
+// already requests. Kubernetes does not support shrinking a PVC below its current size, so a
+// resize-down otherwise passes admission (including dryRun=All) and then silently fails to
+// reconcile. Rejecting it here makes admission authoritative for the shrink case.
+//
+// The check is anchored on the live PVC, not the old workspace spec:
+//   - If no PVC exists yet (workspace never started, or storage never provisioned), there is
+//     nothing Kubernetes can reject at reconcile, so any size is allowed.
+//   - If the PVC exists, the new size must be >= the PVC's current requested size. Comparing to
+//     the PVC (rather than the old spec) tracks what the API will actually accept, including the
+//     narrow RecoverVolumeExpansionFailure path where a request may be lowered toward capacity.
+//
+// PVC lookup failures fail closed, matching the workspace validating webhook's failurePolicy=fail
+// stance that admission is mandatory, not best-effort: a webhook that is up but blind (missing RBAC,
+// API outage) must not silently wave shrinks through. Only NotFound is treated as success - it is
+// the legitimate "no PVC yet, nothing to shrink" case (workspace never started or no storage
+// provisioned). A transient error blocks the update and the caller retries, as with any
+// failurePolicy=fail rejection.
+//
+// Growth is intentionally not blocked here: whether an increase succeeds depends on the
+// StorageClass's allowVolumeExpansion, which the webhook does not resolve; that gotcha still
+// surfaces at reconcile time.
+func (sv *StorageValidator) ValidateStorageSizeNotShrinking(ctx context.Context, workspace *workspacev1alpha1.Workspace) error {
+	if workspace.Spec.Storage == nil || workspace.Spec.Storage.Size.IsZero() {
+		return nil
+	}
+	newSize := workspace.Spec.Storage.Size
+
+	pvc := &corev1.PersistentVolumeClaim{}
+	err := sv.client.Get(ctx, types.NamespacedName{
+		Name:      controller.GeneratePVCName(workspace.Name),
+		Namespace: workspace.Namespace,
+	}, pvc)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			// No PVC yet: nothing provisioned to shrink.
+			return nil
+		}
+		// Fail closed: we cannot confirm the current size, so we do not let the update through.
+		workspacelog.Error(err, "Failed to get PVC for storage shrink validation; rejecting update",
+			"workspace", workspace.GetName(), "namespace", workspace.GetNamespace())
+		return fmt.Errorf("unable to validate storage size against existing volume: %w", err)
+	}
+
+	if violation := validateStorageSizeNotBelowProvisioned(newSize, pvc); violation != nil {
+		return fmt.Errorf("workspace violates storage constraints: %s", violation.Message)
+	}
+	return nil
+}
+
+// validateStorageSizeNotBelowProvisioned returns a violation when newSize is smaller than the
+// PVC's current requested storage. A PVC with no storage request recorded cannot be shrunk below
+// an unknown value, so it is treated as allowed.
+func validateStorageSizeNotBelowProvisioned(newSize resource.Quantity, pvc *corev1.PersistentVolumeClaim) *TemplateViolation {
+	provisioned, ok := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
+	if !ok || provisioned.IsZero() {
+		return nil
+	}
+
+	if newSize.Cmp(provisioned) < 0 {
+		return &TemplateViolation{
+			Type:    ViolationTypeStorageExceeded,
+			Field:   fieldStorageSize,
+			Message: fmt.Sprintf("Storage size cannot be decreased from %s to %s: Kubernetes does not support shrinking a volume below its current size", provisioned.String(), newSize.String()),
+			Allowed: fmt.Sprintf("size >= %s", provisioned.String()),
+			Actual:  newSize.String(),
+		}
+	}
+
+	return nil
+}
 
 // validateStorageSize checks if storage size is within template bounds
 func validateStorageSize(size resource.Quantity, template *workspacev1alpha1.WorkspaceTemplate) *TemplateViolation {
@@ -23,7 +113,7 @@ func validateStorageSize(size resource.Quantity, template *workspacev1alpha1.Wor
 	if config.MinSize != nil && size.Cmp(*config.MinSize) < 0 {
 		return &TemplateViolation{
 			Type:    ViolationTypeStorageExceeded,
-			Field:   "spec.storage.size",
+			Field:   fieldStorageSize,
 			Message: fmt.Sprintf("Storage size %s is below minimum %s required by template '%s'", size.String(), config.MinSize.String(), template.Name),
 			Allowed: fmt.Sprintf("min: %s", config.MinSize.String()),
 			Actual:  size.String(),
@@ -33,7 +123,7 @@ func validateStorageSize(size resource.Quantity, template *workspacev1alpha1.Wor
 	if config.MaxSize != nil && size.Cmp(*config.MaxSize) > 0 {
 		return &TemplateViolation{
 			Type:    ViolationTypeStorageExceeded,
-			Field:   "spec.storage.size",
+			Field:   fieldStorageSize,
 			Message: fmt.Sprintf("Storage size %s exceeds maximum %s allowed by template '%s'", size.String(), config.MaxSize.String(), template.Name),
 			Allowed: fmt.Sprintf("max: %s", config.MaxSize.String()),
 			Actual:  size.String(),
@@ -43,14 +133,21 @@ func validateStorageSize(size resource.Quantity, template *workspacev1alpha1.Wor
 	return nil
 }
 
-// storageEqual compares two StorageSpec for equality
-func storageEqual(old, new *workspacev1alpha1.StorageSpec) bool {
-	if old == nil && new == nil {
-		return true
-	}
-	if old == nil || new == nil {
-		return false
+// validateTemplateStorageConsistency rejects a template whose primaryStorage bounds are
+// self-contradictory (minSize > maxSize). Such a template can never admit any workspace storage
+// size. CEL cannot express this on resource.Quantity, so it is enforced at template admission.
+func validateTemplateStorageConsistency(template *workspacev1alpha1.WorkspaceTemplate) error {
+	config := template.Spec.PrimaryStorage
+	if config == nil || config.MinSize == nil || config.MaxSize == nil {
+		return nil
 	}
 
-	return old.Size.Equal(new.Size) && old.MountPath == new.MountPath
+	if config.MinSize.Cmp(*config.MaxSize) > 0 {
+		return fmt.Errorf(
+			"primaryStorage.minSize %s is greater than primaryStorage.maxSize %s: no storage size can satisfy these bounds (template %q)",
+			config.MinSize.String(), config.MaxSize.String(), template.GetName(),
+		)
+	}
+
+	return nil
 }

--- a/internal/webhook/v1alpha1/storage_validator_test.go
+++ b/internal/webhook/v1alpha1/storage_validator_test.go
@@ -1,0 +1,192 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package v1alpha1
+
+import (
+	"context"
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	workspacev1alpha1 "github.com/jupyter-infra/jupyter-k8s/api/v1alpha1"
+	"github.com/jupyter-infra/jupyter-k8s/internal/controller"
+)
+
+var _ = Describe("StorageValidator", func() {
+	var (
+		ctx    context.Context
+		scheme *runtime.Scheme
+	)
+
+	const (
+		wsName      = "storage-ws"
+		wsNs        = "default"
+		pvcSize     = "2Gi"
+		smaller     = "1Gi"
+		larger      = "5Gi"
+		sameAsPVC   = "2Gi"
+		pvcResource = "persistentvolumeclaims"
+	)
+
+	// makeWorkspace builds a workspace requesting the given storage size ("" means no storage).
+	makeWorkspace := func(size string) *workspacev1alpha1.Workspace {
+		ws := &workspacev1alpha1.Workspace{
+			ObjectMeta: metav1.ObjectMeta{Name: wsName, Namespace: wsNs},
+		}
+		if size != "" {
+			ws.Spec.Storage = &workspacev1alpha1.StorageSpec{Size: resource.MustParse(size)}
+		}
+		return ws
+	}
+
+	// existingPVC builds the workspace's PVC with the given requested storage size.
+	existingPVC := func(size string) *corev1.PersistentVolumeClaim {
+		return &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      controller.GeneratePVCName(wsName),
+				Namespace: wsNs,
+			},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse(size)},
+				},
+			},
+		}
+	}
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		scheme = runtime.NewScheme()
+		Expect(corev1.AddToScheme(scheme)).To(Succeed())
+		Expect(workspacev1alpha1.AddToScheme(scheme)).To(Succeed())
+	})
+
+	Context("when no PVC exists", func() {
+		It("allows any requested size (fake client returns NotFound)", func() {
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+			sv := NewStorageValidator(fakeClient)
+			Expect(sv.ValidateStorageSizeNotShrinking(ctx, makeWorkspace(smaller))).To(Succeed())
+		})
+	})
+
+	Context("when storage is not requested", func() {
+		It("skips the lookup entirely and allows", func() {
+			// A client whose Get always fails proves the lookup is never reached.
+			failingClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(context.Context, client.WithWatch, client.ObjectKey, client.Object, ...client.GetOption) error {
+						return errors.New("Get should not be called when storage is unset")
+					},
+				}).
+				Build()
+			sv := NewStorageValidator(failingClient)
+
+			Expect(sv.ValidateStorageSizeNotShrinking(ctx, makeWorkspace(""))).To(Succeed())
+
+			zero := makeWorkspace("")
+			zero.Spec.Storage = &workspacev1alpha1.StorageSpec{} // size is the zero quantity
+			Expect(sv.ValidateStorageSizeNotShrinking(ctx, zero)).To(Succeed())
+		})
+	})
+
+	Context("when the PVC exists", func() {
+		It("rejects shrinking below the provisioned size", func() {
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(existingPVC(pvcSize)).
+				Build()
+			sv := NewStorageValidator(fakeClient)
+
+			err := sv.ValidateStorageSizeNotShrinking(ctx, makeWorkspace(smaller))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("shrinking"))
+		})
+
+		It("allows keeping the same size", func() {
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(existingPVC(pvcSize)).
+				Build()
+			sv := NewStorageValidator(fakeClient)
+			Expect(sv.ValidateStorageSizeNotShrinking(ctx, makeWorkspace(sameAsPVC))).To(Succeed())
+		})
+
+		It("allows growing beyond the provisioned size", func() {
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(existingPVC(pvcSize)).
+				Build()
+			sv := NewStorageValidator(fakeClient)
+			Expect(sv.ValidateStorageSizeNotShrinking(ctx, makeWorkspace(larger))).To(Succeed())
+		})
+	})
+
+	Context("when retrieving the PVC fails", func() {
+		// getErrorClient returns a fake client whose PVC Get always fails with the given error.
+		getErrorClient := func(getErr error) client.Client {
+			return fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+						if _, ok := obj.(*corev1.PersistentVolumeClaim); ok {
+							return getErr
+						}
+						return errors.New("unexpected Get for non-PVC object")
+					},
+				}).
+				Build()
+		}
+
+		// The webhook fails closed on lookup errors it cannot classify as NotFound: a blind
+		// webhook must not silently wave a shrink through, matching failurePolicy=fail.
+
+		It("fails closed on a Forbidden (RBAC) error", func() {
+			forbidden := apierrors.NewForbidden(
+				schema.GroupResource{Resource: pvcResource}, controller.GeneratePVCName(wsName),
+				errors.New("not allowed"))
+			sv := NewStorageValidator(getErrorClient(forbidden))
+
+			err := sv.ValidateStorageSizeNotShrinking(ctx, makeWorkspace(smaller))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("unable to validate storage size"))
+		})
+
+		It("fails closed on a ServerTimeout (API outage) error", func() {
+			timeout := apierrors.NewServerTimeout(
+				schema.GroupResource{Resource: pvcResource}, "get", 1)
+			sv := NewStorageValidator(getErrorClient(timeout))
+
+			err := sv.ValidateStorageSizeNotShrinking(ctx, makeWorkspace(smaller))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("unable to validate storage size"))
+		})
+
+		It("fails closed on an arbitrary non-status error", func() {
+			sv := NewStorageValidator(getErrorClient(errors.New("connection refused")))
+			err := sv.ValidateStorageSizeNotShrinking(ctx, makeWorkspace(smaller))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("unable to validate storage size"))
+		})
+
+		It("still allows the update when the error is NotFound (no PVC yet)", func() {
+			notFound := apierrors.NewNotFound(
+				schema.GroupResource{Resource: pvcResource}, controller.GeneratePVCName(wsName))
+			sv := NewStorageValidator(getErrorClient(notFound))
+			Expect(sv.ValidateStorageSizeNotShrinking(ctx, makeWorkspace(smaller))).To(Succeed())
+		})
+	})
+})

--- a/internal/webhook/v1alpha1/template_webhook.go
+++ b/internal/webhook/v1alpha1/template_webhook.go
@@ -120,8 +120,9 @@ func (v *WorkspaceTemplateCustomValidator) ValidateCreate(ctx context.Context, t
 		return nil, err
 	}
 
-	// Enforce that an idle-shutdown-locking policy has a default to enforce against.
-	if err := validateIdleShutdownPolicyConsistency(template); err != nil {
+	// Enforce that the template's own constraints are internally consistent, so it cannot make
+	// its own defaults or any workspace value un-admittable.
+	if err := validateTemplateConsistency(template); err != nil {
 		return nil, err
 	}
 
@@ -138,8 +139,9 @@ func (v *WorkspaceTemplateCustomValidator) ValidateUpdate(ctx context.Context, o
 		return nil, err
 	}
 
-	// Enforce that an idle-shutdown-locking policy has a default to enforce against.
-	if err := validateIdleShutdownPolicyConsistency(newTemplate); err != nil {
+	// Enforce that the template's own constraints are internally consistent, so it cannot make
+	// its own defaults or any workspace value un-admittable.
+	if err := validateTemplateConsistency(newTemplate); err != nil {
 		return nil, err
 	}
 
@@ -252,13 +254,51 @@ func maxStorageSizeChanged(oldStorage, newStorage *workspacev1alpha1.StorageConf
 	return false
 }
 
+// validateTemplateConsistency rejects a template whose own constraints are internally
+// inconsistent - contradictions that would make the template's defaults or any workspace value
+// un-admittable, silently self-defeating the template. These checks run on create and update.
+func validateTemplateConsistency(template *workspacev1alpha1.WorkspaceTemplate) error {
+	// defaultImage must be creatable under the template's own image policy (#440).
+	if err := validateTemplateImageConsistency(template); err != nil {
+		return err
+	}
+
+	// primaryStorage minSize must not exceed maxSize.
+	if err := validateTemplateStorageConsistency(template); err != nil {
+		return err
+	}
+
+	// resourceBounds min must not exceed max for any resource.
+	if err := validateTemplateResourceBoundsConsistency(template); err != nil {
+		return err
+	}
+
+	// idleShutdownOverrides bounds must be consistent, and a locked policy needs a default.
+	return validateIdleShutdownPolicyConsistency(template)
+}
+
 // validateIdleShutdownPolicyConsistency rejects a template whose idle shutdown policy locks
 // overrides (Allow=false) without a DefaultIdleShutdown baseline. Without a default there is
 // nothing for the workspace webhook to enforce the lock against, so the policy would silently
 // do nothing - a misconfiguration we surface at template admission instead.
 func validateIdleShutdownPolicyConsistency(template *workspacev1alpha1.WorkspaceTemplate) error {
 	policy := template.Spec.IdleShutdownOverrides
-	if policy == nil || policy.Allow == nil || *policy.Allow {
+	if policy == nil {
+		return nil
+	}
+
+	// The timeout bounds must be internally consistent regardless of the Allow setting: a
+	// min greater than max can never admit any workspace timeout.
+	if policy.MinIdleTimeoutInMinutes != nil && policy.MaxIdleTimeoutInMinutes != nil &&
+		*policy.MinIdleTimeoutInMinutes > *policy.MaxIdleTimeoutInMinutes {
+		return fmt.Errorf(
+			"idleShutdownOverrides.minIdleTimeoutInMinutes %d is greater than maxIdleTimeoutInMinutes %d: "+
+				"no idle timeout can satisfy these bounds (template %q)",
+			*policy.MinIdleTimeoutInMinutes, *policy.MaxIdleTimeoutInMinutes, template.GetName(),
+		)
+	}
+
+	if policy.Allow == nil || *policy.Allow {
 		return nil
 	}
 

--- a/internal/webhook/v1alpha1/template_webhook.go
+++ b/internal/webhook/v1alpha1/template_webhook.go
@@ -277,10 +277,10 @@ func validateTemplateConsistency(template *workspacev1alpha1.WorkspaceTemplate) 
 	return validateIdleShutdownPolicyConsistency(template)
 }
 
-// validateIdleShutdownPolicyConsistency rejects a template whose idle shutdown policy locks
-// overrides (Allow=false) without a DefaultIdleShutdown baseline. Without a default there is
-// nothing for the workspace webhook to enforce the lock against, so the policy would silently
-// do nothing - a misconfiguration we surface at template admission instead.
+// validateIdleShutdownPolicyConsistency rejects a template whose idle shutdown policy is
+// self-defeating: bounds that no timeout can satisfy, a locked policy with no default to enforce
+// against, or a default timeout that its own bounds would reject. All are surfaced at template
+// admission instead of silently making the template's default un-creatable.
 func validateIdleShutdownPolicyConsistency(template *workspacev1alpha1.WorkspaceTemplate) error {
 	policy := template.Spec.IdleShutdownOverrides
 	if policy == nil {
@@ -298,16 +298,35 @@ func validateIdleShutdownPolicyConsistency(template *workspacev1alpha1.Workspace
 		)
 	}
 
-	if policy.Allow == nil || *policy.Allow {
-		return nil
-	}
-
-	if template.Spec.DefaultIdleShutdown == nil {
+	// A locked policy (allow=false) needs a default for workspaces to match against.
+	if policy.Allow != nil && !*policy.Allow && template.Spec.DefaultIdleShutdown == nil {
 		return fmt.Errorf(
 			"idleShutdownOverrides.allow is false but defaultIdleShutdown is not set: "+
 				"a locked idle shutdown policy requires a defaultIdleShutdown for workspaces to match (template %q)",
 			template.GetName(),
 		)
+	}
+
+	// The default timeout must satisfy the declared bounds, regardless of the Allow setting: the
+	// defaulter applies defaultIdleShutdown to any workspace that omits idleShutdown, and the
+	// workspace webhook then enforces the bounds on that enabled default. A default outside the
+	// bounds would make the template's own default un-creatable.
+	def := template.Spec.DefaultIdleShutdown
+	if def != nil && def.Enabled {
+		if policy.MinIdleTimeoutInMinutes != nil && def.IdleTimeoutInMinutes < *policy.MinIdleTimeoutInMinutes {
+			return fmt.Errorf(
+				"defaultIdleShutdown.idleTimeoutInMinutes %d is below idleShutdownOverrides.minIdleTimeoutInMinutes %d: "+
+					"the template default would be rejected by its own bounds (template %q)",
+				def.IdleTimeoutInMinutes, *policy.MinIdleTimeoutInMinutes, template.GetName(),
+			)
+		}
+		if policy.MaxIdleTimeoutInMinutes != nil && def.IdleTimeoutInMinutes > *policy.MaxIdleTimeoutInMinutes {
+			return fmt.Errorf(
+				"defaultIdleShutdown.idleTimeoutInMinutes %d is above idleShutdownOverrides.maxIdleTimeoutInMinutes %d: "+
+					"the template default would be rejected by its own bounds (template %q)",
+				def.IdleTimeoutInMinutes, *policy.MaxIdleTimeoutInMinutes, template.GetName(),
+			)
+		}
 	}
 
 	return nil

--- a/internal/webhook/v1alpha1/template_webhook_test.go
+++ b/internal/webhook/v1alpha1/template_webhook_test.go
@@ -10,6 +10,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -19,6 +21,13 @@ import (
 
 	workspacev1alpha1 "github.com/jupyter-infra/jupyter-k8s/api/v1alpha1"
 	workspaceutil "github.com/jupyter-infra/jupyter-k8s/internal/workspace"
+)
+
+const (
+	testImageA   = "image-a"
+	testImgA     = "img-a"
+	testImgB     = "img-b"
+	testImgDeflt = "img-default"
 )
 
 var _ = Describe("WorkspaceTemplate Defaulter", func() {
@@ -179,13 +188,15 @@ var _ = Describe("WorkspaceTemplate Validator", func() {
 			oldTemplate := &workspacev1alpha1.WorkspaceTemplate{
 				ObjectMeta: metav1.ObjectMeta{Name: testTemplateNameTmpl, Namespace: testNamespaceTeamA},
 				Spec: workspacev1alpha1.WorkspaceTemplateSpec{
-					AllowedImages: []string{"image-a"},
+					DefaultImage:  testImageA,
+					AllowedImages: []string{testImageA},
 				},
 			}
 			newTemplate := &workspacev1alpha1.WorkspaceTemplate{
 				ObjectMeta: metav1.ObjectMeta{Name: testTemplateNameTmpl, Namespace: testNamespaceTeamA},
 				Spec: workspacev1alpha1.WorkspaceTemplateSpec{
-					AllowedImages: []string{"image-a", "image-b"},
+					DefaultImage:  testImageA,
+					AllowedImages: []string{testImageA, "image-b"},
 				},
 			}
 			warnings, err := validator.ValidateUpdate(ctx, oldTemplate, newTemplate)
@@ -259,6 +270,140 @@ var _ = Describe("WorkspaceTemplate Validator", func() {
 
 		It("allows a nil policy without a defaultIdleShutdown", func() {
 			_, err := validator.ValidateCreate(ctx, templateWithIdle(nil, nil))
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("Idle shutdown timeout bounds consistency", func() {
+		intPtr := func(i int) *int { return &i }
+
+		templateWithBounds := func(min, max *int) *workspacev1alpha1.WorkspaceTemplate {
+			return &workspacev1alpha1.WorkspaceTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: testTemplateNameTmpl, Namespace: testNamespaceTeamA},
+				Spec: workspacev1alpha1.WorkspaceTemplateSpec{
+					IdleShutdownOverrides: &workspacev1alpha1.IdleShutdownOverridePolicy{
+						MinIdleTimeoutInMinutes: min,
+						MaxIdleTimeoutInMinutes: max,
+					},
+				},
+			}
+		}
+
+		It("rejects create when min timeout exceeds max timeout", func() {
+			_, err := validator.ValidateCreate(ctx, templateWithBounds(intPtr(60), intPtr(30)))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("minIdleTimeoutInMinutes"))
+		})
+
+		It("allows min equal to max", func() {
+			_, err := validator.ValidateCreate(ctx, templateWithBounds(intPtr(30), intPtr(30)))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("allows only one bound set", func() {
+			_, err := validator.ValidateCreate(ctx, templateWithBounds(intPtr(30), nil))
+			Expect(err).NotTo(HaveOccurred())
+			_, err = validator.ValidateCreate(ctx, templateWithBounds(nil, intPtr(30)))
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("Image policy consistency", func() {
+		boolPtr := func(b bool) *bool { return &b }
+
+		templateWithImages := func(defaultImage string, allowed []string, allowCustom *bool) *workspacev1alpha1.WorkspaceTemplate {
+			return &workspacev1alpha1.WorkspaceTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: testTemplateNameTmpl, Namespace: testNamespaceTeamA},
+				Spec: workspacev1alpha1.WorkspaceTemplateSpec{
+					DefaultImage:      defaultImage,
+					AllowedImages:     allowed,
+					AllowCustomImages: allowCustom,
+				},
+			}
+		}
+
+		It("rejects a defaultImage absent from a non-empty allowedImages", func() {
+			_, err := validator.ValidateCreate(ctx, templateWithImages(testImgDeflt, []string{testImgA, testImgB}, nil))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("defaultImage"))
+			Expect(err.Error()).To(ContainSubstring("allowedImages"))
+		})
+
+		It("allows a defaultImage present in allowedImages", func() {
+			_, err := validator.ValidateCreate(ctx, templateWithImages(testImgA, []string{testImgA, testImgB}, nil))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("allows an empty allowedImages (falls back to defaultImage)", func() {
+			_, err := validator.ValidateCreate(ctx, templateWithImages(testImgDeflt, nil, nil))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("allows a mismatch when custom images are permitted", func() {
+			_, err := validator.ValidateCreate(ctx, templateWithImages(testImgDeflt, []string{testImgA}, boolPtr(true)))
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("Storage bounds consistency", func() {
+		qtyPtr := func(s string) *resource.Quantity {
+			q := resource.MustParse(s)
+			return &q
+		}
+
+		templateWithStorage := func(min, max *resource.Quantity) *workspacev1alpha1.WorkspaceTemplate {
+			return &workspacev1alpha1.WorkspaceTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: testTemplateNameTmpl, Namespace: testNamespaceTeamA},
+				Spec: workspacev1alpha1.WorkspaceTemplateSpec{
+					PrimaryStorage: &workspacev1alpha1.StorageConfig{MinSize: min, MaxSize: max},
+				},
+			}
+		}
+
+		It("rejects minSize greater than maxSize", func() {
+			_, err := validator.ValidateCreate(ctx, templateWithStorage(qtyPtr("20Gi"), qtyPtr("10Gi")))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("minSize"))
+		})
+
+		It("allows minSize equal to maxSize", func() {
+			_, err := validator.ValidateCreate(ctx, templateWithStorage(qtyPtr("10Gi"), qtyPtr("10Gi")))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("allows only one bound set", func() {
+			_, err := validator.ValidateCreate(ctx, templateWithStorage(qtyPtr("10Gi"), nil))
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("Resource bounds consistency", func() {
+		templateWithResourceBounds := func(min, max string) *workspacev1alpha1.WorkspaceTemplate {
+			return &workspacev1alpha1.WorkspaceTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: testTemplateNameTmpl, Namespace: testNamespaceTeamA},
+				Spec: workspacev1alpha1.WorkspaceTemplateSpec{
+					ResourceBounds: &workspacev1alpha1.ResourceBounds{
+						Resources: map[corev1.ResourceName]workspacev1alpha1.ResourceRange{
+							corev1.ResourceCPU: {Min: resource.MustParse(min), Max: resource.MustParse(max)},
+						},
+					},
+				},
+			}
+		}
+
+		It("rejects a resource min greater than max", func() {
+			_, err := validator.ValidateCreate(ctx, templateWithResourceBounds("4", "2"))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("resourceBounds"))
+		})
+
+		It("allows a resource min equal to max", func() {
+			_, err := validator.ValidateCreate(ctx, templateWithResourceBounds("2", "2"))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("allows a valid resource range", func() {
+			_, err := validator.ValidateCreate(ctx, templateWithResourceBounds("1", "4"))
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})

--- a/internal/webhook/v1alpha1/template_webhook_test.go
+++ b/internal/webhook/v1alpha1/template_webhook_test.go
@@ -308,6 +308,71 @@ var _ = Describe("WorkspaceTemplate Validator", func() {
 		})
 	})
 
+	Context("Idle shutdown default within bounds consistency", func() {
+		intPtr := func(i int) *int { return &i }
+		boolPtr := func(b bool) *bool { return &b }
+
+		// templateWithDefaultAndBounds builds a template whose enabled default has the given timeout
+		// and whose override policy declares the given bounds (nil = unset) and allow flag.
+		templateWithDefaultAndBounds := func(defaultTimeout int, min, max *int, allow *bool) *workspacev1alpha1.WorkspaceTemplate {
+			return &workspacev1alpha1.WorkspaceTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: testTemplateNameTmpl, Namespace: testNamespaceTeamA},
+				Spec: workspacev1alpha1.WorkspaceTemplateSpec{
+					DefaultIdleShutdown: &workspacev1alpha1.IdleShutdownSpec{
+						Enabled:              true,
+						IdleTimeoutInMinutes: defaultTimeout,
+					},
+					IdleShutdownOverrides: &workspacev1alpha1.IdleShutdownOverridePolicy{
+						Allow:                   allow,
+						MinIdleTimeoutInMinutes: min,
+						MaxIdleTimeoutInMinutes: max,
+					},
+				},
+			}
+		}
+
+		It("rejects a default timeout below the minimum (allow: false)", func() {
+			_, err := validator.ValidateCreate(ctx, templateWithDefaultAndBounds(30, intPtr(60), intPtr(120), boolPtr(false)))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("below idleShutdownOverrides.minIdleTimeoutInMinutes"))
+		})
+
+		It("rejects a default timeout below the minimum (allow: true)", func() {
+			_, err := validator.ValidateCreate(ctx, templateWithDefaultAndBounds(30, intPtr(60), intPtr(120), boolPtr(true)))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("below idleShutdownOverrides.minIdleTimeoutInMinutes"))
+		})
+
+		It("rejects a default timeout above the maximum", func() {
+			_, err := validator.ValidateCreate(ctx, templateWithDefaultAndBounds(240, intPtr(15), intPtr(120), boolPtr(true)))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("above idleShutdownOverrides.maxIdleTimeoutInMinutes"))
+		})
+
+		It("rejects a default outside a one-sided (min-only) bound", func() {
+			_, err := validator.ValidateCreate(ctx, templateWithDefaultAndBounds(30, intPtr(60), nil, boolPtr(false)))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("below idleShutdownOverrides.minIdleTimeoutInMinutes"))
+		})
+
+		It("allows a default within the bounds", func() {
+			_, err := validator.ValidateCreate(ctx, templateWithDefaultAndBounds(60, intPtr(15), intPtr(120), boolPtr(true)))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("allows a default equal to a bound", func() {
+			_, err := validator.ValidateCreate(ctx, templateWithDefaultAndBounds(15, intPtr(15), intPtr(120), boolPtr(false)))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("ignores the bounds when the default is disabled", func() {
+			tmpl := templateWithDefaultAndBounds(30, intPtr(60), intPtr(120), boolPtr(true))
+			tmpl.Spec.DefaultIdleShutdown.Enabled = false
+			_, err := validator.ValidateCreate(ctx, tmpl)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
 	Context("Image policy consistency", func() {
 		boolPtr := func(b bool) *bool { return &b }
 

--- a/internal/webhook/v1alpha1/validation_types.go
+++ b/internal/webhook/v1alpha1/validation_types.go
@@ -43,3 +43,6 @@ const (
 
 // labelValueTrue is the string value used for boolean-style Kubernetes labels.
 const labelValueTrue = "true"
+
+// fieldStorageSize is the spec path for the primary storage size, used in violation field paths.
+const fieldStorageSize = "spec.storage.size"

--- a/internal/webhook/v1alpha1/workspace_webhook.go
+++ b/internal/webhook/v1alpha1/workspace_webhook.go
@@ -216,6 +216,7 @@ func SetupWorkspaceWebhookWithManager(mgr ctrl.Manager, defaultTemplateNamespace
 	serviceAccountValidator := NewServiceAccountValidator(mgr.GetClient())
 	serviceAccountDefaulter := NewServiceAccountDefaulter(mgr.GetClient())
 	volumeValidator := NewVolumeValidator(mgr.GetClient())
+	storageValidator := NewStorageValidator(mgr.GetClient())
 
 	return ctrl.NewWebhookManagedBy(mgr, &workspacev1alpha1.Workspace{}).
 		WithValidator(&WorkspaceCustomValidator{
@@ -223,6 +224,7 @@ func SetupWorkspaceWebhookWithManager(mgr ctrl.Manager, defaultTemplateNamespace
 			accessStrategyValidator: accessStrategyValidator,
 			serviceAccountValidator: serviceAccountValidator,
 			volumeValidator:         volumeValidator,
+			storageValidator:        storageValidator,
 		}).
 		WithDefaulter(&WorkspaceCustomDefaulter{
 			templateDefaulter:       templateDefaulter,
@@ -356,6 +358,7 @@ type WorkspaceCustomValidator struct {
 	accessStrategyValidator *AccessStrategyValidator
 	serviceAccountValidator *ServiceAccountValidator
 	volumeValidator         *VolumeValidator
+	storageValidator        *StorageValidator
 }
 
 var _ admission.Validator[*workspacev1alpha1.Workspace] = &WorkspaceCustomValidator{}
@@ -446,6 +449,14 @@ func (v *WorkspaceCustomValidator) ValidateUpdate(ctx context.Context, oldWorksp
 
 	// Validate template constraints for new workspace (only changed fields)
 	if err := v.templateValidator.ValidateUpdateWorkspace(ctx, oldWorkspace, newWorkspace); err != nil {
+		return nil, err
+	}
+
+	// Reject shrinking storage below the workspace's provisioned PVC size: Kubernetes cannot
+	// shrink a volume, so a resize-down would pass admission and then silently fail to reconcile
+	// (#439). Anchored on the live PVC, so a workspace with no PVC yet is unaffected. Applies to
+	// all workspaces, template-backed or standalone.
+	if err := v.storageValidator.ValidateStorageSizeNotShrinking(ctx, newWorkspace); err != nil {
 		return nil, err
 	}
 

--- a/internal/webhook/v1alpha1/workspace_webhook_test.go
+++ b/internal/webhook/v1alpha1/workspace_webhook_test.go
@@ -778,47 +778,7 @@ var _ = Describe("Workspace Webhook", func() {
 			})
 		})
 
-		Context("storageEqual", func() {
-			It("should return true for nil storages", func() {
-				Expect(storageEqual(nil, nil)).To(BeTrue())
-			})
-
-			It("should return false when one is nil", func() {
-				storage := &workspacev1alpha1.StorageSpec{Size: resource.MustParse("1Gi")}
-				Expect(storageEqual(nil, storage)).To(BeFalse())
-				Expect(storageEqual(storage, nil)).To(BeFalse())
-			})
-
-			It("should return true for equal storages", func() {
-				storage1 := &workspacev1alpha1.StorageSpec{
-					Size:      resource.MustParse("1Gi"),
-					MountPath: testDataMountPath,
-				}
-				storage2 := &workspacev1alpha1.StorageSpec{
-					Size:      resource.MustParse("1Gi"),
-					MountPath: testDataMountPath,
-				}
-				Expect(storageEqual(storage1, storage2)).To(BeTrue())
-			})
-
-			It("should return false for different sizes", func() {
-				storage1 := &workspacev1alpha1.StorageSpec{Size: resource.MustParse("1Gi")}
-				storage2 := &workspacev1alpha1.StorageSpec{Size: resource.MustParse("2Gi")}
-				Expect(storageEqual(storage1, storage2)).To(BeFalse())
-			})
-
-			It("should return false for different mount paths", func() {
-				storage1 := &workspacev1alpha1.StorageSpec{
-					Size:      resource.MustParse("1Gi"),
-					MountPath: "/data1",
-				}
-				storage2 := &workspacev1alpha1.StorageSpec{
-					Size:      resource.MustParse("1Gi"),
-					MountPath: "/data2",
-				}
-				Expect(storageEqual(storage1, storage2)).To(BeFalse())
-			})
-		})
+		// StorageValidator storage-shrink validation is covered in storage_validator_test.go.
 	})
 
 	Context("isControllerOrAdminUser", func() {

--- a/test/e2e/static/template-enforce-idle-shutdown/invalid-default-out-of-bounds-template.yaml
+++ b/test/e2e/static/template-enforce-idle-shutdown/invalid-default-out-of-bounds-template.yaml
@@ -1,0 +1,24 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: WorkspaceTemplate
+metadata:
+  name: invalid-default-out-of-bounds-template
+  namespace: jupyter-k8s-shared
+spec:
+  displayName: "Invalid Default Out Of Bounds Idle Shutdown Template"
+  defaultImage: jk8s-application-jupyter-uv:latest
+  # The enabled default timeout (5) is below minIdleTimeoutInMinutes (15). The defaulter would
+  # stamp this default onto any workspace that omits idleShutdown, and the workspace webhook would
+  # then reject it against the same bounds - making the template's own default un-creatable.
+  # The template admission webhook must reject this misconfiguration.
+  defaultIdleShutdown:
+    enabled: true
+    idleTimeoutInMinutes: 5
+    detection:
+      httpGet:
+        path: /api/status
+        port: 8888
+        transport: network
+  idleShutdownOverrides:
+    allow: true
+    minIdleTimeoutInMinutes: 15
+    maxIdleTimeoutInMinutes: 60

--- a/test/e2e/static/template-validation/inconsistent-default-image-template.yaml
+++ b/test/e2e/static/template-validation/inconsistent-default-image-template.yaml
@@ -1,0 +1,14 @@
+# Self-inconsistent template: defaultImage is not a member of a non-empty allowedImages
+# (with allowCustomImages unset/false). The template webhook must reject this because the
+# template's own default would be un-creatable under its own image policy (issue #440).
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: WorkspaceTemplate
+metadata:
+  name: inconsistent-default-image-template
+  namespace: jupyter-k8s-shared
+spec:
+  displayName: "Inconsistent Default Image Template"
+  defaultImage: jk8s-application-jupyter-uv:latest
+  allowedImages:
+    - some-other-image:latest
+    - yet-another-image:latest

--- a/test/e2e/template_enforce_idle_shutdown_test.go
+++ b/test/e2e/template_enforce_idle_shutdown_test.go
@@ -183,6 +183,26 @@ var _ = Describe("Template Idle Shutdown Enforcement", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(output).To(BeEmpty(), "template should not exist after webhook rejection")
 		})
+
+		It("should reject a template whose default idle timeout is outside its own bounds", func() {
+			templateFilename := "invalid-default-out-of-bounds-template"
+			templateName := "invalid-default-out-of-bounds-template"
+
+			By("attempting to create a template whose enabled default timeout is below the minimum")
+			path := BuildTestResourcePath(templateFilename, groupDir, "")
+			cmd := exec.Command("kubectl", "apply", "-f", path)
+			output, err := utils.Run(cmd)
+			Expect(err).To(HaveOccurred(), "template webhook should reject a default outside its own bounds")
+			Expect(output).To(ContainSubstring("below idleShutdownOverrides.minIdleTimeoutInMinutes"),
+				"rejection should explain the default is below the minimum bound")
+
+			By("verifying the template was not created")
+			cmd = exec.Command("kubectl", verbGet, "workspacetemplate", templateName,
+				"-n", SharedNamespace, "--ignore-not-found")
+			output, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).To(BeEmpty(), "template should not exist after webhook rejection")
+		})
 	})
 })
 

--- a/test/e2e/workspace_storage_test.go
+++ b/test/e2e/workspace_storage_test.go
@@ -167,6 +167,31 @@ var _ = Describe("Workspace Storage", Ordered, func() {
 				"workspace-storage", "/home/jovyan/data")
 		})
 
+		It("should reject shrinking storage size on update", func() {
+			workspaceFilename := baseWorkspaceName
+			workspaceName := baseWorkspaceName
+
+			By("creating a workspace with 2Gi storage")
+			createWorkspaceForTest(workspaceFilename, group, baseSubgroup)
+
+			By("waiting for the workspace to become Available (provisions the PVC at 2Gi)")
+			WaitForWorkspaceToReachCondition(
+				workspaceName,
+				workspaceNamespace,
+				ConditionTypeAvailable,
+				ConditionTrue,
+			)
+
+			By("attempting to shrink the storage size to 1Gi")
+			patchCmd := `{"spec":{"storage":{"size":"1Gi"}}}`
+			cmd := exec.Command("kubectl", "patch", "workspace", workspaceName,
+				"-n", workspaceNamespace, "--type=merge", "-p", patchCmd)
+			output, err := utils.Run(cmd)
+			Expect(err).To(HaveOccurred(), "expected webhook to reject a storage size shrink")
+			Expect(output).To(ContainSubstring("shrinking"),
+				"rejection should explain that the storage size cannot shrink")
+		})
+
 		It("should delete pvc when workspace is deleted", func() {
 			workspaceFilename := baseWorkspaceName
 			workspaceName := baseWorkspaceName

--- a/test/e2e/workspace_template_test.go
+++ b/test/e2e/workspace_template_test.go
@@ -422,6 +422,28 @@ var _ = Describe("Workspace Template", Ordered, func() {
 		})
 	})
 
+	Context("Self-consistency", func() {
+		It("should reject a template whose defaultImage is not in a non-empty allowedImages", func() {
+			templateFilename := "inconsistent-default-image-template"
+			templateName := "inconsistent-default-image-template"
+
+			By("attempting to create a template whose default image would be un-creatable")
+			path := BuildTestResourcePath(templateFilename, groupDir, subgroupValidation)
+			cmd := exec.Command("kubectl", "apply", "-f", path)
+			output, err := utils.Run(cmd)
+			Expect(err).To(HaveOccurred(), "template webhook should reject a self-inconsistent image policy")
+			Expect(output).To(ContainSubstring("defaultImage"),
+				"rejection should explain the defaultImage / allowedImages inconsistency")
+
+			By("verifying the template was not created")
+			cmd = exec.Command("kubectl", verbGet, "workspacetemplate", templateName,
+				"-n", SharedNamespace, "--ignore-not-found")
+			output, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).To(BeEmpty(), "template should not exist after webhook rejection")
+		})
+	})
+
 	Context("Mutability and Deletion Protection", func() {
 		It("should prevent template deletion when workspace is using it", func() {
 			workspaceName := "deletion-protection-workspace"


### PR DESCRIPTION
This PR a/ expands consistency check on template admission (idle timeout setting consistency), b/ private storage settings on workspace admission.

Closes: #439 
Closes: #440

### Implementation
1. update template validation webhook
    1.1. enforce that when `template.spec.idleShutdownOverrides.allow=true`, then `template.spec.defaultIdleShutdown` is defined
    1.2. enforce idle shutdown timeout rules: `min <= default <= max`
    1.3. enforce that when `len(allowedImages) > 0`, then `defaultImage` is in  `allowedImages`
    1.4. enforce that `resources.limits` is consistent with `resources.requests`
2. update workspace validation webhook
    2.1. enforce that when the PV exists for a workspace, we don't request to shrink it
3. update documentation

### Testing
- E2E test cases on template admission (idleTimeout bound checks)
- E2E test cases on workspace storage admission (disallow shrinkage)