### PR TITLE
feat: emit edge-triggered Events on integration status transitions

### DIFF
--- a/internal/controller/conditions.go
+++ b/internal/controller/conditions.go
@@ -76,6 +76,13 @@ const (
 	// only) lets an admin see an unresolved integration on the Workspace status. The detailed cause is
 	// in the operator logs (reconcileIntegrationFreeze); the status message points there.
 	IntegrationReasonNotResolved = "NotResolved"
+
+	// Kubernetes Event reasons for integration status transitions (recorded on the Workspace via the
+	// EventRecorder, surfaced by `kubectl describe workspace`). These are EDGE-TRIGGERED: an event is
+	// emitted only when an integration's probe verdict changes, never on every report-only probe cadence
+	// (see getIntegrationStatusEvent), so a persistently-degraded integration does not spam the event stream.
+	IntegrationEventDegraded  = "IntegrationDegraded"
+	IntegrationEventRecovered = "IntegrationRecovered"
 )
 
 // NewCondition creates a new condition with the specified status

--- a/internal/controller/integration_prober.go
+++ b/internal/controller/integration_prober.go
@@ -210,6 +210,70 @@ func preserveConditionTimestamp(prior, next *workspacev1alpha1.IntegrationStatus
 	}
 }
 
+// integrationEvent describes a Kubernetes Event to record for an integration status transition. A zero
+// value (Type == "") means "no event": the verdict did not transition in a way worth recording.
+type integrationEvent struct {
+	Type    string // corev1.EventTypeNormal or corev1.EventTypeWarning
+	Reason  string // IntegrationEventDegraded / IntegrationEventRecovered
+	Message string
+}
+
+// getIntegrationStatusEvent decides whether an integration's probe-verdict change warrants a Kubernetes
+// Event on the Workspace, and of what kind. It is EDGE-TRIGGERED to avoid event spam on the flat
+// report-only probe cadence: an event fires only on a verdict TRANSITION, never for an unchanged re-probe.
+//
+//   - newly-seen not-ready (no prior), Ready->not-ready, or a reason change while still not-ready
+//     (e.g. PodNotFound->ProbeFailed) -> Warning IntegrationDegraded.
+//   - not-ready -> Ready -> Normal IntegrationRecovered.
+//   - an unchanged verdict (same condition Status+Reason), or a healthy first attach (no prior, Ready)
+//     -> no event: a steady-state healthy integration is silent.
+//
+// Message is deliberately excluded from the change test (mirrors preserveConditionTimestamp): a failing
+// probe's stderr can vary run-to-run without the verdict changing, and must not trigger a fresh event.
+func getIntegrationStatusEvent(name string, prior, next *workspacev1alpha1.IntegrationStatus) integrationEvent {
+	if next == nil || len(next.Conditions) == 0 {
+		return integrationEvent{}
+	}
+	nextCond := next.Conditions[0]
+	nextReady := nextCond.Status == metav1.ConditionTrue
+
+	var hadPrior, priorReady bool
+	var priorReason string
+	if prior != nil && len(prior.Conditions) > 0 {
+		hadPrior = true
+		priorReady = prior.Conditions[0].Status == metav1.ConditionTrue
+		priorReason = prior.Conditions[0].Reason
+	}
+
+	if nextReady {
+		// Announce a RECOVERY only (was not-ready -> now Ready). A healthy first attach (no prior) or a
+		// steady-state Ready re-probe stays silent.
+		if hadPrior && !priorReady {
+			return integrationEvent{
+				Type:    corev1.EventTypeNormal,
+				Reason:  IntegrationEventRecovered,
+				Message: fmt.Sprintf("integration %q is ready", name),
+			}
+		}
+		return integrationEvent{}
+	}
+
+	// next is not ready. Skip an unchanged not-ready verdict (same reason); emit on newly-seen, a
+	// transition from Ready, or a reason change while still not-ready.
+	if hadPrior && !priorReady && priorReason == nextCond.Reason {
+		return integrationEvent{}
+	}
+	msg := fmt.Sprintf("integration %q is not ready (%s)", name, nextCond.Reason)
+	if nextCond.Message != "" {
+		msg = fmt.Sprintf("%s: %s", msg, nextCond.Message)
+	}
+	return integrationEvent{
+		Type:    corev1.EventTypeWarning,
+		Reason:  IntegrationEventDegraded,
+		Message: msg,
+	}
+}
+
 // FindRunningPod locates a running pod for the workspace by its labels (mirrors the idle checker).
 func (p *IntegrationProber) FindRunningPod(ctx context.Context, workspace *workspacev1alpha1.Workspace) (*corev1.Pod, error) {
 	podList := &corev1.PodList{}

--- a/internal/controller/integration_prober_test.go
+++ b/internal/controller/integration_prober_test.go
@@ -18,6 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -548,5 +549,140 @@ func TestIntegrationProber_EmptyExecCommand(t *testing.T) {
 				t.Errorf("%s: want reason=%q, got %+v", name, IntegrationReasonProbeError, cond)
 			}
 		})
