### PR TITLE
feat: add WebSocket connection type for k8s-native remote connections

### DIFF
--- a/api/connection/v1alpha1/workspace_connection_types.go
+++ b/api/connection/v1alpha1/workspace_connection_types.go
@@ -17,6 +17,9 @@ const (
 
 	// ConnectionTypeWebUI represents web UI connection type
 	ConnectionTypeWebUI = "web-ui"
+
+	// ConnectionTypeWebSocket represents WebSocket remote connection type
+	ConnectionTypeWebSocket = "websocket"
 )
 
 // WorkspaceConnectionRequestSpec represents the spec of a workspace connection request

--- a/api/connection/v1alpha1/workspace_connection_types.go
+++ b/api/connection/v1alpha1/workspace_connection_types.go
@@ -19,7 +19,7 @@ const (
 	ConnectionTypeWebUI = "web-ui"
 
 	// ConnectionTypeWebSocket represents WebSocket remote connection type
-	ConnectionTypeWebSocket = "websocket"
+	ConnectionTypeWebSocket = "ssh-over-websocket"
 )
 
 // WorkspaceConnectionRequestSpec represents the spec of a workspace connection request

--- a/internal/extensionapi/serverroute_connection.go
+++ b/internal/extensionapi/serverroute_connection.go
@@ -156,6 +156,72 @@ func (s *ExtensionServer) generateBearerTokenURL(r *http.Request, ws *workspacev
 	return fmt.Sprintf("%s?token=%s", bearerURL, token), nil
 }
 
