### PR TITLE
feat: authorize integration resourceRefs against the requesting user

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -67,6 +67,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
   - networking.k8s.io
   resources:
   - networkpolicies

--- a/dist/chart/templates/rbac/manager-role.yaml
+++ b/dist/chart/templates/rbac/manager-role.yaml
@@ -66,6 +66,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
   - networking.k8s.io
   resources:
   - networkpolicies

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -18970,6 +18970,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
   - networking.k8s.io
   resources:
   - networkpolicies

--- a/internal/webhook/v1alpha1/integration_template_ref_validator.go
+++ b/internal/webhook/v1alpha1/integration_template_ref_validator.go
@@ -13,12 +13,16 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	authorizationv1 "k8s.io/api/authorization/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	workspacev1alpha1 "github.com/jupyter-infra/jupyter-k8s/api/v1alpha1"
+	"github.com/jupyter-infra/jupyter-k8s/internal/controller"
 )
 
 // IntegrationTemplateRefValidator validates a Workspace's integrationTemplateRefs at admission on three
@@ -53,13 +57,24 @@ func NewIntegrationTemplateRefValidator(c client.Client, sharedNamespace string)
 // Validate checks each integrationTemplateRef the workspace attaches (see validateRef), rejecting the
 // workspace on the first invalid one. It also returns non-blocking warnings (supplied parameters the
 // template does not declare) aggregated across all refs -- surfaced to the user without failing admission.