+	}
+}
+
+// statusWithReason builds an IntegrationStatus carrying a single Ready condition of the given verdict, for
+// exercising the edge-triggered event decision. nil reason/ready combinations are the caller's choice.
+func statusWithReason(name string, ready bool, reason, msg string) *workspacev1alpha1.IntegrationStatus {
+	s := buildIntegrationStatus(name, ready, reason, msg)
+	return &s
+}
+
+// TestIntegrationStatusEvent covers the edge-triggered event decision directly: an event fires only on a
+// verdict TRANSITION (never on an unchanged re-probe), a healthy first attach is silent, a not-ready ->
+// Ready flip recovers, and a reason change while still not-ready re-warns. This is the anti-spam contract.
+func TestIntegrationStatusEvent(t *testing.T) {
+	const name = "ray"
+	ready := func(msg string) *workspacev1alpha1.IntegrationStatus {
+		return statusWithReason(name, true, IntegrationReasonReady, msg)
+	}
+	failed := func(reason, msg string) *workspacev1alpha1.IntegrationStatus {
+		return statusWithReason(name, false, reason, msg)
+	}
+
+	cases := []struct {
+		name       string
+		prior      *workspacev1alpha1.IntegrationStatus
+		next       *workspacev1alpha1.IntegrationStatus
+		wantType   string // "" means no event expected
+		wantReason string
+	}{
+		{"healthy first attach -> silent", nil, ready(""), "", ""},
+		{"steady-state Ready re-probe -> silent", ready(""), ready(""), "", ""},
+		{"first-seen not-ready -> Warning", nil, failed(IntegrationReasonProbeFailed, probeFailMsg), corev1.EventTypeWarning, IntegrationEventDegraded},
+		{"Ready -> not-ready -> Warning", ready(""), failed(IntegrationReasonProbeFailed, probeFailMsg), corev1.EventTypeWarning, IntegrationEventDegraded},
+		{"unchanged not-ready (same reason) -> silent", failed(IntegrationReasonProbeFailed, "at 10:00"), failed(IntegrationReasonProbeFailed, "at 10:05"), "", ""},
+		{"not-ready reason change -> Warning", failed(IntegrationReasonPodNotFound, ""), failed(IntegrationReasonProbeFailed, probeFailMsg), corev1.EventTypeWarning, IntegrationEventDegraded},
+		{"not-ready -> Ready -> Recovered", failed(IntegrationReasonProbeFailed, probeFailMsg), ready(""), corev1.EventTypeNormal, IntegrationEventRecovered},
+		{"nil next -> silent", ready(""), nil, "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ev := getIntegrationStatusEvent(name, tc.prior, tc.next)
+			if ev.Type != tc.wantType || ev.Reason != tc.wantReason {
+				t.Errorf("got type=%q reason=%q, want type=%q reason=%q", ev.Type, ev.Reason, tc.wantType, tc.wantReason)
+			}
+			if tc.wantType != "" && !strings.Contains(ev.Message, name) {
+				t.Errorf("event message must name the integration %q, got %q", name, ev.Message)
+			}
+		})
+	}
+}
+
+// drainRecorder collects all buffered events from a FakeRecorder without blocking (the channel is buffered),
+// so a spec can assert exactly which reasons fired across a sequence of probe cycles.
+func drainRecorder(r *record.FakeRecorder) []string {
+	var out []string
+	for {
+		select {
+		case e := <-r.Events:
+			out = append(out, e)
+		default:
+			return out
+		}
+	}
+}
+
+// TestProbeIntegrationStatus_EmitsEdgeTriggeredEvents drives the full state-machine probe path with a real
+// FakeRecorder to prove the anti-spam contract end-to-end: a degraded integration emits ONE Warning on the
+// transition and stays silent while it remains degraded, then emits ONE Normal event when it recovers.
+func TestProbeIntegrationStatus_EmitsEdgeTriggeredEvents(t *testing.T) {
+	ns, wsName := testNamespace, "event-ws"
+	rm := proberResourceManager(probeTemplate(intReadyName, ns, true))
+	pod := runningWSPod(ns, wsName)
+
+	newWS := func() *workspacev1alpha1.Workspace {
+		ws := &workspacev1alpha1.Workspace{
+			ObjectMeta: metav1.ObjectMeta{Name: wsName, Namespace: ns},
+			Spec:       workspacev1alpha1.WorkspaceSpec{IntegrationTemplateRefs: []workspacev1alpha1.IntegrationTemplateRef{ref(intReadyName)}},
+		}
+		ws.Status.ResolvedIntegrations = []workspacev1alpha1.ResolvedIntegration{{Name: intReadyName}}
+		return ws
+	}
+
+	recorder := record.NewFakeRecorder(10)
+	failVerdict := buildIntegrationStatus(intReadyName, false, IntegrationReasonProbeFailed, probeFailMsg)
+	mock := &mockIntegrationProber{pod: pod, probeByName: map[string]workspacev1alpha1.IntegrationStatus{intReadyName: failVerdict}}
+	sm := &StateMachine{resourceManager: rm, integrationProber: mock, recorder: recorder}
+
+	ws := newWS()
+
+	// Cycle 1: first probe returns ProbeFailed -> exactly one Warning IntegrationDegraded.
+	sm.probeIntegrationStatus(context.Background(), ws)
+	events := drainRecorder(recorder)
+	if len(events) != 1 || !strings.Contains(events[0], IntegrationEventDegraded) || !strings.Contains(events[0], "Warning") {
+		t.Fatalf("cycle 1: want one Warning %s event, got %v", IntegrationEventDegraded, events)
+	}
+
+	// Cycle 2: still ProbeFailed (unchanged verdict) -> NO new event (edge-triggered, not per-cadence).
+	sm.probeIntegrationStatus(context.Background(), ws)
+	if events := drainRecorder(recorder); len(events) != 0 {
+		t.Fatalf("cycle 2: unchanged degraded verdict must emit no event, got %v", events)
+	}
+
+	// Cycle 3: probe now returns Ready -> exactly one Normal IntegrationRecovered.
+	mock.probeByName[intReadyName] = buildIntegrationStatus(intReadyName, true, IntegrationReasonReady, "")
+	sm.probeIntegrationStatus(context.Background(), ws)
+	events = drainRecorder(recorder)
+	if len(events) != 1 || !strings.Contains(events[0], IntegrationEventRecovered) || !strings.Contains(events[0], "Normal") {
+		t.Fatalf("cycle 3: want one Normal %s event, got %v", IntegrationEventRecovered, events)
+	}
+
+	// Cycle 4: steady-state Ready re-probe -> silent.
+	sm.probeIntegrationStatus(context.Background(), ws)
+	if events := drainRecorder(recorder); len(events) != 0 {
+		t.Fatalf("cycle 4: steady-state Ready re-probe must emit no event, got %v", events)
+	}
+}
+
+// TestProbeIntegrationStatus_HealthyFirstAttachIsSilent guards the common case: a workspace whose
+// integration is Ready on the very first probe must not emit an event (no prior verdict to transition from).
+func TestProbeIntegrationStatus_HealthyFirstAttachIsSilent(t *testing.T) {
+	ns, wsName := testNamespace, "healthy-ws"
+	rm := proberResourceManager(probeTemplate(intReadyName, ns, true))
+	recorder := record.NewFakeRecorder(10)
+	mock := &mockIntegrationProber{pod: runningWSPod(ns, wsName)} // default Probe() returns Ready
+	sm := &StateMachine{resourceManager: rm, integrationProber: mock, recorder: recorder}
+
+	ws := &workspacev1alpha1.Workspace{
+		ObjectMeta: metav1.ObjectMeta{Name: wsName, Namespace: ns},
+		Spec:       workspacev1alpha1.WorkspaceSpec{IntegrationTemplateRefs: []workspacev1alpha1.IntegrationTemplateRef{ref(intReadyName)}},
+	}
+	ws.Status.ResolvedIntegrations = []workspacev1alpha1.ResolvedIntegration{{Name: intReadyName}}
+
+	sm.probeIntegrationStatus(context.Background(), ws)
+	if events := drainRecorder(recorder); len(events) != 0 {
+		t.Fatalf("healthy first attach must be silent, got %v", events)
 	}
 }