+// generateWebSocketConnectionURL generates a WebSocket connection URL with JWT token.
+// Used for k8s-native remote connections (WebSocket proxy sidecar).
+// Returns a wss:// URL with the token as a query parameter. The client (Toolkit/connect script)
+// extracts the token and passes it via Authorization: Bearer header to the proxy.
+func (s *ExtensionServer) generateWebSocketConnectionURL(r *http.Request, ws *workspacev1alpha1.Workspace, accessStrategy *workspacev1alpha1.WorkspaceAccessStrategy) (string, error) {
+	user := GetUser(r)
+	if user == "" {
+		return "", fmt.Errorf("user information not found in request headers")
+	}
+	groups := GetGroups(r)
+	extra := GetExtra(r)
+
+	if accessStrategy == nil {
+		return "", fmt.Errorf("no AccessStrategy configured for workspace")
+	}
+	if accessStrategy.Spec.BearerAuthURLTemplate == "" {
+		return "", fmt.Errorf("BearerAuthURLTemplate not configured in AccessStrategy")
+	}
+
+	// Create signer based on access strategy
+	signer, err := s.signerFactory.CreateSigner(accessStrategy)
+	if err != nil {
+		return "", fmt.Errorf("failed to create signer: %w", err)
+	}
+
+	// Generate URL from template (reuses the same BearerAuthURLTemplate)
+	wsURL, err := s.renderBearerAuthURL(accessStrategy.Spec.BearerAuthURLTemplate, ws, accessStrategy)
+	if err != nil {
+		return "", fmt.Errorf("failed to render WebSocket URL: %w", err)
+	}
+
+	// Parse URL to extract domain and path for JWT claims
+	parsedURL, err := url.Parse(wsURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse generated URL: %w", err)
+	}
+
+	domain := parsedURL.Host
+	path := parsedURL.Path
+
+	// Strip /bearer-auth suffix if present (template may be shared with web UI)
+	if strings.HasSuffix(path, "/bearer-auth") {
+		path = strings.TrimSuffix(path, "/bearer-auth")
+		if path == "" {
+			path = "/"
+		}
+	}
+
+	// Generate JWT token for the WebSocket connection
+	token, err := signer.GenerateToken(user, groups, user, extra, path, domain, jwt.TokenTypeBootstrap, true)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate JWT token: %w", err)
+	}
+
+	// Replace scheme with wss:// and strip /bearer-auth from the URL
+	parsedURL.Scheme = "wss"
+	if strings.HasSuffix(parsedURL.Path, "/bearer-auth") {
+		parsedURL.Path = strings.TrimSuffix(parsedURL.Path, "/bearer-auth")
+		if parsedURL.Path == "" {
+			parsedURL.Path = "/"
+		}
+	}
+
+	return fmt.Sprintf("%s?token=%s", parsedURL.String(), token), nil
+}
+
 // generatePluginConnectionURL delegates connection URL generation to a plugin.
 func (s *ExtensionServer) generatePluginConnectionURL(r *http.Request, ws *workspacev1alpha1.Workspace, pluginName, action, connectionType string, resolvedContext map[string]string, namespace string) (string, error) {
 	pc, ok := s.pluginClients[pluginName]
@@ -269,6 +335,10 @@ func (s *ExtensionServer) HandleConnectionCreate(w http.ResponseWriter, r *http.
 		responseURL, err = s.generateBearerTokenURL(r, ws, accessStrategy)
 		responseType = connectionv1alpha1.ConnectionTypeWebUI
 
+	case connectionv1alpha1.ConnectionTypeWebSocket:
+		responseURL, err = s.generateWebSocketConnectionURL(r, ws, accessStrategy)
+		responseType = connectionv1alpha1.ConnectionTypeWebSocket
+
 	default:
 		// All *-remote types go through the plugin handler map
 		pluginName, action, found := resolveConnectionHandler(accessStrategy, connectionType)
@@ -277,15 +347,16 @@ func (s *ExtensionServer) HandleConnectionCreate(w http.ResponseWriter, r *http.
 			return
 		}
 		if pluginName == handlerK8sNative {
-			WriteKubernetesError(w, http.StatusBadRequest, fmt.Sprintf("k8s-native handler is not supported for remote connections (requested %q)", connectionType))
-			return
+			responseURL, err = s.generateWebSocketConnectionURL(r, ws, accessStrategy)
+			responseType = connectionType
+		} else {
+			if _, ok := s.pluginClients[pluginName]; !ok {
+				WriteKubernetesError(w, http.StatusBadRequest, "plugin endpoints not configured. Please configure controller.plugins in helm values")
+				return
+			}
+			responseURL, err = s.generatePluginConnectionURL(r, ws, pluginName, action, connectionType, resolvedContext, namespace)
+			responseType = connectionType
 		}
-		if _, ok := s.pluginClients[pluginName]; !ok {
-			WriteKubernetesError(w, http.StatusBadRequest, "plugin endpoints not configured. Please configure controller.plugins in helm values")
-			return
-		}
-		responseURL, err = s.generatePluginConnectionURL(r, ws, pluginName, action, connectionType, resolvedContext, namespace)
-		responseType = connectionType
 	}
 
 	if err != nil {
@@ -335,14 +406,16 @@ func validateWorkspaceConnectionRequest(req *connectionv1alpha1.WorkspaceConnect
 
 	connectionType := req.Spec.WorkspaceConnectionType
 
-	// Accept web-ui, known remote types, and any *-remote pattern
+	// Accept web-ui, websocket, known remote types, and any *-remote pattern
 	switch {
 	case connectionType == connectionv1alpha1.ConnectionTypeWebUI:
+		// valid
+	case connectionType == connectionv1alpha1.ConnectionTypeWebSocket:
 		// valid
 	case isRemoteConnectionType(connectionType):
 		// valid — known or unknown remote types are accepted
 	default:
-		return fmt.Errorf("invalid workspaceConnectionType: '%s'. Must be 'web-ui' or follow the '{ide}-remote' pattern (e.g. 'vscode-remote', 'kiro-remote', 'cursor-remote')", connectionType)
+		return fmt.Errorf("invalid workspaceConnectionType: '%s'. Must be 'web-ui', 'websocket', or follow the '{ide}-remote' pattern (e.g. 'vscode-remote', 'kiro-remote', 'cursor-remote')", connectionType)
 	}
 
 	return nil

--- a/internal/extensionapi/serverroute_connection.go
+++ b/internal/extensionapi/serverroute_connection.go
@@ -415,7 +415,7 @@ func validateWorkspaceConnectionRequest(req *connectionv1alpha1.WorkspaceConnect
 	case isRemoteConnectionType(connectionType):
 		// valid — known or unknown remote types are accepted
 	default:
-		return fmt.Errorf("invalid workspaceConnectionType: '%s'. Must be 'web-ui', 'websocket', or follow the '{ide}-remote' pattern (e.g. 'vscode-remote', 'kiro-remote', 'cursor-remote')", connectionType)
+		return fmt.Errorf("invalid workspaceConnectionType: '%s'. Must be 'web-ui', 'ssh-over-websocket', or follow the '{ide}-remote' pattern (e.g. 'vscode-remote', 'kiro-remote', 'cursor-remote')", connectionType)
 	}
 
 	return nil

--- a/internal/extensionapi/serverroute_connection_test.go
+++ b/internal/extensionapi/serverroute_connection_test.go
@@ -31,6 +31,8 @@ import (
 )
 
 const testUser = "test-user"
+const testWorkspaceMyWorkspace = "myworkspace"
+const testStrategyWebSocket = "ws-strategy"
 
 // mockSignerFactory for testing
 type mockSignerFactory struct {
@@ -128,7 +130,7 @@ func TestGenerateBearerTokenURL(t *testing.T) {
 
 func TestGenerateBearerTokenURL_SubdomainRouting(t *testing.T) {
 	workspace := &workspacev1alpha1.Workspace{
-		ObjectMeta: metav1.ObjectMeta{Name: "myworkspace", Namespace: namespaceDefault},
+		ObjectMeta: metav1.ObjectMeta{Name: testWorkspaceMyWorkspace, Namespace: namespaceDefault},
 		Spec: workspacev1alpha1.WorkspaceSpec{
 			AccessStrategy: &workspacev1alpha1.AccessStrategyRef{Name: "subdomain-strategy"},
 		},
@@ -902,7 +904,7 @@ func TestValidateWorkspaceConnectionRequest(t *testing.T) {
 				},
 			},
 			expectError: true,
-			errorMsg:    "invalid workspaceConnectionType: 'invalid-type'. Must be 'web-ui', 'websocket', or follow the '{ide}-remote' pattern (e.g. 'vscode-remote', 'kiro-remote', 'cursor-remote')",
+			errorMsg:    "invalid workspaceConnectionType: 'invalid-type'. Must be 'web-ui', 'ssh-over-websocket', or follow the '{ide}-remote' pattern (e.g. 'vscode-remote', 'kiro-remote', 'cursor-remote')",
 		},
 		{
 			name: "invalid connection type - bare remote",
@@ -913,7 +915,7 @@ func TestValidateWorkspaceConnectionRequest(t *testing.T) {
 				},
 			},
 			expectError: true,
-			errorMsg:    "invalid workspaceConnectionType: '-remote'. Must be 'web-ui', 'websocket', or follow the '{ide}-remote' pattern (e.g. 'vscode-remote', 'kiro-remote', 'cursor-remote')",
+			errorMsg:    "invalid workspaceConnectionType: '-remote'. Must be 'web-ui', 'ssh-over-websocket', or follow the '{ide}-remote' pattern (e.g. 'vscode-remote', 'kiro-remote', 'cursor-remote')",
 		},
 	}
 
@@ -1093,14 +1095,14 @@ func TestIsRemoteConnectionType(t *testing.T) {
 
 func TestGenerateWebSocketConnectionURL_Success(t *testing.T) {
 	workspace := &workspacev1alpha1.Workspace{
-		ObjectMeta: metav1.ObjectMeta{Name: "myworkspace", Namespace: namespaceDefault},
+		ObjectMeta: metav1.ObjectMeta{Name: testWorkspaceMyWorkspace, Namespace: namespaceDefault},
 		Spec: workspacev1alpha1.WorkspaceSpec{
-			AccessStrategy: &workspacev1alpha1.AccessStrategyRef{Name: "ws-strategy"},
+			AccessStrategy: &workspacev1alpha1.AccessStrategyRef{Name: testStrategyWebSocket},
 		},
 	}
 
 	accessStrategy := &workspacev1alpha1.WorkspaceAccessStrategy{
-		ObjectMeta: metav1.ObjectMeta{Name: "ws-strategy", Namespace: namespaceDefault},
+		ObjectMeta: metav1.ObjectMeta{Name: testStrategyWebSocket, Namespace: namespaceDefault},
 		Spec: workspacev1alpha1.WorkspaceAccessStrategySpec{
 			BearerAuthURLTemplate: "https://myworkspace-default.example.com/ssh-ws",
 		},
@@ -1133,15 +1135,15 @@ func TestGenerateWebSocketConnectionURL_Success(t *testing.T) {
 
 func TestGenerateWebSocketConnectionURL_StripsBearerAuth(t *testing.T) {
 	workspace := &workspacev1alpha1.Workspace{
-		ObjectMeta: metav1.ObjectMeta{Name: "myworkspace", Namespace: namespaceDefault},
+		ObjectMeta: metav1.ObjectMeta{Name: testWorkspaceMyWorkspace, Namespace: namespaceDefault},
 		Spec: workspacev1alpha1.WorkspaceSpec{
-			AccessStrategy: &workspacev1alpha1.AccessStrategyRef{Name: "ws-strategy"},
+			AccessStrategy: &workspacev1alpha1.AccessStrategyRef{Name: testStrategyWebSocket},
 		},
 	}
 
 	// Template with /bearer-auth suffix (shared with web UI)
 	accessStrategy := &workspacev1alpha1.WorkspaceAccessStrategy{
-		ObjectMeta: metav1.ObjectMeta{Name: "ws-strategy", Namespace: namespaceDefault},
+		ObjectMeta: metav1.ObjectMeta{Name: testStrategyWebSocket, Namespace: namespaceDefault},
 		Spec: workspacev1alpha1.WorkspaceAccessStrategySpec{
 			BearerAuthURLTemplate: "https://myworkspace-default.example.com/bearer-auth",
 		},
@@ -1172,7 +1174,7 @@ func TestGenerateWebSocketConnectionURL_StripsBearerAuth(t *testing.T) {
 
 func TestGenerateWebSocketConnectionURL_NoAccessStrategy(t *testing.T) {
 	workspace := &workspacev1alpha1.Workspace{
-		ObjectMeta: metav1.ObjectMeta{Name: "myworkspace", Namespace: namespaceDefault},
+		ObjectMeta: metav1.ObjectMeta{Name: testWorkspaceMyWorkspace, Namespace: namespaceDefault},
 	}
 
 	server := &ExtensionServer{
@@ -1192,11 +1194,11 @@ func TestGenerateWebSocketConnectionURL_NoAccessStrategy(t *testing.T) {
 
 func TestGenerateWebSocketConnectionURL_MissingUser(t *testing.T) {
 	workspace := &workspacev1alpha1.Workspace{
-		ObjectMeta: metav1.ObjectMeta{Name: "myworkspace", Namespace: namespaceDefault},
+		ObjectMeta: metav1.ObjectMeta{Name: testWorkspaceMyWorkspace, Namespace: namespaceDefault},
 	}
 
 	accessStrategy := &workspacev1alpha1.WorkspaceAccessStrategy{
-		ObjectMeta: metav1.ObjectMeta{Name: "ws-strategy", Namespace: namespaceDefault},
+		ObjectMeta: metav1.ObjectMeta{Name: testStrategyWebSocket, Namespace: namespaceDefault},
 		Spec: workspacev1alpha1.WorkspaceAccessStrategySpec{
 			BearerAuthURLTemplate: "https://myworkspace-default.example.com/ssh-ws",
 		},
@@ -1219,11 +1221,11 @@ func TestGenerateWebSocketConnectionURL_MissingUser(t *testing.T) {
 
 func TestGenerateWebSocketConnectionURL_MissingTemplate(t *testing.T) {
 	workspace := &workspacev1alpha1.Workspace{
-		ObjectMeta: metav1.ObjectMeta{Name: "myworkspace", Namespace: namespaceDefault},
+		ObjectMeta: metav1.ObjectMeta{Name: testWorkspaceMyWorkspace, Namespace: namespaceDefault},
 	}
 
 	accessStrategy := &workspacev1alpha1.WorkspaceAccessStrategy{
-		ObjectMeta: metav1.ObjectMeta{Name: "ws-strategy", Namespace: namespaceDefault},
+		ObjectMeta: metav1.ObjectMeta{Name: testStrategyWebSocket, Namespace: namespaceDefault},
 		Spec:       workspacev1alpha1.WorkspaceAccessStrategySpec{},
 	}
 

--- a/internal/extensionapi/serverroute_connection_test.go
+++ b/internal/extensionapi/serverroute_connection_test.go
@@ -902,7 +902,7 @@ func TestValidateWorkspaceConnectionRequest(t *testing.T) {
 				},
 			},
 			expectError: true,
-			errorMsg:    "invalid workspaceConnectionType: 'invalid-type'. Must be 'web-ui' or follow the '{ide}-remote' pattern (e.g. 'vscode-remote', 'kiro-remote', 'cursor-remote')",
+			errorMsg:    "invalid workspaceConnectionType: 'invalid-type'. Must be 'web-ui', 'websocket', or follow the '{ide}-remote' pattern (e.g. 'vscode-remote', 'kiro-remote', 'cursor-remote')",
 		},
 		{
 			name: "invalid connection type - bare remote",
@@ -913,7 +913,7 @@ func TestValidateWorkspaceConnectionRequest(t *testing.T) {
 				},
 			},
 			expectError: true,
-			errorMsg:    "invalid workspaceConnectionType: '-remote'. Must be 'web-ui' or follow the '{ide}-remote' pattern (e.g. 'vscode-remote', 'kiro-remote', 'cursor-remote')",
+			errorMsg:    "invalid workspaceConnectionType: '-remote'. Must be 'web-ui', 'websocket', or follow the '{ide}-remote' pattern (e.g. 'vscode-remote', 'kiro-remote', 'cursor-remote')",
 		},
 	}
 
@@ -1086,5 +1086,158 @@ func TestIsRemoteConnectionType(t *testing.T) {
 				t.Errorf("isRemoteConnectionType(%q) = %v, want %v", tt.connectionType, result, tt.expected)
 			}
 		})
+	}
+}
+
+// --- generateWebSocketConnectionURL tests ---
+
+func TestGenerateWebSocketConnectionURL_Success(t *testing.T) {
+	workspace := &workspacev1alpha1.Workspace{
+		ObjectMeta: metav1.ObjectMeta{Name: "myworkspace", Namespace: namespaceDefault},
+		Spec: workspacev1alpha1.WorkspaceSpec{
+			AccessStrategy: &workspacev1alpha1.AccessStrategyRef{Name: "ws-strategy"},
+		},
+	}
+
+	accessStrategy := &workspacev1alpha1.WorkspaceAccessStrategy{
+		ObjectMeta: metav1.ObjectMeta{Name: "ws-strategy", Namespace: namespaceDefault},
+		Spec: workspacev1alpha1.WorkspaceAccessStrategySpec{
+			BearerAuthURLTemplate: "https://myworkspace-default.example.com/ssh-ws",
+		},
+	}
+
+	server := &ExtensionServer{
+		config:        &ExtensionConfig{},
+		signerFactory: &mockSignerFactory{signer: &mockSigner{token: testToken}},
+	}
+
+	req := httptest.NewRequest("POST", "/test", nil)
+	req.Header.Set("X-Remote-User", testUser)
+
+	connURL, err := server.generateWebSocketConnectionURL(req, workspace, accessStrategy)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.HasPrefix(connURL, "wss://") {
+		t.Errorf("expected wss:// scheme, got: %s", connURL)
+	}
+	if !strings.Contains(connURL, "token="+testToken) {
+		t.Errorf("expected token in URL, got: %s", connURL)
+	}
+	if !strings.Contains(connURL, "myworkspace-default.example.com") {
+		t.Errorf("expected host in URL, got: %s", connURL)
+	}
+}
+
+func TestGenerateWebSocketConnectionURL_StripsBearerAuth(t *testing.T) {
+	workspace := &workspacev1alpha1.Workspace{
+		ObjectMeta: metav1.ObjectMeta{Name: "myworkspace", Namespace: namespaceDefault},
+		Spec: workspacev1alpha1.WorkspaceSpec{
+			AccessStrategy: &workspacev1alpha1.AccessStrategyRef{Name: "ws-strategy"},
+		},
+	}
+
+	// Template with /bearer-auth suffix (shared with web UI)
+	accessStrategy := &workspacev1alpha1.WorkspaceAccessStrategy{
+		ObjectMeta: metav1.ObjectMeta{Name: "ws-strategy", Namespace: namespaceDefault},
+		Spec: workspacev1alpha1.WorkspaceAccessStrategySpec{
+			BearerAuthURLTemplate: "https://myworkspace-default.example.com/bearer-auth",
+		},
+	}
+
+	server := &ExtensionServer{
+		config:        &ExtensionConfig{},
+		signerFactory: &mockSignerFactory{signer: &mockSigner{token: testToken}},
+	}
+
+	req := httptest.NewRequest("POST", "/test", nil)
+	req.Header.Set("X-Remote-User", testUser)
+
+	url, err := server.generateWebSocketConnectionURL(req, workspace, accessStrategy)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should strip /bearer-auth from the URL
+	if strings.Contains(url, "/bearer-auth") {
+		t.Errorf("expected /bearer-auth to be stripped, got: %s", url)
+	}
+	if !strings.HasPrefix(url, "wss://") {
+		t.Errorf("expected wss:// scheme, got: %s", url)
+	}
+}
+
+func TestGenerateWebSocketConnectionURL_NoAccessStrategy(t *testing.T) {
+	workspace := &workspacev1alpha1.Workspace{
+		ObjectMeta: metav1.ObjectMeta{Name: "myworkspace", Namespace: namespaceDefault},
+	}
+
+	server := &ExtensionServer{
+		config:        &ExtensionConfig{},
+		signerFactory: &mockSignerFactory{signer: &mockSigner{token: testToken}},
+	}
+
+	req := httptest.NewRequest("POST", "/test", nil)
+	req.Header.Set("X-Remote-User", testUser)
+
+	_, err := server.generateWebSocketConnectionURL(req, workspace, nil)
+
+	if err == nil {
+		t.Error("expected error for nil access strategy")
+	}
+}
+
+func TestGenerateWebSocketConnectionURL_MissingUser(t *testing.T) {
+	workspace := &workspacev1alpha1.Workspace{
+		ObjectMeta: metav1.ObjectMeta{Name: "myworkspace", Namespace: namespaceDefault},
+	}
+
+	accessStrategy := &workspacev1alpha1.WorkspaceAccessStrategy{
+		ObjectMeta: metav1.ObjectMeta{Name: "ws-strategy", Namespace: namespaceDefault},
+		Spec: workspacev1alpha1.WorkspaceAccessStrategySpec{
+			BearerAuthURLTemplate: "https://myworkspace-default.example.com/ssh-ws",
+		},
+	}
+
+	server := &ExtensionServer{
+		config:        &ExtensionConfig{},
+		signerFactory: &mockSignerFactory{signer: &mockSigner{token: testToken}},
+	}
+
+	req := httptest.NewRequest("POST", "/test", nil)
+	// No X-Remote-User header
+
+	_, err := server.generateWebSocketConnectionURL(req, workspace, accessStrategy)
+
+	if err == nil {
+		t.Error("expected error for missing user")
+	}
+}
+
+func TestGenerateWebSocketConnectionURL_MissingTemplate(t *testing.T) {
+	workspace := &workspacev1alpha1.Workspace{
+		ObjectMeta: metav1.ObjectMeta{Name: "myworkspace", Namespace: namespaceDefault},
+	}
+
+	accessStrategy := &workspacev1alpha1.WorkspaceAccessStrategy{
+		ObjectMeta: metav1.ObjectMeta{Name: "ws-strategy", Namespace: namespaceDefault},
+		Spec:       workspacev1alpha1.WorkspaceAccessStrategySpec{},
+	}
+
+	server := &ExtensionServer{
+		config:        &ExtensionConfig{},
+		signerFactory: &mockSignerFactory{signer: &mockSigner{token: testToken}},
+	}
+
+	req := httptest.NewRequest("POST", "/test", nil)
+	req.Header.Set("X-Remote-User", testUser)
+
+	_, err := server.generateWebSocketConnectionURL(req, workspace, accessStrategy)
+
+	if err == nil {
+		t.Error("expected error for missing BearerAuthURLTemplate")
 	}
 }


### PR DESCRIPTION
Adds `websocket` as a new connection type in the Extension API. When requested, the API generates a JWT token and returns a `wss://` URL — no external plugin or cloud service needed.

   This is part of the WebSocket remote connection feature ([design doc](https://quip-amazon.com/72OzARFCXng2/Parker-WebSocket)) which enables remote IDE connections through the cluster's existing ingress infrastructure.

   ## Changes

   - `api/connection/v1alpha1/workspace_connection_types.go`: Added `ConnectionTypeWebSocket = "websocket"` constant
   - `internal/extensionapi/serverroute_connection.go`:
     - Added `websocket` case in the connection type switch (calls `generateWebSocketConnectionURL`)
     - Added `generateWebSocketConnectionURL` function (generates JWT, builds `wss://` URL from `BearerAuthURLTemplate`)
     - Updated validation to accept `websocket` as a valid connection type
   - `internal/extensionapi/serverroute_connection_test.go`: 5 new unit tests + updated validation error messages

   ## Usage

   Request a WebSocket connection:
   ```
   apiVersion: connection.workspace.jupyter.org/v1alpha1
   kind: WorkspaceConnection
   metadata:
     namespace: default
   spec:
     workspaceName: my-workspace
     workspaceConnectionType: websocket
```

   Response:
```
   {
     "status": {
       "workspaceConnectionType": "websocket",
       "workspaceConnectionUrl": "wss://my-workspace-mzxw6ytb.workspaces.example.com/ssh-ws?token=<jwt>"
     }
   }
```

   The client extracts the token from the URL and passes it via Authorization: Bearer header when connecting with websocat.

   Access Strategy Configuration

   The workspace's access strategy needs BearerAuthURLTemplate configured:

   apiVersion: workspace.jupyter.org/v1alpha1
   kind: WorkspaceAccessStrategy
   metadata:
     name: websocket-access
   spec:
     bearerAuthURLTemplate: "https://{{ .Workspace.Name }}-{{ b32encode .Workspace.Namespace }}.workspaces.example.com/ssh-ws"

   Backward Compatibility

   Fully backward compatible. Existing web-ui and *-remote connection types are unchanged. The websocket type is a new addition.

   Testing

   - make build passes
   - make test passes (5 new unit tests)
   - make lint passes
   - E2E tests will be added in a follow-up once the full stack (IngressRoute, proxy sidecar, access strategy) is deployed together

DESIGN DOC: https://github.com/jupyter-infra/workspace-websocket-proxy/issues/3
