### PR TITLE
feat: drop per-ref namespace from resourceRef; always use the workspace namespace

### DIFF
--- a/api/v1alpha1/workspaceintegrationtemplate_types.go
+++ b/api/v1alpha1/workspaceintegrationtemplate_types.go
@@ -28,20 +28,17 @@ type ResourceRef struct {
 	// Kind of the target resource (e.g., "RayCluster")
 	Kind string `json:"kind"`
 
-	// Metadata identifies the specific object to fetch. Its name/namespace support template
-	// expressions: {{ .Workspace.Name }}, {{ .Parameters.X }}.
+	// Metadata identifies the specific object to fetch. Its name supports template
+	// expressions: {{ .Workspace.Name }}, {{ .Parameters.X }}. The object is always resolved in the
+	// referencing workspace's own namespace.
 	Metadata ResourceRefMetadata `json:"metadata"`
 }
 
-// ResourceRefMetadata is the templated object identity (name + optional namespace) of a ResourceRef.
+// ResourceRefMetadata is the templated object identity (name) of a ResourceRef. The object is always
+// looked up in the referencing workspace's namespace; a resourceRef cannot target another namespace.
 type ResourceRefMetadata struct {
 	// Name of the target object; supports template expressions.
 	Name string `json:"name"`
-
-	// Namespace of the target object; supports template expressions. Defaults to the workspace's
-	// namespace if omitted.
-	// +optional
-	Namespace string `json:"namespace,omitempty"`
 }
 
 // IntegrationTemplateParameter declares a single parameter a WorkspaceIntegrationTemplate consumes.

--- a/config/crd/bases/workspace.jupyter.org_workspaceintegrationtemplates.yaml
+++ b/config/crd/bases/workspace.jupyter.org_workspaceintegrationtemplates.yaml
@@ -5199,17 +5199,13 @@ spec:
                       type: string
                     metadata:
                       description: |-
-                        Metadata identifies the specific object to fetch. Its name/namespace support template
-                        expressions: {{ .Workspace.Name }}, {{ .Parameters.X }}.
+                        Metadata identifies the specific object to fetch. Its name supports template
+                        expressions: {{ .Workspace.Name }}, {{ .Parameters.X }}. The object is always resolved in the
+                        referencing workspace's own namespace.
                       properties:
                         name:
                           description: Name of the target object; supports template
                             expressions.
-                          type: string
-                        namespace:
-                          description: |-
-                            Namespace of the target object; supports template expressions. Defaults to the workspace's
-                            namespace if omitted.
                           type: string
                       required:
                       - name

--- a/dist/chart/templates/crd/workspaceintegrationtemplates.workspace.jupyter.org.yaml
+++ b/dist/chart/templates/crd/workspaceintegrationtemplates.workspace.jupyter.org.yaml
@@ -5202,17 +5202,13 @@ spec:
                       type: string
                     metadata:
                       description: |-
-                        Metadata identifies the specific object to fetch. Its name/namespace support template
-                        expressions: {{ "{{ .Workspace.Name }}" }}, {{ "{{ .Parameters.X }}" }}.
+                        Metadata identifies the specific object to fetch. Its name supports template
+                        expressions: {{ "{{ .Workspace.Name }}" }}, {{ "{{ .Parameters.X }}" }}. The object is always resolved in the
+                        referencing workspace's own namespace.
                       properties:
                         name:
                           description: Name of the target object; supports template
                             expressions.
-                          type: string
-                        namespace:
-                          description: |-
-                            Namespace of the target object; supports template expressions. Defaults to the workspace's
-                            namespace if omitted.
                           type: string
                       required:
                       - name

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -10560,17 +10560,13 @@ spec:
                       type: string
                     metadata:
                       description: |-
-                        Metadata identifies the specific object to fetch. Its name/namespace support template
-                        expressions: {{ .Workspace.Name }}, {{ .Parameters.X }}.
+                        Metadata identifies the specific object to fetch. Its name supports template
+                        expressions: {{ .Workspace.Name }}, {{ .Parameters.X }}. The object is always resolved in the
+                        referencing workspace's own namespace.
                       properties:
                         name:
                           description: Name of the target object; supports template
                             expressions.