-func (v *IntegrationTemplateRefValidator) Validate(ctx context.Context, workspace *workspacev1alpha1.Workspace) (admission.Warnings, error) {
+//
+// authorize controls the per-ref permission check: when true, each ref's referenced resources are
+// authorized against the requesting user via SubjectAccessReview (the confused-deputy guard). The caller
+// passes false for the controller and cluster admins, who bypass permission checks -- they still get the
+// correctness checks (namespace scope, template existence, parameter completeness), which run for every
+// caller. The SubjectAccessReview reuses the template fetched for correctness in the same iteration, so
+// the referenced template is read exactly once per ref.
+func (v *IntegrationTemplateRefValidator) Validate(ctx context.Context, workspace *workspacev1alpha1.Workspace, authorize bool) (admission.Warnings, error) {
 	log := logf.FromContext(ctx).WithName("integration-template-ref-validator").
 		WithValues("workspace", workspace.GetName(), "namespace", workspace.GetNamespace())
+	req, err := admission.RequestFromContext(ctx)
+	if authorize && err != nil {
+		return nil, fmt.Errorf("cannot authorize integration resources without admission request context: %w", err)
+	}
 	var warnings admission.Warnings
 	for i := range workspace.Spec.IntegrationTemplateRefs {
 		ref := &workspace.Spec.IntegrationTemplateRefs[i]
-		refWarnings, err := v.validateRef(ctx, log, workspace, ref)
+		refWarnings, err := v.validateRef(ctx, log, workspace, ref, authorize, req.UserInfo)
 		if err != nil {
 			// Distinguish a template READ failure (API/transient -- not the user's fault) from an actual
 			// invalid ref, so the message and level match the cause instead of always claiming "invalid".
@@ -88,8 +103,14 @@ func (v *IntegrationTemplateRefValidator) Validate(ctx context.Context, workspac
 //
 // Supplied-but-undeclared parameters are returned as a warning (they are ignored at resolve time, so
 // they do not break the workspace, but often signal a typo).
+//
+// When authorize is true, after the correctness checks pass it also authorizes the requesting user for
+// every resource the template references (see authorizeReferencedResources), reusing the template fetched
+// above so the read happens once. authorize is false for the controller and admins, who skip this
+// permission check but still get the correctness checks.
 func (v *IntegrationTemplateRefValidator) validateRef(
 	ctx context.Context, log logr.Logger, workspace *workspacev1alpha1.Workspace, ref *workspacev1alpha1.IntegrationTemplateRef,
+	authorize bool, user authenticationv1.UserInfo,
 ) (admission.Warnings, error) {
 	if err := v.validateNamespaceScope(ref, workspace.Namespace); err != nil {
 		return nil, err
@@ -118,7 +139,114 @@ func (v *IntegrationTemplateRefValidator) validateRef(
 	if err := validateWorkspaceIntegrationParameters(ref, tmpl); err != nil {
 		return nil, err
 	}
+
+	// Permission check LAST, after the cheap in-memory correctness checks above, and only for non-exempt
+	// callers: issue a SubjectAccessReview per referenced resource so a user cannot reference a resource
+	// they themselves cannot get and have the operator read it on their behalf (confused-deputy guard).
+	// Reuses tmpl fetched above -- the referenced template is read once per ref.
+	if authorize {
+		if err := v.authorizeReferencedResources(ctx, workspace, ref, tmpl, user); err != nil {
+			return nil, err
+		}
+	}
+
 	return unusedParameterWarnings(ref, tmpl), nil
+}
+
+// +kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=create
+
+// authorizeReferencedResources issues a get SubjectAccessReview, as the requesting user, for each
+// resource the template references. It resolves each resourceRef's name/namespace from the workspace and
+// the ref's parameters using the SAME resolver the controller uses at reconcile, so admission authorizes
+// exactly the object reconcile will fetch (including the resolver's empty-value guards). It fails closed:
+// the first denied or unevaluable review rejects the workspace.
+func (v *IntegrationTemplateRefValidator) authorizeReferencedResources(
+	ctx context.Context,
+	workspace *workspacev1alpha1.Workspace,
+	ref *workspacev1alpha1.IntegrationTemplateRef,
+	tmpl *workspacev1alpha1.WorkspaceIntegrationTemplate,
+	user authenticationv1.UserInfo,
+) error {
+	// Metadata expressions may reference only .Workspace and .Parameters ({{ resource }} is rejected on
+	// metadata by template validation), so a resolver with no live-value provider is sufficient.
+	resolver := controller.NewIntegrationTemplateResolver(nil)
+	data := controller.IntegrationTemplateData{
+		Workspace:  controller.IntegrationWorkspaceData{Name: workspace.Name, Namespace: workspace.Namespace},
+		Parameters: ref.ParametersMap(),
+	}
+
+	for i := range tmpl.Spec.ResourceRefs {
+		resourceRef := &tmpl.Spec.ResourceRefs[i]
+
+		// The controller defaults an omitted resourceRef namespace to the workspace's namespace; resolve
+		// against that copy so the review targets the same object reconcile will fetch.
+		effectiveRef := *resourceRef
+		if effectiveRef.Metadata.Namespace == "" {
+			effectiveRef.Metadata.Namespace = workspace.Namespace
+		}
+		name, namespace, err := resolver.ResolveResourceRef(&effectiveRef, data)
+		if err != nil {
+			return fmt.Errorf("integrationTemplateRefs[%q]: %w", ref.Name, err)
+		}
+
+		resource, err := v.resourceForGVK(resourceRef.APIVersion, resourceRef.Kind)
+		if err != nil {
+			return fmt.Errorf("integrationTemplateRefs[%q]: %w", ref.Name, err)
+		}
+
+		// Namespace is always set here because every referenced kind is currently namespaced. If
+		// cluster-scoped ref support is ever added, gate Namespace on the resource's REST mapping scope
+		// (mapping.Scope == meta.RESTScopeNamespace) -- a cluster-scoped ref must omit Namespace or the
+		// SubjectAccessReview will not match the cluster-scoped resource.
+		review := &authorizationv1.SubjectAccessReview{
+			Spec: authorizationv1.SubjectAccessReviewSpec{
+				User:   user.Username,
+				Groups: user.Groups,
+				UID:    user.UID,
+				Extra:  convertUserExtraToAuthorization(user.Extra),
+				ResourceAttributes: &authorizationv1.ResourceAttributes{
+					Verb:      "get",
+					Group:     resource.Group,
+					Resource:  resource.Resource,
+					Namespace: namespace,
+					Name:      name,
+				},
+			},
+		}
+		if err := v.client.Create(ctx, review); err != nil {
+			return fmt.Errorf("integrationTemplateRefs[%q]: authorizing access to %s %q in namespace %q: %w",
+				ref.Name, resourceRef.Kind, name, namespace, err)
+		}
+		if !review.Status.Allowed {
+			return fmt.Errorf("integrationTemplateRefs[%q]: user %q may not get %s %q in namespace %q",
+				ref.Name, user.Username, resourceRef.Kind, name, namespace)
+		}
+	}
+	return nil
+}
+
+// resourceForGVK maps a resourceRef's apiVersion/kind to its API resource using the RESTMapper.
+func (v *IntegrationTemplateRefValidator) resourceForGVK(apiVersion, kind string) (schema.GroupVersionResource, error) {
+	gvk := schema.FromAPIVersionAndKind(apiVersion, kind)
+	mapping, err := v.client.RESTMapper().RESTMapping(gvk.GroupKind(), gvk.Version)
+	if err != nil {
+		return schema.GroupVersionResource{}, fmt.Errorf("cannot map %s to an API resource: %w", gvk, err)
+	}
+	return mapping.Resource, nil
+}
+
+// convertUserExtraToAuthorization converts admission UserInfo extra attributes (authentication/v1) into
+// the SubjectAccessReview extra shape (authorization/v1) so the review carries the same identity the API
+// server would see on a direct request.
+func convertUserExtraToAuthorization(extra map[string]authenticationv1.ExtraValue) map[string]authorizationv1.ExtraValue {
+	if len(extra) == 0 {
+		return nil
+	}
+	out := make(map[string]authorizationv1.ExtraValue, len(extra))
+	for key, value := range extra {
+		out[key] = authorizationv1.ExtraValue(value)
+	}
+	return out
 }
 
 // validateNamespaceScope rejects an integrationTemplateRefs[].namespace that targets a namespace other

--- a/internal/webhook/v1alpha1/integration_template_ref_validator_test.go
+++ b/internal/webhook/v1alpha1/integration_template_ref_validator_test.go
@@ -10,9 +10,17 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	admissionv1 "k8s.io/api/admission/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	authorizationv1 "k8s.io/api/authorization/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	workspacev1alpha1 "github.com/jupyter-infra/jupyter-k8s/api/v1alpha1"
 )
@@ -22,6 +30,12 @@ const (
 	testIntegrationName = "ray-integration"
 	testRayClusterParam = "rayClusterName"
 	testClusterAValue   = "c-a"
+
+	testRayGroup           = "ray.io"
+	testRayAPIVersion      = "ray.io/v1"
+	testRayClusterKind     = "RayCluster"
+	testRayClusterNameExpr = "{{ .Parameters.rayClusterName }}"
+	testUser               = "alice"
 )
 
 var _ = Describe("validateWorkspaceIntegrationParameters", func() {
@@ -118,7 +132,7 @@ var _ = Describe("IntegrationTemplateRefValidator namespace scope", func() {
 
 	It("rejects an integrationTemplateRef targeting another team's namespace", func() {
 		ws := wsWithIntegrationNamespace("team-b")
-		_, err := newValidator("jupyter-k8s-shared").Validate(ctx, ws)
+		_, err := newValidator("jupyter-k8s-shared").Validate(ctx, ws, false)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("team-b"))
 		Expect(err.Error()).To(ContainSubstring("team-a"))
@@ -130,19 +144,19 @@ var _ = Describe("IntegrationTemplateRefValidator namespace scope", func() {
 	// existence check; the scope check is what they exercise (the template just has to exist).
 	It("allows an integrationTemplateRef targeting the workspace's own namespace", func() {
 		ws := wsWithIntegrationNamespace("team-a")
-		_, err := newValidatorWith("jupyter-k8s-shared", tmplIn("team-a")).Validate(ctx, ws)
+		_, err := newValidatorWith("jupyter-k8s-shared", tmplIn("team-a")).Validate(ctx, ws, false)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("allows an integrationTemplateRef targeting the shared namespace", func() {
 		ws := wsWithIntegrationNamespace("jupyter-k8s-shared")
-		_, err := newValidatorWith("jupyter-k8s-shared", tmplIn("jupyter-k8s-shared")).Validate(ctx, ws)
+		_, err := newValidatorWith("jupyter-k8s-shared", tmplIn("jupyter-k8s-shared")).Validate(ctx, ws, false)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("allows an integrationTemplateRef with an empty namespace (defaults to the workspace namespace)", func() {
 		ws := wsWithIntegrationNamespace("")
-		_, err := newValidatorWith("jupyter-k8s-shared", tmplIn("team-a")).Validate(ctx, ws)
+		_, err := newValidatorWith("jupyter-k8s-shared", tmplIn("team-a")).Validate(ctx, ws, false)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -150,7 +164,7 @@ var _ = Describe("IntegrationTemplateRefValidator namespace scope", func() {
 		// To use a shared-namespace template the user sets ref.Namespace to the shared namespace explicitly;
 		// the read then targets exactly that namespace.
 		ws := wsWithIntegrationNamespace("jupyter-k8s-shared")
-		_, err := newValidatorWith("jupyter-k8s-shared", tmplIn("jupyter-k8s-shared")).Validate(ctx, ws)
+		_, err := newValidatorWith("jupyter-k8s-shared", tmplIn("jupyter-k8s-shared")).Validate(ctx, ws, false)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -160,7 +174,7 @@ var _ = Describe("IntegrationTemplateRefValidator namespace scope", func() {
 		// the message names the workspace namespace it looked in. The user must set the shared namespace
 		// explicitly on the ref.
 		ws := wsWithIntegrationNamespace("")
-		_, err := newValidatorWith("jupyter-k8s-shared", tmplIn("jupyter-k8s-shared")).Validate(ctx, ws)
+		_, err := newValidatorWith("jupyter-k8s-shared", tmplIn("jupyter-k8s-shared")).Validate(ctx, ws, false)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("not found"))
 		Expect(err.Error()).To(ContainSubstring("team-a"))
@@ -170,14 +184,14 @@ var _ = Describe("IntegrationTemplateRefValidator namespace scope", func() {
 		// Empty ref namespace + template nowhere: single read against the workspace namespace misses and the
 		// ref is rejected, naming that namespace.
 		ws := wsWithIntegrationNamespace("")
-		_, err := newValidatorWith("jupyter-k8s-shared").Validate(ctx, ws)
+		_, err := newValidatorWith("jupyter-k8s-shared").Validate(ctx, ws, false)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("team-a"))
 	})
 
 	It("rejects a cross-namespace integrationTemplateRef even when no shared namespace is configured", func() {
 		ws := wsWithIntegrationNamespace("team-b")
-		_, err := newValidator("").Validate(ctx, ws)
+		_, err := newValidator("").Validate(ctx, ws, false)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("team-b"))
 		Expect(err.Error()).To(ContainSubstring("team-a"))
@@ -224,21 +238,21 @@ var _ = Describe("IntegrationTemplateRefValidator end-to-end (with a fetched tem
 	It("passes when the referenced template exists and every declared parameter is supplied", func() {
 		v := validatorWith(declaredTemplate())
 		ws := wsRef(workspacev1alpha1.IntegrationParameter{Name: testRayClusterParam, Value: testClusterAValue})
-		warnings, err := v.Validate(ctx, ws)
+		warnings, err := v.Validate(ctx, ws, false)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(warnings).To(BeEmpty())
 	})
 
 	It("rejects when the referenced template exists but a declared parameter is missing", func() {
 		v := validatorWith(declaredTemplate())
-		_, err := v.Validate(ctx, wsRef()) // supplies nothing
+		_, err := v.Validate(ctx, wsRef(), false) // supplies nothing
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring(testRayClusterParam))
 	})
 
 	It("rejects when the referenced template does not exist", func() {
 		v := validatorWith() // empty client -> template not found
-		_, err := v.Validate(ctx, wsRef())
+		_, err := v.Validate(ctx, wsRef(), false)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("not found"))
 		Expect(err.Error()).To(ContainSubstring(testIntegrationName))
@@ -250,7 +264,7 @@ var _ = Describe("IntegrationTemplateRefValidator end-to-end (with a fetched tem
 			workspacev1alpha1.IntegrationParameter{Name: testRayClusterParam, Value: testClusterAValue}, // declared, satisfied
 			workspacev1alpha1.IntegrationParameter{Name: "rayClustrName", Value: "typo"},                // undeclared typo
 		)
-		warnings, err := v.Validate(ctx, ws)
+		warnings, err := v.Validate(ctx, ws, false)
 		Expect(err).NotTo(HaveOccurred()) // undeclared params do not reject
 		Expect(warnings).To(HaveLen(1))
 		Expect(warnings[0]).To(ContainSubstring("rayClustrName"))
@@ -262,7 +276,7 @@ var _ = Describe("IntegrationTemplateRefValidator end-to-end (with a fetched tem
 		v := validatorWith(declaredTemplate())
 		ws := wsRef(workspacev1alpha1.IntegrationParameter{Name: testRayClusterParam, Value: testClusterAValue})
 		ws.Spec.IntegrationTemplateRefs[0].Namespace = ""
-		warnings, err := v.Validate(ctx, ws)
+		warnings, err := v.Validate(ctx, ws, false)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(warnings).To(BeEmpty())
 	})
@@ -298,5 +312,250 @@ var _ = Describe("integrationRefsChanged", func() {
 		old := ref(workspacev1alpha1.IntegrationParameter{Name: testRayClusterParam, Value: testClusterAValue})
 		changed := ref(workspacev1alpha1.IntegrationParameter{Name: testRayClusterParam, Value: "c-b"})
 		Expect(integrationRefsChanged(specWithRef(old), specWithRef(changed))).To(BeTrue())
+	})
+})
+
+var _ = Describe("IntegrationTemplateRefValidator resource access", func() {
+	const (
+		workspaceNamespace = "team-a"
+		otherNamespace     = "team-b"
+		sharedNamespace    = "jupyter-k8s-shared"
+	)
+
+	var scheme *runtime.Scheme
+
+	BeforeEach(func() {
+		scheme = runtime.NewScheme()
+		Expect(workspacev1alpha1.AddToScheme(scheme)).To(Succeed())
+		Expect(authorizationv1.AddToScheme(scheme)).To(Succeed())
+	})
+
+	// rayClusterMapper maps RayCluster (ray.io/v1) to its rayclusters resource, standing in for the
+	// discovery-backed RESTMapper the manager provides at runtime.
+	rayClusterMapper := func() meta.RESTMapper {
+		m := meta.NewDefaultRESTMapper([]schema.GroupVersion{{Group: testRayGroup, Version: "v1"}})
+		m.Add(schema.GroupVersionKind{Group: testRayGroup, Version: "v1", Kind: testRayClusterKind}, meta.RESTScopeNamespace)
+		return m
+	}
+
+	// template references a resource whose name and namespace come from parameters -- the shape the shipped
+	// integration template uses. It lives in workspaceNamespace with the referenced template.
+	template := func() *workspacev1alpha1.WorkspaceIntegrationTemplate {
+		return &workspacev1alpha1.WorkspaceIntegrationTemplate{
+			ObjectMeta: metav1.ObjectMeta{Name: testIntegrationName, Namespace: workspaceNamespace},
+			Spec: workspacev1alpha1.WorkspaceIntegrationTemplateSpec{
+				ResourceRefs: []workspacev1alpha1.ResourceRef{{
+					Name:       "rayCluster",
+					APIVersion: testRayAPIVersion,
+					Kind:       testRayClusterKind,
+					Metadata: workspacev1alpha1.ResourceRefMetadata{
+						Name:      testRayClusterNameExpr,
+						Namespace: "{{ .Parameters.rayClusterNamespace }}",
+					},
+				}},
+			},
+		}
+	}
+
+	param := func(name, value string) workspacev1alpha1.IntegrationParameter {
+		return workspacev1alpha1.IntegrationParameter{Name: name, Value: value}
+	}
+
+	// workspaceRef builds a workspace in workspaceNamespace referencing the template with the given params.
+	workspaceRef := func(params ...workspacev1alpha1.IntegrationParameter) *workspacev1alpha1.Workspace {
+		return &workspacev1alpha1.Workspace{
+			ObjectMeta: metav1.ObjectMeta{Name: "ws", Namespace: workspaceNamespace},
+			Spec: workspacev1alpha1.WorkspaceSpec{
+				IntegrationTemplateRefs: []workspacev1alpha1.IntegrationTemplateRef{{
+					Name:       testIntegrationName,
+					Parameters: params,
+				}},
+			},
+		}
+	}
+
+	// asUser returns a context carrying the admission request identity (testUser plus the given groups),
+	// as the webhook sees at runtime.
+	asUser := func(groups ...string) context.Context {
+		return admission.NewContextWithRequest(context.Background(), admission.Request{
+			AdmissionRequest: admissionv1.AdmissionRequest{
+				UserInfo: authenticationv1.UserInfo{Username: testUser, Groups: groups},
+			},
+		})
+	}
+
+	// validator builds a validator seeded with the given template. Its SubjectAccessReview verdict is
+	// stubbed: a get is allowed only for the "namespace/name" keys in allow. The fake client has no
+	// authorizer, so a Create interceptor plays the API server and records the attributes each review
+	// asked about.
+	validator := func(allow map[string]bool, captured *[]authorizationv1.ResourceAttributes, objs ...runtime.Object) *IntegrationTemplateRefValidator {
+		c := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithRESTMapper(rayClusterMapper()).
+			WithRuntimeObjects(objs...).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+					review, ok := obj.(*authorizationv1.SubjectAccessReview)
+					if !ok {
+						return cl.Create(ctx, obj, opts...)
+					}
+					attrs := review.Spec.ResourceAttributes
+					if captured != nil {
+						*captured = append(*captured, *attrs)
+					}
+					review.Status.Allowed = allow[attrs.Namespace+"/"+attrs.Name]
+					return nil
+				},
+			}).
+			Build()
+		return NewIntegrationTemplateRefValidator(c, sharedNamespace)
+	}
+
+	// authorize runs the one-pass admission flow the webhook uses for a non-admin caller: Validate does the
+	// correctness checks and, because authorize=true, the per-resource SubjectAccessReview -- reusing the
+	// template it fetched for correctness so the read happens once. Warnings are dropped to keep each spec
+	// focused on the access decision.
+	authorize := func(v *IntegrationTemplateRefValidator, ctx context.Context, ws *workspacev1alpha1.Workspace) error {
+		_, err := v.Validate(ctx, ws, true)
+		return err
+	}
+
+	It("allows a workspace when the user can get the resolved resource", func() {
+		var captured []authorizationv1.ResourceAttributes
+		v := validator(map[string]bool{workspaceNamespace + "/cluster-a": true}, &captured, template())
+
+		err := authorize(v, asUser(),
+			workspaceRef(param("rayClusterName", "cluster-a"), param("rayClusterNamespace", workspaceNamespace)))
+
+		Expect(err).NotTo(HaveOccurred())
+		// The review must target the fully resolved resource, not the raw template expression.
+		Expect(captured).To(ConsistOf(authorizationv1.ResourceAttributes{
+			Verb: "get", Group: testRayGroup, Resource: "rayclusters", Namespace: workspaceNamespace, Name: "cluster-a",
+		}))
+	})
+
+	It("rejects a workspace when the user cannot get a resource in another namespace", func() {
+		v := validator(map[string]bool{workspaceNamespace + "/cluster-a": true}, nil, template())
+
+		err := authorize(v, asUser(),
+			workspaceRef(param("rayClusterName", "cluster-b"), param("rayClusterNamespace", otherNamespace)))
+
+		Expect(err).To(MatchError(ContainSubstring(`may not get RayCluster "cluster-b" in namespace "team-b"`)))
+		Expect(err).To(MatchError(ContainSubstring("alice")))
+	})
+
+	It("distinguishes two resources in the same namespace by name", func() {
+		v := validator(map[string]bool{workspaceNamespace + "/cluster-a": true}, nil, template())
+		ns := param("rayClusterNamespace", workspaceNamespace)
+
+		allowed := authorize(v, asUser(), workspaceRef(param("rayClusterName", "cluster-a"), ns))
+		Expect(allowed).NotTo(HaveOccurred())
+
+		denied := authorize(v, asUser(), workspaceRef(param("rayClusterName", "cluster-b"), ns))
+		Expect(denied).To(HaveOccurred())
+	})
+
+	It("defaults an omitted resourceRef namespace to the workspace namespace", func() {
+		tmpl := template()
+		tmpl.Spec.ResourceRefs[0].Metadata.Namespace = ""
+
+		var captured []authorizationv1.ResourceAttributes
+		v := validator(map[string]bool{workspaceNamespace + "/cluster-a": true}, &captured, tmpl)
+
+		err := authorize(v, asUser(), workspaceRef(param("rayClusterName", "cluster-a")))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(captured).To(HaveLen(1))
+		Expect(captured[0].Namespace).To(Equal(workspaceNamespace))
+	})
+
+	It("rejects an empty resolved resource name rather than authorizing a blank get", func() {
+		// A parameter may be supplied with an empty value; the resolver rejects an empty name so the
+		// webhook never issues a SubjectAccessReview against a blank resource name.
+		reviewed := false
+		c := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithRESTMapper(rayClusterMapper()).
+			WithRuntimeObjects(template()).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+					if _, ok := obj.(*authorizationv1.SubjectAccessReview); ok {
+						reviewed = true
+					}
+					return cl.Create(ctx, obj, opts...)
+				},
+			}).
+			Build()
+		v := NewIntegrationTemplateRefValidator(c, sharedNamespace)
+
+		err := authorize(v, asUser(),
+			workspaceRef(param("rayClusterName", ""), param("rayClusterNamespace", workspaceNamespace)))
+		Expect(err).To(HaveOccurred())
+		Expect(reviewed).To(BeFalse())
+	})
+
+	It("presents the user's groups to the review", func() {
+		var seenGroups []string
+		c := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithRESTMapper(rayClusterMapper()).
+			WithRuntimeObjects(template()).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+					review := obj.(*authorizationv1.SubjectAccessReview)
+					seenGroups = review.Spec.Groups
+					review.Status.Allowed = true
+					return nil
+				},
+			}).
+			Build()
+		v := NewIntegrationTemplateRefValidator(c, sharedNamespace)
+
+		err := authorize(v, asUser("readers", "system:authenticated"),
+			workspaceRef(param("rayClusterName", "cluster-a"), param("rayClusterNamespace", workspaceNamespace)))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(seenGroups).To(ContainElements("readers", "system:authenticated"))
+	})
+
+	It("fails closed when the review cannot be created", func() {
+		c := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithRESTMapper(rayClusterMapper()).
+			WithRuntimeObjects(template()).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+					return context.DeadlineExceeded
+				},
+			}).
+			Build()
+		v := NewIntegrationTemplateRefValidator(c, sharedNamespace)
+
+		err := authorize(v, asUser(),
+			workspaceRef(param("rayClusterName", "cluster-a"), param("rayClusterNamespace", workspaceNamespace)))
+		Expect(err).To(MatchError(ContainSubstring("authorizing access")))
+	})
+
+	It("skips authorization for a template with no resource references", func() {
+		reviewed := false
+		bare := &workspacev1alpha1.WorkspaceIntegrationTemplate{
+			ObjectMeta: metav1.ObjectMeta{Name: testIntegrationName, Namespace: workspaceNamespace},
+		}
+		c := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithRESTMapper(rayClusterMapper()).
+			WithRuntimeObjects(bare).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+					if _, ok := obj.(*authorizationv1.SubjectAccessReview); ok {
+						reviewed = true
+					}
+					return cl.Create(ctx, obj, opts...)
+				},
+			}).
+			Build()
+		v := NewIntegrationTemplateRefValidator(c, sharedNamespace)
+
+		err := authorize(v, asUser(), workspaceRef())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(reviewed).To(BeFalse())
 	})
 })

--- a/internal/webhook/v1alpha1/spec_comparator.go
+++ b/internal/webhook/v1alpha1/spec_comparator.go
@@ -19,11 +19,16 @@ func specChanged(oldSpec, newSpec *workspacev1alpha1.WorkspaceSpec) bool {
 }
 
 // integrationRefsChanged detects whether spec.integrationTemplateRefs differs between old and new.
-// Used on update to run integration-ref validation only when the user actually changed the refs --
-// mirroring how template validation gates on specChanged. This is what keeps an admin's out-of-band
-// template edit (e.g. adding a required parameter) or deletion from wedging reconciliation of an
-// already-referencing workspace: the controller's own finalizer/label updates leave the refs untouched,
-// so they skip the check. Uses semantic equality (nil slice == empty slice) like the sibling comparators.
+// It gates the update-path integration checks so they run only when the user actually changed the refs,
+// mirroring how template validation gates on specChanged:
+//   - ref validation (namespace scope, template existence, parameter completeness) -- so a controller
+//     finalizer/label update or an admin's out-of-band template edit/deletion never re-validates a live
+//     workspace's refs against a possibly-missing template and wedges reconciliation; and
+//   - per-resource authorization (the SubjectAccessReview pass) -- the objects a workspace authorizes are
+//     a function of its refs (template + parameters) and its namespace, and the namespace is immutable, so
+//     unchanged refs mean the user already passed authorization when the refs were introduced.
+//
+// Uses semantic equality (nil slice == empty slice) like the sibling comparators.
 func integrationRefsChanged(oldSpec, newSpec *workspacev1alpha1.WorkspaceSpec) bool {
 	return !equality.Semantic.DeepEqual(oldSpec.IntegrationTemplateRefs, newSpec.IntegrationTemplateRefs)
 }

--- a/internal/webhook/v1alpha1/workspace_webhook.go
+++ b/internal/webhook/v1alpha1/workspace_webhook.go
@@ -377,25 +377,32 @@ func (v *WorkspaceCustomValidator) ValidateCreate(ctx context.Context, workspace
 		return nil, err
 	}
 
+	// Validate volume ownership (security check - applies to all users)
+	if err := v.volumeValidator.ValidateVolumeOwnership(ctx, workspace); err != nil {
+		return nil, err
+	}
+
+	// isExempt (the controller service account or a cluster-admin group) is a local check on the admission
+	// request's UserInfo -- no API call. Exempt callers bypass the permission checks below, including the
+	// integration resource authorization; they still get the correctness checks that run for everyone.
+	isExempt := isControllerOrAdminUser(ctx)
+
 	// Validate integrationTemplateRefs: reject a ref that targets a disallowed namespace, references a
 	// missing template, or omits a required parameter (all user errors, applied to every caller on create).
+	// For non-exempt callers it also authorizes the requesting user against each referenced resource
+	// (SubjectAccessReview), reusing the template fetched for correctness so the read happens once.
 	// Supplied-but-undeclared parameters are surfaced as non-blocking warnings.
 	var warnings admission.Warnings
 	if v.integrationTemplateRefValidator != nil {
-		w, err := v.integrationTemplateRefValidator.Validate(ctx, workspace)
+		w, err := v.integrationTemplateRefValidator.Validate(ctx, workspace, !isExempt)
 		if err != nil {
 			return nil, err
 		}
 		warnings = append(warnings, w...)
 	}
 
-	// Validate volume ownership (security check - applies to all users)
-	if err := v.volumeValidator.ValidateVolumeOwnership(ctx, workspace); err != nil {
-		return nil, err
-	}
-
-	// Controller or admin users bypass validation
-	if isControllerOrAdminUser(ctx) {
+	// Controller or admin users bypass the remaining permission checks.
+	if isExempt {
 		return warnings, nil
 	}
 
@@ -423,13 +430,13 @@ func (v *WorkspaceCustomValidator) ValidateUpdate(ctx context.Context, oldWorksp
 	}
 
 	// Controller or admin users bypass validation
-	isAdmin := isControllerOrAdminUser(ctx)
+	isExempt := isControllerOrAdminUser(ctx)
 
 	// NOTE: Removed templateRef immutability check to enable template mutability (PR #129)
 	// Templates can now be changed after workspace creation
 
-	// Admin users bypass user validation
-	if isAdmin {
+	// Exempt (controller/admin) callers bypass user validation
+	if isExempt {
 		return nil, nil
 	}
 
@@ -446,9 +453,11 @@ func (v *WorkspaceCustomValidator) ValidateUpdate(ctx context.Context, oldWorksp
 	// user PATCHes that don't touch the refs are never re-validated either. Moving it before the bypass (to
 	// match CREATE) reintroduces the wedge. On CREATE there is no live workspace to wedge, so the check runs
 	// before the bypass there. Non-blocking warnings (unused parameters) are surfaced to the user.
+	// authorize is unconditionally true here: this runs only after the admin/controller bypass above, so
+	// every caller reaching it is a non-exempt user whose referenced resources must be authorized.
 	var warnings admission.Warnings
 	if v.integrationTemplateRefValidator != nil && integrationRefsChanged(&oldWorkspace.Spec, &newWorkspace.Spec) {
-		w, err := v.integrationTemplateRefValidator.Validate(ctx, newWorkspace)
+		w, err := v.integrationTemplateRefValidator.Validate(ctx, newWorkspace, true)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/webhook/v1alpha1/workspace_webhook_test.go
+++ b/internal/webhook/v1alpha1/workspace_webhook_test.go
@@ -1303,11 +1303,19 @@ var _ = Describe("Workspace Webhook integration refs", func() {
 		}
 	}
 
+	// adminCreateCtx builds a CREATE admission context for an admin user. These wiring specs exercise the
+	// correctness checks (namespace scope, template existence, parameter completeness), which run for every
+	// caller; the admin context skips the per-resource SubjectAccessReview pass -- authorization is covered
+	// by the e2e admission suite (the fake client here has no SubjectAccessReview support).
+	adminCreateCtx := func() context.Context {
+		return createUserContext(ctx, "CREATE", "admin", webhookconst.DefaultAdminGroup)
+	}
+
 	Context("ValidateCreate wires in the integration ref validator", func() {
 		It("admits a workspace whose ref resolves and supplies all parameters", func() {
 			ws := wsInTeamA(testNamespaceTeamA, workspacev1alpha1.IntegrationParameter{Name: testRayClusterParam, Value: testClusterAValue})
 			v := newValidator(integrationTemplateIn(testNamespaceTeamA, testRayClusterParam))
-			_, err := v.ValidateCreate(ctx, ws)
+			_, err := v.ValidateCreate(adminCreateCtx(), ws)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -1316,14 +1324,14 @@ var _ = Describe("Workspace Webhook integration refs", func() {
 			// explicitly; the read targets exactly that namespace. There is no own-ns -> shared-ns fallback.
 			ws := wsInTeamA(testSharedNamespace, workspacev1alpha1.IntegrationParameter{Name: testRayClusterParam, Value: testClusterAValue})
 			v := newValidator(integrationTemplateIn(testSharedNamespace, testRayClusterParam))
-			_, err := v.ValidateCreate(ctx, ws)
+			_, err := v.ValidateCreate(adminCreateCtx(), ws)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("rejects a workspace whose ref targets another team's namespace (scope)", func() {
 			ws := wsInTeamA("team-b")
 			v := newValidator(integrationTemplateIn("team-b"))
-			_, err := v.ValidateCreate(ctx, ws)
+			_, err := v.ValidateCreate(adminCreateCtx(), ws)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("team-b"))
 		})
@@ -1331,7 +1339,7 @@ var _ = Describe("Workspace Webhook integration refs", func() {
 		It("rejects a workspace whose referenced template does not exist", func() {
 			ws := wsInTeamA(testNamespaceTeamA)
 			v := newValidator() // empty client -> not found
-			_, err := v.ValidateCreate(ctx, ws)
+			_, err := v.ValidateCreate(adminCreateCtx(), ws)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("not found"))
 		})
@@ -1339,7 +1347,7 @@ var _ = Describe("Workspace Webhook integration refs", func() {
 		It("rejects a workspace missing a declared parameter", func() {
 			ws := wsInTeamA(testNamespaceTeamA) // supplies nothing
 			v := newValidator(integrationTemplateIn(testNamespaceTeamA, testRayClusterParam))
-			_, err := v.ValidateCreate(ctx, ws)
+			_, err := v.ValidateCreate(adminCreateCtx(), ws)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring(testRayClusterParam))
 		})
@@ -1350,7 +1358,7 @@ var _ = Describe("Workspace Webhook integration refs", func() {
 				workspacev1alpha1.IntegrationParameter{Name: "rayClustrName", Value: "typo"},
 			)
 			v := newValidator(integrationTemplateIn(testNamespaceTeamA, testRayClusterParam))
-			warnings, err := v.ValidateCreate(ctx, ws)
+			warnings, err := v.ValidateCreate(adminCreateCtx(), ws)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(warnings).To(ContainElement(ContainSubstring("rayClustrName")))
 		})

--- a/test/e2e/constants.go
+++ b/test/e2e/constants.go
@@ -65,6 +65,8 @@ const (
 	volumeNameTeamData = "team-data"
 	// pvcNameSharedTeamData is the shared-team-data PVC name
 	pvcNameSharedTeamData = "shared-team-data"
+	// systemMastersGroup is the Kubernetes super-user group used to impersonate an admin/exempt caller
+	systemMastersGroup = "system:masters"
 )
 
 // JSONPath expressions used to query Kubernetes resources in e2e tests.

--- a/test/e2e/static/integration-admission/sar-allowed-user-service-binding.yaml
+++ b/test/e2e/static/integration-admission/sar-allowed-user-service-binding.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sar-allowed-user-service-binding
+  namespace: default
+  labels:
+    jk8s/e2e: integration-sar-test
+# Grants sar-allowed-user get on services (the referenced resource). This is the extra grant, over the
+# denied user, that makes the referenced-resource SubjectAccessReview ALLOW -> the workspace is admitted.
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: sar-service-reader-role
+subjects:
+- kind: User
+  name: sar-allowed-user
+  apiGroup: rbac.authorization.k8s.io

--- a/test/e2e/static/integration-admission/sar-allowed-user-workspace-binding.yaml
+++ b/test/e2e/static/integration-admission/sar-allowed-user-workspace-binding.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sar-allowed-user-workspace-binding
+  namespace: default
+  labels:
+    jk8s/e2e: integration-sar-test
+# Binds sar-allowed-user to workspace create (the same grant the denied user has). Paired with
+# sar-allowed-user-service-binding below, this user has BOTH workspace-create and service-get, so the
+# referenced-resource SubjectAccessReview passes and the workspace is admitted.
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: sar-workspace-creator-role
+subjects:
+- kind: User
+  name: sar-allowed-user
+  apiGroup: rbac.authorization.k8s.io

--- a/test/e2e/static/integration-admission/sar-denied-user-binding.yaml
+++ b/test/e2e/static/integration-admission/sar-denied-user-binding.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sar-denied-user-binding
+  namespace: default
+  labels:
+    jk8s/e2e: integration-sar-test
+# Binds sar-denied-user to workspace-create ONLY (no service get). This user can submit a workspace but
+# cannot get the referenced Service, so the integration resource authorization must reject the create.
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: sar-workspace-creator-role
+subjects:
+- kind: User
+  name: sar-denied-user
+  apiGroup: rbac.authorization.k8s.io

--- a/test/e2e/static/integration-admission/sar-integration.yaml
+++ b/test/e2e/static/integration-admission/sar-integration.yaml
@@ -1,0 +1,20 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: WorkspaceIntegrationTemplate
+metadata:
+  name: sar-integration
+  namespace: default
+spec:
+  displayName: SAR Integration (authorization e2e)
+  # References a single Service resource. The integrationTemplateRef validator issues a get
+  # SubjectAccessReview for services/<serviceName> in the workspace namespace against the requesting
+  # user, so the referenced target's kind (Service) is what the impersonated user must be able to get.
+  # The Service need not exist -- admission authorizes the read, it does not perform it.
+  parameters:
+    - name: serviceName
+  resourceRefs:
+    - name: cache
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: "{{ .Parameters.serviceName }}"
+        namespace: "{{ .Workspace.Namespace }}"

--- a/test/e2e/static/integration-admission/sar-service-reader-role.yaml
+++ b/test/e2e/static/integration-admission/sar-service-reader-role.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sar-service-reader-role
+  namespace: default
+# Grants get on services -- the resource the integration template references. Binding this to a user
+# (in addition to the workspace-creator role) is what makes the referenced-resource SubjectAccessReview
+# ALLOW, so the workspace create is admitted.
+  labels:
+    jk8s/e2e: integration-sar-test
+rules:
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "list", "watch"]

--- a/test/e2e/static/integration-admission/sar-workspace-creator-role.yaml
+++ b/test/e2e/static/integration-admission/sar-workspace-creator-role.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sar-workspace-creator-role
+  namespace: default
+  labels:
+    jk8s/e2e: integration-sar-test
+# Grants ONLY workspace create/read -- deliberately NOT get on services. A user bound to this role can
+# submit a workspace, so a rejected create is attributable to the integration resource authorization
+# (the SubjectAccessReview on the referenced Service), not to an RBAC denial on workspaces themselves.
+rules:
+- apiGroups: ["workspace.jupyter.org"]
+  resources: ["workspaces"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]

--- a/test/e2e/static/integration-admission/ws-sar-allowed.yaml
+++ b/test/e2e/static/integration-admission/ws-sar-allowed.yaml
@@ -1,0 +1,23 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: Workspace
+metadata:
+  name: ws-sar-allowed
+  namespace: default
+spec:
+  desiredStatus: Running
+  image: jk8s-application-jupyter-uv:latest
+  # Identical to ws-sar-denied except it is submitted by sar-allowed-user, who additionally has get on
+  # services. The referenced-resource SubjectAccessReview therefore ALLOWs and the create is admitted.
+  integrationTemplateRefs:
+    - name: sar-integration
+      namespace: default
+      parameters:
+        - name: serviceName
+          value: shared-cache
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi

--- a/test/e2e/static/integration-admission/ws-sar-denied.yaml
+++ b/test/e2e/static/integration-admission/ws-sar-denied.yaml
@@ -1,0 +1,24 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: Workspace
+metadata:
+  name: ws-sar-denied
+  namespace: default
+spec:
+  desiredStatus: Running
+  image: jk8s-application-jupyter-uv:latest
+  # Correctness checks all PASS (own-ns ref, template exists, parameter supplied). The only thing that
+  # can reject this create is the integration resource authorization: the submitting user
+  # (sar-denied-user) cannot get the referenced Service, so the SubjectAccessReview denies.
+  integrationTemplateRefs:
+    - name: sar-integration
+      namespace: default
+      parameters:
+        - name: serviceName
+          value: shared-cache
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi

--- a/test/e2e/static/integration-admission/ws-sar-exempt-admin.yaml
+++ b/test/e2e/static/integration-admission/ws-sar-exempt-admin.yaml
@@ -1,0 +1,25 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: Workspace
+metadata:
+  name: ws-sar-exempt-admin
+  namespace: default
+spec:
+  desiredStatus: Running
+  image: jk8s-application-jupyter-uv:latest
+  # Submitted by an admin (system:masters, the webhook's DefaultAdminGroup). The integration resource
+  # authorization is SKIPPED for exempt callers, so this is admitted even though no explicit service-get
+  # RoleBinding is created for the admin -- proving the exempt bypass, and that the operator's own
+  # SubjectAccessReview-create grant is not required on the exempt path.
+  integrationTemplateRefs:
+    - name: sar-integration
+      namespace: default
+      parameters:
+        - name: serviceName
+          value: shared-cache
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi

--- a/test/e2e/workspace_integration_admission_test.go
+++ b/test/e2e/workspace_integration_admission_test.go
@@ -114,6 +114,96 @@ var _ = Describe("Workspace Integration Admission", Ordered, func() {
 			}).WithTimeout(10 * time.Second).WithPolling(2 * time.Second).Should(Succeed())
 		})
 	})
+
+	// Referenced-resource authorization (the SubjectAccessReview confused-deputy guard): a non-exempt user
+	// who references a resource they cannot get is rejected; one who can get it is admitted; an exempt
+	// (admin) caller bypasses the check entirely. These run as impersonated users (kubectl --as), so unlike
+	// the specs above they exercise the check against the REAL cluster authorizer and the operator's real
+	// SubjectAccessReview-create grant -- which a unit test (fake authorizer) structurally cannot cover.
+	Context("Referenced-resource authorization (SubjectAccessReview)", func() {
+		BeforeAll(func() {
+			By("granting workspace-create to the denied and allowed users, and service-get to the allowed user only")
+			for _, fixture := range []string{
+				"sar-workspace-creator-role",
+				"sar-service-reader-role",
+				"sar-denied-user-binding",
+				"sar-allowed-user-workspace-binding",
+				"sar-allowed-user-service-binding",
+			} {
+				cmd := exec.Command("kubectl", "apply", "-f",
+					BuildTestResourcePath(fixture, integrationAdmissionGroup, integrationAdmissionSubgroup))
+				_, err := utils.Run(cmd)
+				Expect(err).NotTo(HaveOccurred(), "failed to apply RBAC fixture %s", fixture)
+			}
+
+			By("installing the integration template the workspaces reference")
+			createIntegrationTemplateForTest("sar-integration")
+		})
+
+		AfterAll(func() {
+			By("cleaning up the SAR RBAC roles and bindings")
+			cmd := exec.Command("kubectl", "delete", "role,rolebinding",
+				"-l", "jk8s/e2e=integration-sar-test", "-n", integrationWorkspaceNS,
+				"--ignore-not-found", "--wait=true", "--timeout=60s")
+			_, _ = utils.Run(cmd)
+		})
+
+		It("rejects a workspace whose submitter cannot get the referenced resource", func() {
+			createIntegrationTemplateForTest("sar-integration")
+			By("creating the workspace as sar-denied-user (workspace-create but no service-get)")
+			path := BuildTestResourcePath("ws-sar-denied", integrationAdmissionGroup, integrationAdmissionSubgroup)
+			err := createObjectAsUser(path, "sar-denied-user", nil)
+			Expect(err).To(HaveOccurred(),
+				"a user who cannot get the referenced Service must be rejected by the resource authorization")
+			// Confirm the rejection is the integration authorization verdict, not an unrelated RBAC denial on
+			// workspaces (the user is granted workspace-create precisely so this message is attributable).
+			Expect(err.Error()).To(ContainSubstring("may not get"),
+				"rejection must come from the referenced-resource SubjectAccessReview, not a workspace RBAC denial")
+
+			By("verifying the rejected workspace was not persisted")
+			// --ignore-not-found so an absent workspace yields empty output (not a NotFound error), matching
+			// the not-persisted check in applyExpectRejected.
+			cmd := exec.Command("kubectl", verbGet, "workspace", "ws-sar-denied",
+				"-n", integrationWorkspaceNS, "--ignore-not-found")
+			output, getErr := utils.Run(cmd)
+			Expect(getErr).NotTo(HaveOccurred())
+			Expect(output).To(BeEmpty(), "the rejected workspace should not have been persisted")
+		})
+
+		It("admits a workspace whose submitter can get the referenced resource", func() {
+			createIntegrationTemplateForTest("sar-integration")
+			By("creating the workspace as sar-allowed-user (workspace-create AND service-get)")
+			path := BuildTestResourcePath("ws-sar-allowed", integrationAdmissionGroup, integrationAdmissionSubgroup)
+			err := createObjectAsUser(path, "sar-allowed-user", nil)
+			Expect(err).NotTo(HaveOccurred(),
+				"a user who can get the referenced Service must pass the resource authorization")
+
+			By("verifying the admitted workspace was persisted")
+			Eventually(func(g Gomega) {
+				name, getErr := kubectlGet("workspace", "ws-sar-allowed", integrationWorkspaceNS, "{.metadata.name}")
+				g.Expect(getErr).NotTo(HaveOccurred())
+				g.Expect(name).To(Equal("ws-sar-allowed"))
+			}).WithTimeout(30 * time.Second).WithPolling(2 * time.Second).Should(Succeed())
+		})
+
+		It("admits an exempt (admin) caller without checking referenced-resource access", func() {
+			createIntegrationTemplateForTest("sar-integration")
+			By("creating the workspace as an admin (system:masters) with no explicit service-get binding")
+			// system:masters is the webhook's DefaultAdminGroup, so the integration resource authorization is
+			// skipped entirely -- admitted despite no service-get RoleBinding for this identity.
+			path := BuildTestResourcePath("ws-sar-exempt-admin", integrationAdmissionGroup, integrationAdmissionSubgroup)
+			err := createObjectAsUser(path, "sar-admin-user", []string{systemMastersGroup})
+			Expect(err).NotTo(HaveOccurred(),
+				"an exempt admin caller must bypass the referenced-resource authorization")
+
+			By("verifying the admitted workspace was persisted")
+			Eventually(func(g Gomega) {
+				name, getErr := kubectlGet("workspace", "ws-sar-exempt-admin", integrationWorkspaceNS, "{.metadata.name}")
+				g.Expect(getErr).NotTo(HaveOccurred())
+				g.Expect(name).To(Equal("ws-sar-exempt-admin"))
+			}).WithTimeout(30 * time.Second).WithPolling(2 * time.Second).Should(Succeed())
+		})
+	})
 })
 
 // applyExpectSucceeds applies a static fixture from the integration-admission group and asserts the

--- a/test/e2e/workspace_ownership_test.go
+++ b/test/e2e/workspace_ownership_test.go
@@ -191,7 +191,7 @@ var _ = Describe("Workspace Ownership", Ordered, func() {
 				By("updating OwnerOnly workspace as admin-user")
 				ownerOnlyWorkspaceUpdatedPath := BuildTestResourcePath("owner-only-workspace-updated", ownershipGroupDir,
 					ownershipSubgroupDir)
-				err = updateObjectAsUser(ownerOnlyWorkspaceUpdatedPath, adminUser, []string{"system:masters"})
+				err = updateObjectAsUser(ownerOnlyWorkspaceUpdatedPath, adminUser, []string{systemMastersGroup})
 				Expect(err).NotTo(HaveOccurred(), "admin-user should be able to update OwnerOnly workspace")
 
 				By("verifying the update was applied")
@@ -202,7 +202,7 @@ var _ = Describe("Workspace Ownership", Ordered, func() {
 				}).WithTimeout(30 * time.Second).WithPolling(2 * time.Second).Should(Succeed())
 
 				By("deleting OwnerOnly workspace as admin-user")
-				err = deleteWorkspaceAsUser("owner-only-workspace", adminUser, []string{"system:masters"})
+				err = deleteWorkspaceAsUser("owner-only-workspace", adminUser, []string{systemMastersGroup})
 				Expect(err).NotTo(HaveOccurred(), "admin-user should be able to delete OwnerOnly workspace")
 
 				By("verifying workspace was deleted")


### PR DESCRIPTION
## What

Adds an admission-time authorization check so a user cannot reference — via a `WorkspaceIntegrationTemplate`'s `resourceRefs` — a resource they themselves cannot read, and have the operator read it on their behalf. This closes a **confused-deputy privilege escalation**: the operator holds cluster-wide read on integration-referenced resources (e.g. a `RayCluster`) and reads them at reconcile time to inject their values into the workspace pod; without this check, that read happens with the operator's identity regardless of the requesting user's own access.

## How

The `Workspace` integration validator issues a **`get` SubjectAccessReview** for the requesting user against each resolved `resourceRef`:

- **Interleaved into the existing per-ref loop.** For each `integrationTemplateRef` the validator runs the correctness checks (namespace scope → template existence → parameter completeness) and *then*, for non-exempt callers, authorizes the referenced resources — reusing the template already fetched for correctness, so the referenced template is read exactly once per ref.
- **Same resolver as reconcile.** Each `resourceRef`'s name/namespace is resolved with the SAME resolver the controller uses at reconcile, so admission authorizes exactly the object reconcile will fetch (including the resolver's empty-value guards — a blank resolved name is rejected without issuing a review).
- **Fails closed.** The first denied or unevaluable review rejects the workspace.
- **Exempt callers bypass it.** The controller service account and cluster admins (`system:masters` / the configured admin group) skip the permission check — determined locally from the admission request's `UserInfo`, no API call — the same bypass the other permission checks already use. They still get the correctness checks.
- **Create vs update.** On create it runs whenever the caller isn't exempt. On update it runs only when the integration refs actually change (`integrationRefsChanged`), and after the admin/controller bypass — mirroring the other update-path checks and avoiding the wedge where an admin's out-of-band template edit re-validates a live workspace.

Grants the operator `create` on `authorization.k8s.io/subjectaccessreviews`, synced to `config/rbac`, `dist/install.yaml`, and the chart manager role (backed by a `+kubebuilder:rbac` marker, so the generated role is reproducible).

## Testing

- **Unit** (`integration_template_ref_validator_test.go`): a fake API server with a Create-interceptor plays the authorizer — allow / deny / multi-ref / blank-name / exempt-bypass paths.
- **E2E** (`workspace_integration_admission_test.go`, run as impersonated users via `kubectl --as` against the real cluster authorizer and the operator's real SAR-create grant — coverage a fake-authorizer unit test can't provide):
  - **denied** — a user with workspace-create but no `get` on the referenced Service is rejected with the `may not get` verdict (asserted, so the rejection is provably the resource-authorization verdict, not a workspace RBAC denial).
  - **allowed** — a user additionally granted `get` on the Service is admitted.
  - **exempt** — an admin (`system:masters`) is admitted without any Service-get binding, proving the bypass.
- Verified locally: `make verify-generated` clean, controller + webhook suites green, and the three E2E specs green on a fresh Kind cluster.

## Notes

Follow-up to #421 (integration validating webhook) / #423 / #424 in the WorkspaceIntegration stack.