--- a/internal/controller/state_machine.go
+++ b/internal/controller/state_machine.go
@@ -400,8 +400,15 @@ func (sm *StateMachine) probeIntegrationStatus(
 	var statuses []workspacev1alpha1.IntegrationStatus
 	// appendStatus preserves the prior timestamp on an unchanged verdict and records the status. There is
 	// no per-verdict interval math: every integration re-probes on the same flat operator cadence (the
-	// prober's ProbePeriod), mirroring how the idle checker requeues on a flat CheckInterval.
+	// prober's ProbePeriod), mirroring how the idle checker requeues on a flat CheckInterval. It also
+	// records a Kubernetes Event on a verdict TRANSITION (edge-triggered: never on an unchanged re-probe),
+	// so a degraded/recovered integration is visible via `kubectl describe workspace`, not only in status.
 	appendStatus := func(s workspacev1alpha1.IntegrationStatus) {
+		if sm.recorder != nil {
+			if ev := getIntegrationStatusEvent(s.Name, prior[s.Name], &s); ev.Type != "" {
+				sm.recorder.Event(workspace, ev.Type, ev.Reason, ev.Message)
+			}
+		}
 		preserveConditionTimestamp(prior[s.Name], &s)
 		statuses = append(statuses, s)
 	}


### PR DESCRIPTION
## What

Emit a Kubernetes **Event** on the `Workspace` when an integration's report-only status probe verdict changes, so a degraded or recovered integration is visible via `kubectl describe workspace` / `kubectl get events` — not only in `status.integrationStatuses[]`.

Follow-up to #424, answering @henrywa2's review question ("should we record an event as well?").

## How

The decision lives in a pure, unit-tested helper `getIntegrationStatusEvent(name, prior, next)` that is **edge-triggered** — it fires only on a verdict **transition**, never on an unchanged re-probe.

Edge-triggering is required here **by necessity**: `probeIntegrationStatus` runs every reconcile (the flat probe cadence, ~5m in the chart, plus every event-driven reconcile), so a naive `recorder.Event` in the not-ready branch would emit a duplicate event **every cycle** while an integration stays degraded and flood the event stream. This differs from the existing state-machine events (`WorkspaceStopped` / `IdleShutdown`), which sit on one-shot terminal transitions and so are naturally single-fire without any transition guard — the report-only probe has no such natural guard, so the helper provides one explicitly.

| Transition | Event |
|---|---|
| newly-seen not-ready · Ready→not-ready · reason change while not-ready | **Warning** `IntegrationDegraded` |
| not-ready → Ready | **Normal** `IntegrationRecovered` |
| unchanged verdict · healthy first attach | **silent** (no event) |

- Message is excluded from the change test (mirrors `preserveConditionTimestamp`), so a failing probe's run-to-run stderr does not retrigger an event.
- Wired at the single `appendStatus` choke point in `probeIntegrationStatus`, guarded on a non-nil recorder.
- **No RBAC/chart change** — the manager `ClusterRole` already grants `events` create.

## Testing

- `TestIntegrationStatusEvent` — 8 transition cases exercising the anti-spam decision directly (silent first-attach, silent steady-state, degrade, recover, reason-change re-warn, nil-next).
- `TestProbeIntegrationStatus_EmitsEdgeTriggeredEvents` — drives the full state-machine probe path with a real `FakeRecorder` over 4 cycles: degraded→**1 Warning**, unchanged→**0**, recovered→**1 Normal**, steady-state→**0**.
- `TestProbeIntegrationStatus_HealthyFirstAttachIsSilent` — a healthy first probe emits nothing.
- Verified locally: `golangci-lint run` and `golangci-lint run ./test/e2e/...` both 0 issues, controller unit suite green, `make verify-generated` clean.