-                          type: string
-                        namespace:
-                          description: |-
-                            Namespace of the target object; supports template expressions. Defaults to the workspace's
-                            namespace if omitted.
                           type: string
                       required:
                       - name

--- a/docs/source/reference/custom-resources/workspaceintegrationtemplate.md
+++ b/docs/source/reference/custom-resources/workspaceintegrationtemplate.md
@@ -90,7 +90,8 @@ _Appears in:_
 
 
 
-ResourceRefMetadata is the templated object identity (name + optional namespace) of a ResourceRef.
+ResourceRefMetadata is the templated object identity (name) of a ResourceRef. The object is always
+looked up in the referencing workspace's namespace; a resourceRef cannot target another namespace.
 
 _Appears in:_
 - [ResourceRef](#resourceref)
@@ -98,7 +99,6 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `name` _string_ | Name of the target object; supports template expressions. |  |  |
-| `namespace` _string_ | Namespace of the target object; supports template expressions. Defaults to the workspace's<br />namespace if omitted. |  | Optional: \{\} <br /> |
 
 
 

--- a/internal/controller/integration_template_resolver.go
+++ b/internal/controller/integration_template_resolver.go
@@ -164,39 +164,27 @@ func (r *IntegrationTemplateResolver) ResolveTemplateExpression(templateExpressi
 	return buf.String(), nil
 }
 
-// ResolveResourceRef resolves template expressions in a resourceRef's name/namespace fields
-// and validates they don't resolve to empty strings. The ref's name/namespace templates may
-// only reference workspace metadata and parameters — not other resources — so resources is
-// not threaded in here.
+// ResolveResourceRef resolves the template expression in a resourceRef's name field and validates
+// it doesn't resolve to an empty string. The ref's name template may only reference workspace
+// metadata and parameters — not other resources — so resources is not threaded in here.
 //
-// Namespace is +optional on the CRD ("defaults to the workspace's namespace if omitted"), but
-// this function does NOT apply that default: it requires both name and namespace to resolve to
-// non-empty strings. The caller is responsible for pre-filling the namespace default (typically
-// the workspace namespace) before calling — see the freeze capture path (fetchResources), which
-// sets effectiveRef.Metadata.Namespace when the field is empty. The empty checks here are a
-// defense-in-depth guard against an un-defaulted ref or a template that evaluates to "".
-func (r *IntegrationTemplateResolver) ResolveResourceRef(ref *workspacev1alpha1.ResourceRef, data IntegrationTemplateData) (resolvedName, resolvedNamespace string, err error) {
+// There is no per-ref namespace: the referenced object is always looked up in the referencing
+// workspace's own namespace, which the caller supplies (see fetchReferencedResources). The empty
+// check is a defense-in-depth guard against a template that evaluates to "".
+func (r *IntegrationTemplateResolver) ResolveResourceRef(ref *workspacev1alpha1.ResourceRef, data IntegrationTemplateData) (resolvedName string, err error) {
 	if ref == nil {
-		return "", "", fmt.Errorf("resourceRef is nil")
+		return "", fmt.Errorf("resourceRef is nil")
 	}
 
 	resolvedName, err = r.ResolveTemplateExpression(ref.Metadata.Name, data)
 	if err != nil {
-		return "", "", fmt.Errorf("resourceRef %q metadata.name template: %w", ref.Name, err)
+		return "", fmt.Errorf("resourceRef %q metadata.name template: %w", ref.Name, err)
 	}
 	if resolvedName == "" {
-		return "", "", fmt.Errorf("resourceRef %q metadata.name resolved to empty string (template: %q)", ref.Name, ref.Metadata.Name)
+		return "", fmt.Errorf("resourceRef %q metadata.name resolved to empty string (template: %q)", ref.Name, ref.Metadata.Name)
 	}
 
-	resolvedNamespace, err = r.ResolveTemplateExpression(ref.Metadata.Namespace, data)
-	if err != nil {
-		return "", "", fmt.Errorf("resourceRef %q metadata.namespace template: %w", ref.Name, err)
-	}
-	if resolvedNamespace == "" {
-		return "", "", fmt.Errorf("resourceRef %q metadata.namespace resolved to empty string (template: %q)", ref.Name, ref.Metadata.Namespace)
-	}
-
-	return resolvedName, resolvedNamespace, nil
+	return resolvedName, nil
 }
 
 // ResolvePodModifications resolves all template expressions across the templatable string

--- a/internal/controller/integration_template_resolver_test.go
+++ b/internal/controller/integration_template_resolver_test.go
@@ -139,25 +139,24 @@ func TestResolveTemplateExpression_FrozenReplayMissingKeyIsError(t *testing.T) {
 	}
 }
 
-func TestResolveResourceRef_TemplatedNameAndNamespace(t *testing.T) {
+func TestResolveResourceRef_TemplatedName(t *testing.T) {
 	r := NewIntegrationTemplateResolver(nil)
 	ref := &workspacev1alpha1.ResourceRef{
 		Name: rayClusterHandle, APIVersion: "ray.io/v1", Kind: rayClusterKind,
 		Metadata: workspacev1alpha1.ResourceRefMetadata{
-			Name:      "{{ .Parameters.rayClusterName }}",
-			Namespace: "{{ .Workspace.Namespace }}",
+			Name: "{{ .Parameters.rayClusterName }}",
 		},
 	}
 	data := IntegrationTemplateData{
 		Workspace:  IntegrationWorkspaceData{Namespace: testTeamNamespace},
 		Parameters: map[string]string{rayClusterNameKey: testClusterName},
 	}
-	name, ns, err := r.ResolveResourceRef(ref, data)
+	name, err := r.ResolveResourceRef(ref, data)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if name != testClusterName || ns != testTeamNamespace {
-		t.Fatalf("ResolveResourceRef = (%q,%q), want (demo,team-a)", name, ns)
+	if name != testClusterName {
+		t.Fatalf("ResolveResourceRef = %q, want %q", name, testClusterName)
 	}
 }
 
@@ -166,13 +165,12 @@ func TestResolveResourceRef_EmptyResolvedNameIsError(t *testing.T) {
 	ref := &workspacev1alpha1.ResourceRef{
 		Name: rayClusterHandle, APIVersion: "ray.io/v1", Kind: rayClusterKind,
 		Metadata: workspacev1alpha1.ResourceRefMetadata{
-			Name:      "{{ .Parameters.rayClusterName }}",
-			Namespace: "ns",
+			Name: "{{ .Parameters.rayClusterName }}",
 		},
 	}
 	// Parameter resolves to empty -> defense-in-depth empty check must fail.
 	data := IntegrationTemplateData{Parameters: map[string]string{rayClusterNameKey: ""}}
-	if _, _, err := r.ResolveResourceRef(ref, data); err == nil {
+	if _, err := r.ResolveResourceRef(ref, data); err == nil {
 		t.Fatal("expected an error when the resolved name is empty, got nil")
 	}
 }

--- a/internal/controller/resource_manager_integration.go
+++ b/internal/controller/resource_manager_integration.go
@@ -182,13 +182,11 @@ func (rm *ResourceManager) fetchReferencedResources(
 	refResolver *IntegrationTemplateResolver,
 ) (map[string]*unstructured.Unstructured, error) {
 	resources := make(map[string]*unstructured.Unstructured, len(template.Spec.ResourceRefs))
+	// A resourceRef is always resolved in the workspace's own namespace (there is no per-ref namespace).
+	resolvedNamespace := data.Workspace.Namespace
 	for i := range template.Spec.ResourceRefs {
 		ref := &template.Spec.ResourceRefs[i]
-		effectiveRef := *ref
-		if effectiveRef.Metadata.Namespace == "" {
-			effectiveRef.Metadata.Namespace = data.Workspace.Namespace
-		}
-		resolvedName, resolvedNamespace, err := refResolver.ResolveResourceRef(&effectiveRef, data)
+		resolvedName, err := refResolver.ResolveResourceRef(ref, data)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/controller/resource_manager_integration_test.go
+++ b/internal/controller/resource_manager_integration_test.go
@@ -130,8 +130,7 @@ func freezeTemplate(ns string) *workspacev1alpha1.WorkspaceIntegrationTemplate {
 			ResourceRefs: []workspacev1alpha1.ResourceRef{{
 				Name: rayClusterHandle, APIVersion: rayAPIVersion, Kind: rayClusterKind,
 				Metadata: workspacev1alpha1.ResourceRefMetadata{
-					Name:      rayClusterNameExpr,
-					Namespace: "{{ .Parameters.rayClusterNamespace }}",
+					Name: rayClusterNameExpr,
 				},
 			}},
 			DeploymentModifications: &workspacev1alpha1.DeploymentModifications{

--- a/internal/webhook/v1alpha1/integration_template_validation.go
+++ b/internal/webhook/v1alpha1/integration_template_validation.go
@@ -69,17 +69,13 @@ func validateIntegrationTemplate(tmpl *workspacev1alpha1.WorkspaceIntegrationTem
 		allowedResourceRefIDs[tmpl.Spec.ResourceRefs[i].Name] = true
 	}
 
-	// 2. A resourceRef's own metadata.name/namespace may interpolate .Workspace/.Parameters but NEVER
-	//    {{ resource }} (they identify the resource to fetch, so can't depend on a fetched one).
+	// 2. A resourceRef's own metadata.name may interpolate .Workspace/.Parameters but NEVER
+	//    {{ resource }} (it identifies the resource to fetch, so can't depend on a fetched one). There
+	//    is no per-ref namespace: the resource is always fetched in the workspace's own namespace.
 	for i := range tmpl.Spec.ResourceRefs {
 		ref := &tmpl.Spec.ResourceRefs[i]
 		if err := validateMetadataExpression(ref.Metadata.Name, allowedParamNames); err != nil {
 			return fmt.Errorf("resourceRef %q metadata.name: %w", ref.Name, err)
-		}
-		if ref.Metadata.Namespace != "" {
-			if err := validateMetadataExpression(ref.Metadata.Namespace, allowedParamNames); err != nil {
-				return fmt.Errorf("resourceRef %q metadata.namespace: %w", ref.Name, err)
-			}
 		}
 	}
 

--- a/internal/webhook/v1alpha1/integration_template_validation_test.go
+++ b/internal/webhook/v1alpha1/integration_template_validation_test.go
@@ -32,8 +32,7 @@ func validTemplate() *workspacev1alpha1.WorkspaceIntegrationTemplate {
 			ResourceRefs: []workspacev1alpha1.ResourceRef{{
 				Name: "rayCluster", APIVersion: "ray.io/v1", Kind: "RayCluster",
 				Metadata: workspacev1alpha1.ResourceRefMetadata{
-					Name:      "{{ .Parameters.rayClusterName }}",
-					Namespace: "{{ .Parameters.rayClusterNamespace }}",
+					Name: "{{ .Parameters.rayClusterName }}",
 				},
 			}},
 			DeploymentModifications: &workspacev1alpha1.DeploymentModifications{
@@ -211,17 +210,6 @@ func TestValidateIntegrationTemplate_PrimaryMergeEnvValidated(t *testing.T) {
 	err := validateIntegrationTemplate(tmpl)
 	if err == nil || !strings.Contains(err.Error(), "undeclared resourceRef") {
 		t.Fatalf("expected primaryContainerModifications mergeEnv to be validated, got: %v", err)
-	}
-}
-
-func TestValidateIntegrationTemplate_MetadataNamespaceRejectsResource(t *testing.T) {
-	tmpl := validTemplate()
-	// A resourceRef's metadata.namespace, like its name, identifies the resource to fetch and so may not
-	// depend on a fetched one -- a {{ resource }} there must be rejected, not only in metadata.name.
-	tmpl.Spec.ResourceRefs[0].Metadata.Namespace = `{{ resource "rayCluster" "{.metadata.namespace}" }}`
-	err := validateIntegrationTemplate(tmpl)
-	if err == nil || !strings.Contains(err.Error(), "may not reference resources") {
-		t.Fatalf("expected metadata.namespace to reject a {{ resource }} expression, got: %v", err)
 	}
 }
 

--- a/test/e2e/static/integration-admission/invalid-integration-undeclared-param.yaml
+++ b/test/e2e/static/integration-admission/invalid-integration-undeclared-param.yaml
@@ -17,7 +17,6 @@ spec:
       kind: Service
       metadata:
         name: "{{ .Parameters.serviceName }}"
-        namespace: "{{ .Workspace.Namespace }}"
   deploymentModifications:
     podModifications:
       primaryContainerModifications:

--- a/test/e2e/static/integration-admission/invalid-integration-undeclared-resource.yaml
+++ b/test/e2e/static/integration-admission/invalid-integration-undeclared-resource.yaml
@@ -15,7 +15,6 @@ spec:
       kind: Service
       metadata:
         name: "{{ .Parameters.serviceName }}"
-        namespace: "{{ .Workspace.Namespace }}"
   deploymentModifications:
     podModifications:
       additionalContainers:

--- a/test/e2e/static/integration-admission/valid-integration-shared.yaml
+++ b/test/e2e/static/integration-admission/valid-integration-shared.yaml
@@ -15,4 +15,3 @@ spec:
       kind: Service
       metadata:
         name: "{{ .Parameters.serviceName }}"
-        namespace: "{{ .Workspace.Namespace }}"

--- a/test/e2e/static/integration-admission/valid-integration.yaml
+++ b/test/e2e/static/integration-admission/valid-integration.yaml
@@ -16,4 +16,3 @@ spec:
       kind: Service
       metadata:
         name: "{{ .Parameters.serviceName }}"
-        namespace: "{{ .Workspace.Namespace }}"


### PR DESCRIPTION
## What

A `WorkspaceIntegrationTemplate`'s `resourceRefs` no longer carry a `metadata.namespace`. A referenced object is **always** resolved in the referencing workspace's own namespace — a resourceRef can no longer target another namespace.

## Why

The operator holds cluster-wide read on integration-referenced resources and reads them at reconcile time to inject their values into the workspace pod. A per-ref namespace let a workspace author point a resourceRef at **another** namespace and have the operator read it on their behalf — a confused-deputy cross-namespace read. Removing the field eliminates that class of access structurally, so no admission-time SubjectAccessReview is needed to guard it. (This supersedes the SAR approach in the now-closed #446.)

## How

- **API:** remove `ResourceRefMetadata.Namespace`; regenerate CRDs, `dist/install.yaml`, and reference docs. `resourceRefs[].metadata` now has only `name` (still required).
- **Resolver:** `ResolveResourceRef` resolves only the name and returns `(name, err)`.
- **Controller:** `fetchReferencedResources` looks the object up in the workspace's namespace directly (drops the per-ref namespace-default block).
- **Validation:** the template validator no longer validates a `metadata.namespace` expression.
- Update unit tests; drop the now-moot `metadata.namespace` `{{ resource }}` rejection test; strip the stray `namespace:` line from the four integration-admission e2e fixtures (the CRD does not preserve unknown fields, so the apiserver would otherwise reject them on apply).

## Testing

All six CI gates verified locally (CI-pinned toolchain: golangci-lint v2.12.2, kubebuilder 4.13.1):
- `make verify-generated` — generated files up to date
- `make test` (unit + envtest, incl. the freeze envtest that looks the RayCluster up in the workspace namespace) — all packages pass
- `make lint` + `make lint-e2e` — 0 issues
- `test-chart` (kind) — live `helm-deploy` STATUS: deployed, controller 1/1, installed WIT CRD confirms the namespace field is gone
- `test-e2e` (kind), focused on the **Workspace Integration Admission** suite — `SUCCESS! 8 Passed | 0 Failed`

Also live-verified on a HyperPod test cluster: a WIT with a single `rayClusterName` param resolves the sidecar FQDN using `.Workspace.Namespace` and freezes correctly.

## Notes

Follow-up in the WorkspaceIntegration stack (#421/#423/#424). Replaces the closed SAR PR #446.
