### PR TITLE
Merge main into ray-clusters

### DIFF
--- a/api/connection/v1alpha1/workspace_connection_types.go
+++ b/api/connection/v1alpha1/workspace_connection_types.go
@@ -17,6 +17,9 @@ const (
 
 	// ConnectionTypeWebUI represents web UI connection type
 	ConnectionTypeWebUI = "web-ui"
+
+	// ConnectionTypeWebSocket represents WebSocket remote connection type
+	ConnectionTypeWebSocket = "ssh-over-websocket"
 )
 
 // WorkspaceConnectionRequestSpec represents the spec of a workspace connection request

--- a/api/v1alpha1/workspacetemplate_types.go
+++ b/api/v1alpha1/workspacetemplate_types.go
@@ -240,7 +240,7 @@ type ResourceBounds struct {
 
 // ResourceRange defines min and max for a resource
 // NOTE: CEL validation for min <= max is not possible due to resource.Quantity type limitations
-// Validation is enforced at runtime in the template resolver
+// Consistency (min <= max) is enforced by the WorkspaceTemplate validating webhook
 type ResourceRange struct {
 	// Min is the minimum allowed value
 	// +kubebuilder:validation:Required
@@ -253,7 +253,7 @@ type ResourceRange struct {
 
 // StorageConfig defines storage settings
 // NOTE: CEL validation for minSize <= maxSize is not possible due to resource.Quantity type limitations
-// Validation is enforced at runtime in the template resolver
+// Consistency (minSize <= maxSize) is enforced by the WorkspaceTemplate validating webhook
 type StorageConfig struct {
 	// DefaultSize is the default storage size
 	// +kubebuilder:default="10Gi"

--- a/config/crd/bases/workspace.jupyter.org_workspacetemplates.yaml
+++ b/config/crd/bases/workspace.jupyter.org_workspacetemplates.yaml
@@ -3919,7 +3919,7 @@ spec:
                       description: |-
                         ResourceRange defines min and max for a resource
                         NOTE: CEL validation for min <= max is not possible due to resource.Quantity type limitations
-                        Validation is enforced at runtime in the template resolver
+                        Consistency (min <= max) is enforced by the WorkspaceTemplate validating webhook
                       properties:
                         max:
                           anyOf:

--- a/config/rbac/extension_api_auth_binding.yaml
+++ b/config/rbac/extension_api_auth_binding.yaml
@@ -1,16 +1,27 @@
-## This RoleBinding is applied separately from kustomize because it must live
-## in kube-system, and kustomize's global namespace transform would override that.
-## See Makefile deploy/undeploy targets.
+## ClusterRole/ClusterRoleBinding for reading extension-apiserver-authentication
+## configmap. Uses cluster-scoped resources instead of a kube-system RoleBinding
+## for compatibility with environments that lack cross-namespace permissions
+## (e.g., EKS addon framework).
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRole
 metadata:
-  name: jupyter-k8s-extension-api-auth
-  namespace: kube-system
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: extension-apiserver-authentication-reader
+  name: jupyter-k8s-read-auth-configmap
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["extension-apiserver-authentication"]
+    verbs: ["get", "list", "watch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: jupyter-k8s-read-auth-configmap
 subjects:
-- kind: ServiceAccount
-  name: jupyter-k8s-controller-manager
-  namespace: jupyter-k8s-system
+  - kind: ServiceAccount
+    name: jupyter-k8s-controller-manager
+    namespace: jupyter-k8s-system
+roleRef:
+  kind: ClusterRole
+  name: jupyter-k8s-read-auth-configmap
+  apiGroup: rbac.authorization.k8s.io

--- a/dist/chart/templates/crd/workspacetemplates.workspace.jupyter.org.yaml
+++ b/dist/chart/templates/crd/workspacetemplates.workspace.jupyter.org.yaml
@@ -3922,7 +3922,7 @@ spec:
                       description: |-
                         ResourceRange defines min and max for a resource
                         NOTE: CEL validation for min <= max is not possible due to resource.Quantity type limitations
-                        Validation is enforced at runtime in the template resolver
+                        Consistency (min <= max) is enforced by the WorkspaceTemplate validating webhook
                       properties:
                         max:
                           anyOf:

--- a/dist/chart/templates/rbac/extension-api-auth-binding.yaml
+++ b/dist/chart/templates/rbac/extension-api-auth-binding.yaml
@@ -1,20 +1,34 @@
 {{- if .Values.extensionApi.enable }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/name: {{ include "jupyter-k8s.name" . }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-  name: jupyter-k8s-extension-api-auth
-  namespace: kube-system
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: extension-apiserver-authentication-reader
+  name: {{ include "jupyter-k8s.resourceName" (dict "suffix" "read-auth-configmap" "context" $) }}
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["extension-apiserver-authentication"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "jupyter-k8s.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "jupyter-k8s.resourceName" (dict "suffix" "read-auth-configmap" "context" $) }}
 subjects:
-- kind: ServiceAccount
-  name: {{ include "jupyter-k8s.resourceName" (dict "suffix" "controller-manager" "context" $) }}
-  namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: {{ include "jupyter-k8s.resourceName" (dict "suffix" "controller-manager" "context" $) }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "jupyter-k8s.resourceName" (dict "suffix" "read-auth-configmap" "context" $) }}
+  apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -13245,7 +13245,7 @@ spec:
                       description: |-
                         ResourceRange defines min and max for a resource
                         NOTE: CEL validation for min <= max is not possible due to resource.Quantity type limitations
-                        Validation is enforced at runtime in the template resolver
+                        Consistency (min <= max) is enforced by the WorkspaceTemplate validating webhook
                       properties:
                         max:
                           anyOf:

--- a/docs/source/concepts/templates/bounds.md
+++ b/docs/source/concepts/templates/bounds.md
@@ -60,6 +60,12 @@ spec:
     maxIdleTimeoutInMinutes: 480
 ```
 
+`allow` controls whether workspace users may disable idle shutdown, and whether the `idleShutdown` field of a workspace may diverge from the template's defined defaults. It matters because the `idleShutdown.detection` settings are deeply tied to the application running in the workspace. Misconfiguring the `idleShutdown.detection` field of a workspace may prevent the operator from shutting down idle workspaces.
+
+The `minIdleTimeoutInMinutes` and `maxIdleTimeoutInMinutes` bounds are independent of `allow`: they cap `idleShutdown.idleTimeoutInMinutes` on any workspace with idle shutdown *enabled*, whether or not overrides are allowed. So even with `allow: false`, you can still permit users to tune the timeout within those bounds. If `allow: false` and `minIdleTimeoutInMinutes` is omitted, the enforced minimum falls back to the template's `spec.defaultIdleShutdown.idleTimeoutInMinutes`; `maxIdleTimeoutInMinutes` behaves the same way. When `allow: true`, an omitted bound simply leaves that side unbounded.
+
+A template with `allow: false` must define `defaultIdleShutdown`, or the template webhook rejects it.
+
 ## Environment and label requirements
 
 Templates can require specific environment variables or labels with regex validation:

--- a/docs/source/concepts/templates/bounds.md
+++ b/docs/source/concepts/templates/bounds.md
@@ -60,11 +60,17 @@ spec:
     maxIdleTimeoutInMinutes: 480
 ```
 
-`allow` controls whether workspace users may disable idle shutdown, and whether the `idleShutdown` field of a workspace may diverge from the template's defined defaults. It matters because the `idleShutdown.detection` settings are deeply tied to the application running in the workspace. Misconfiguring the `idleShutdown.detection` field of a workspace may prevent the operator from shutting down idle workspaces.
+`allow` controls whether workspace users may disable idle shutdown.
+- when set to `false`: the workspace idle shutdown config must match the template's defaults exactly, except that `idleTimeoutInMinutes` may vary within certain bounds (see below).
+- when set to `true`: workspaces may disable idle shutdown, or vary any field of `idleShutdown`.
 
-The `minIdleTimeoutInMinutes` and `maxIdleTimeoutInMinutes` bounds are independent of `allow`: they cap `idleShutdown.idleTimeoutInMinutes` on any workspace with idle shutdown *enabled*, whether or not overrides are allowed. So even with `allow: false`, you can still permit users to tune the timeout within those bounds. If `allow: false` and `minIdleTimeoutInMinutes` is omitted, the enforced minimum falls back to the template's `spec.defaultIdleShutdown.idleTimeoutInMinutes`; `maxIdleTimeoutInMinutes` behaves the same way. When `allow: true`, an omitted bound simply leaves that side unbounded.
+```{note}
+`idleShutdown.detection` settings are deeply tied to the application running in the workspace. Misconfiguring the `idleShutdown.detection` field of a workspace may prevent the operator from shutting down idle workspaces. If workspace users are not familiar with such settings, it is safer to set `allow: false`.
+```
 
-A template with `allow: false` must define `defaultIdleShutdown`, or the template webhook rejects it.
+The `minIdleTimeoutInMinutes` and `maxIdleTimeoutInMinutes` are always enforced:
+- with `allow: false`: a workspace may set its own idle timeout within these bounds; if `min` and/or `max` is omitted, the implicit lower or upper bound is the template's default.
+- with `allow: true`: a workspace that enables idle shutdown must set its timeout within these bounds; if `min` and/or `max` is omitted, that side is unbounded.
 
 ## Environment and label requirements
 

--- a/docs/source/dive-deeper/webhooks/template-validation.md
+++ b/docs/source/dive-deeper/webhooks/template-validation.md
@@ -8,6 +8,17 @@ On **create and update**, the webhook rejects templates whose `defaultAccessStra
 
 On **update**, when constraint fields change, the webhook returns a **warning** telling the user that the template controller will re-validate affected workspaces.
 
+## Self-consistency
+
+On **create and update**, the webhook rejects a template whose own constraints are internally inconsistent:
+
+- `defaultImage` must be a member of `allowedImages` when that list is non-empty and `allowCustomImages` is false.
+- `primaryStorage.minSize` must not exceed `primaryStorage.maxSize`.
+- `resourceBounds` `min` must not exceed `max` for any resource.
+- `idleShutdownOverrides.minIdleTimeoutInMinutes` must not exceed `maxIdleTimeoutInMinutes`.
+- `idleShutdownOverrides.allow: false` requires a `defaultIdleShutdown` for workspaces to match against.
+- an enabled `defaultIdleShutdown.idleTimeoutInMinutes` must fall within the `idleShutdownOverrides` timeout bounds.
+
 ## Constraint fields
 
 Changes to any of the following fields trigger the warning:

--- a/docs/source/dive-deeper/webhooks/workspace-validation.md
+++ b/docs/source/dive-deeper/webhooks/workspace-validation.md
@@ -7,6 +7,7 @@ The validating webhook enforces constraints on workspace create, update, and del
 | Check | Description |
 |-------|-------------|
 | Template constraints | Validates resources, images, storage size, and idle shutdown bounds against the template's constraint fields |
+| Storage size shrink | On update, rejects a decrease of `spec.storage.size` below the workspace's provisioned PVC size |
 | Reference namespace scope | Rejects references to templates or access strategies outside the workspace's own namespace or the configured shared namespace |
 | Volume ownership | Rejects references to other workspaces' primary storage PVCs (secondary storage can be shared freely) |
 
@@ -29,9 +30,13 @@ When a workspace has `ownershipType: OwnerOnly`:
 
 On `DELETE`, the webhook only checks ownership permission for `OwnerOnly` workspaces. All other deletes pass through (RBAC is the primary guard).
 
-## Idle shutdown override enforcement
+## Storage size changes
 
-When the template sets `idleShutdownOverrides.allow: false`, the webhook requires the workspace's `idleShutdown` to match the template's `defaultIdleShutdown` on every field except `idleTimeoutInMinutes`. Declared `minIdleTimeoutInMinutes`/`maxIdleTimeoutInMinutes` bounds are enforced on any *enabled* idle shutdown regardless of `allow`; a disabled idle shutdown has no timeout to bound. See [idle shutdown bounds](../../concepts/templates/bounds.md) for the policy semantics.
+On update, the webhook rejects shrinking `spec.storage.size` below the size the workspace's PVC already requests. Kubernetes does not support shrinking a volume below its current size, so a resize-down would otherwise pass admission but fail to reconcile.
+
+```{note}
+The webhook does not block a size increase at admission: whether it succeeds at reconciliation depends on the StorageClass's `allowVolumeExpansion`.
+```
 
 ## Lazy constraint enforcement
 

--- a/docs/source/dive-deeper/webhooks/workspace-validation.md
+++ b/docs/source/dive-deeper/webhooks/workspace-validation.md
@@ -29,6 +29,10 @@ When a workspace has `ownershipType: OwnerOnly`:
 
 On `DELETE`, the webhook only checks ownership permission for `OwnerOnly` workspaces. All other deletes pass through (RBAC is the primary guard).
 
+## Idle shutdown override enforcement
+
+When the template sets `idleShutdownOverrides.allow: false`, the webhook requires the workspace's `idleShutdown` to match the template's `defaultIdleShutdown` on every field except `idleTimeoutInMinutes`. Declared `minIdleTimeoutInMinutes`/`maxIdleTimeoutInMinutes` bounds are enforced on any *enabled* idle shutdown regardless of `allow`; a disabled idle shutdown has no timeout to bound. See [idle shutdown bounds](../../concepts/templates/bounds.md) for the policy semantics.
+
 ## Lazy constraint enforcement
 
 The webhook enforces template constraints at **admission time**, when a user creates or updates a workspace.

--- a/docs/source/reference/custom-resources/workspacetemplate.md
+++ b/docs/source/reference/custom-resources/workspacetemplate.md
@@ -91,7 +91,7 @@ _Appears in:_
 
 ResourceRange defines min and max for a resource
 NOTE: CEL validation for min <= max is not possible due to resource.Quantity type limitations
-Validation is enforced at runtime in the template resolver
+Consistency (min <= max) is enforced by the WorkspaceTemplate validating webhook
 
 _Appears in:_
 - [ResourceBounds](#resourcebounds)
@@ -109,7 +109,7 @@ _Appears in:_
 
 StorageConfig defines storage settings
 NOTE: CEL validation for minSize <= maxSize is not possible due to resource.Quantity type limitations
-Validation is enforced at runtime in the template resolver
+Consistency (minSize <= maxSize) is enforced by the WorkspaceTemplate validating webhook
 
 _Appears in:_
 - [WorkspaceTemplateSpec](#workspacetemplatespec)

--- a/hack/apply-helm-patches.sh
+++ b/hack/apply-helm-patches.sh
@@ -325,28 +325,45 @@ if [ -f "${APISERVICE_YAML}" ]; then
     sed -i 's|{{ .Release.Namespace }}/jupyter-k8s-extension-server-cert|{{ .Release.Namespace }}/{{ include "jupyter-k8s.resourceName" (dict "suffix" "extension-server-cert" "context" $) }}|' "${APISERVICE_YAML}"
 fi
 
-# --- Create extension API auth RoleBinding in kube-system ---
-echo "Creating extension API auth RoleBinding template..."
+# --- Create extension API auth ClusterRole/ClusterRoleBinding ---
+# Uses cluster-scoped resources instead of a kube-system RoleBinding for
+# compatibility with environments that lack cross-namespace permissions
+# (e.g., EKS addon framework).
+echo "Creating extension API auth ClusterRole/ClusterRoleBinding template..."
 cat > "${CHART_DIR}/templates/rbac/extension-api-auth-binding.yaml" << 'AUTHEOF'
 {{- if .Values.extensionApi.enable }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/name: {{ include "jupyter-k8s.name" . }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-  name: jupyter-k8s-extension-api-auth
-  namespace: kube-system
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: extension-apiserver-authentication-reader
+  name: {{ include "jupyter-k8s.resourceName" (dict "suffix" "read-auth-configmap" "context" $) }}
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["extension-apiserver-authentication"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "jupyter-k8s.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ include "jupyter-k8s.resourceName" (dict "suffix" "read-auth-configmap" "context" $) }}
 subjects:
-- kind: ServiceAccount
-  name: {{ include "jupyter-k8s.resourceName" (dict "suffix" "controller-manager" "context" $) }}
-  namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: {{ include "jupyter-k8s.resourceName" (dict "suffix" "controller-manager" "context" $) }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "jupyter-k8s.resourceName" (dict "suffix" "read-auth-configmap" "context" $) }}
+  apiGroup: rbac.authorization.k8s.io
 {{- end }}
 AUTHEOF
 

--- a/internal/authmiddleware/serverroute_bearer_auth.go
+++ b/internal/authmiddleware/serverroute_bearer_auth.go
@@ -13,7 +13,7 @@ import (
 )
 
 // handleBearerAuth handles bearer token authentication requests
-// Takes short lived JWT tokens from URL parameter and exchanges them for 6-hour session cookies
+// Takes short lived JWT tokens from Authorization header or URL parameter and exchanges them for session cookies
 func (s *Server) handleBearerAuth(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
@@ -36,12 +36,23 @@ func (s *Server) handleBearerAuth(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Extract token from forwarded URI query parameters
-	token := parsedURL.Query().Get("token")
+	// Extract token: prefer Authorization header, fall back to URL query parameter
+	var token string
+	if authHeader := r.Header.Get(HeaderAuthorization); authHeader != "" {
+		extracted, err := ExtractBearerToken(authHeader)
+		if err != nil {
+			s.logger.Error("Invalid Authorization header", "error", err)
+			http.Error(w, "Invalid Authorization header", http.StatusBadRequest)
+			return
+		}
+		token = extracted
+	} else {
+		token = parsedURL.Query().Get("token")
+	}
+
 	if token == "" {
-		s.logger.Error("Missing token parameter",
-			"forwarded_uri", forwardedURI,
-			"query_params", parsedURL.Query())
+		s.logger.Error("Missing token: provide Authorization: Bearer header or ?token= query parameter",
+			"forwarded_uri", forwardedURI)
 		http.Error(w, "Missing token parameter", http.StatusBadRequest)
 		return
 	}

--- a/internal/authmiddleware/serverroute_bearer_auth_test.go
+++ b/internal/authmiddleware/serverroute_bearer_auth_test.go
@@ -84,6 +84,62 @@ func TestHandleBearerAuthMissingToken(t *testing.T) {
 	}
 }
 
+func TestHandleBearerAuthWithAuthorizationHeader(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	server := &Server{
+		logger: logger,
+		config: &Config{
+			PathRegexPattern:            DefaultPathRegexPattern,
+			RoutingMode:                 DefaultRoutingMode,
+			WorkspaceNamespacePathRegex: DefaultWorkspaceNamespacePathRegex,
+			WorkspaceNamePathRegex:      DefaultWorkspaceNamePathRegex,
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/bearer-auth", nil)
+	req.Header.Set(HeaderForwardedURI, "/workspaces/default/myworkspace/")
+	req.Header.Set(HeaderForwardedHost, "test.example.com")
+	req.Header.Set(HeaderAuthorization, "Bearer valid-token")
+	w := httptest.NewRecorder()
+
+	server.handleBearerAuth(w, req)
+
+	// Should proceed past token extraction — will fail later at BearerTokenReview
+	// because no k8s client is configured, but the point is it didn't fail at token extraction
+	assert.NotContains(t, w.Body.String(), "Missing token parameter")
+	assert.NotContains(t, w.Body.String(), "Invalid Authorization header")
+}
+
+func TestHandleBearerAuthInvalidAuthorizationHeader(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	server := &Server{logger: logger}
+
+	req := httptest.NewRequest(http.MethodGet, "/bearer-auth", nil)
+	req.Header.Set(HeaderForwardedURI, "/workspaces/default/workspace")
+	req.Header.Set(HeaderAuthorization, "Basic dXNlcjpwYXNz")
+	w := httptest.NewRecorder()
+
+	server.handleBearerAuth(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "Invalid Authorization header")
+}
+
+func TestHandleBearerAuthEmptyBearerToken(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	server := &Server{logger: logger}
+
+	req := httptest.NewRequest(http.MethodGet, "/bearer-auth", nil)
+	req.Header.Set(HeaderForwardedURI, "/workspaces/default/workspace")
+	req.Header.Set(HeaderAuthorization, "Bearer ")
+	w := httptest.NewRecorder()
+
+	server.handleBearerAuth(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "Invalid Authorization header")
+}
+
 func TestHandleBearerAuthMissingForwardedHost(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	server := &Server{

--- a/internal/extensionapi/serverroute_connection.go
+++ b/internal/extensionapi/serverroute_connection.go
@@ -156,6 +156,72 @@ func (s *ExtensionServer) generateBearerTokenURL(r *http.Request, ws *workspacev
 	return fmt.Sprintf("%s?token=%s", bearerURL, token), nil
 }
 
+// generateWebSocketConnectionURL generates a WebSocket connection URL with JWT token.
+// Used for k8s-native remote connections (WebSocket proxy sidecar).
+// Returns a wss:// URL with the token as a query parameter. The client (Toolkit/connect script)
+// extracts the token and passes it via Authorization: Bearer header to the proxy.
+func (s *ExtensionServer) generateWebSocketConnectionURL(r *http.Request, ws *workspacev1alpha1.Workspace, accessStrategy *workspacev1alpha1.WorkspaceAccessStrategy) (string, error) {
+	user := GetUser(r)
+	if user == "" {
+		return "", fmt.Errorf("user information not found in request headers")
+	}
+	groups := GetGroups(r)
+	extra := GetExtra(r)
+
+	if accessStrategy == nil {
+		return "", fmt.Errorf("no AccessStrategy configured for workspace")
+	}
+	if accessStrategy.Spec.BearerAuthURLTemplate == "" {
+		return "", fmt.Errorf("BearerAuthURLTemplate not configured in AccessStrategy")
+	}
+
+	// Create signer based on access strategy
+	signer, err := s.signerFactory.CreateSigner(accessStrategy)
+	if err != nil {
+		return "", fmt.Errorf("failed to create signer: %w", err)
+	}
+
+	// Generate URL from template (reuses the same BearerAuthURLTemplate)
+	wsURL, err := s.renderBearerAuthURL(accessStrategy.Spec.BearerAuthURLTemplate, ws, accessStrategy)
+	if err != nil {
+		return "", fmt.Errorf("failed to render WebSocket URL: %w", err)
+	}
+
+	// Parse URL to extract domain and path for JWT claims
+	parsedURL, err := url.Parse(wsURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse generated URL: %w", err)
+	}
+
+	domain := parsedURL.Host
+	path := parsedURL.Path
+
+	// Strip /bearer-auth suffix if present (template may be shared with web UI)
+	if strings.HasSuffix(path, "/bearer-auth") {
+		path = strings.TrimSuffix(path, "/bearer-auth")
+		if path == "" {
+			path = "/"
+		}
+	}
+
+	// Generate JWT token for the WebSocket connection
+	token, err := signer.GenerateToken(user, groups, user, extra, path, domain, jwt.TokenTypeBootstrap, true)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate JWT token: %w", err)
+	}
+
+	// Replace scheme with wss:// and strip /bearer-auth from the URL
+	parsedURL.Scheme = "wss"
+	if strings.HasSuffix(parsedURL.Path, "/bearer-auth") {
+		parsedURL.Path = strings.TrimSuffix(parsedURL.Path, "/bearer-auth")
+		if parsedURL.Path == "" {
+			parsedURL.Path = "/"
+		}
+	}
+
+	return fmt.Sprintf("%s?token=%s", parsedURL.String(), token), nil
+}
+
 // generatePluginConnectionURL delegates connection URL generation to a plugin.
 func (s *ExtensionServer) generatePluginConnectionURL(r *http.Request, ws *workspacev1alpha1.Workspace, pluginName, action, connectionType string, resolvedContext map[string]string, namespace string) (string, error) {
 	pc, ok := s.pluginClients[pluginName]
@@ -269,6 +335,10 @@ func (s *ExtensionServer) HandleConnectionCreate(w http.ResponseWriter, r *http.
 		responseURL, err = s.generateBearerTokenURL(r, ws, accessStrategy)
 		responseType = connectionv1alpha1.ConnectionTypeWebUI
 
+	case connectionv1alpha1.ConnectionTypeWebSocket:
+		responseURL, err = s.generateWebSocketConnectionURL(r, ws, accessStrategy)
+		responseType = connectionv1alpha1.ConnectionTypeWebSocket
+
 	default:
 		// All *-remote types go through the plugin handler map
 		pluginName, action, found := resolveConnectionHandler(accessStrategy, connectionType)
@@ -277,15 +347,16 @@ func (s *ExtensionServer) HandleConnectionCreate(w http.ResponseWriter, r *http.
 			return
 		}
 		if pluginName == handlerK8sNative {
-			WriteKubernetesError(w, http.StatusBadRequest, fmt.Sprintf("k8s-native handler is not supported for remote connections (requested %q)", connectionType))
-			return
+			responseURL, err = s.generateWebSocketConnectionURL(r, ws, accessStrategy)
+			responseType = connectionType
+		} else {
+			if _, ok := s.pluginClients[pluginName]; !ok {
+				WriteKubernetesError(w, http.StatusBadRequest, "plugin endpoints not configured. Please configure controller.plugins in helm values")
+				return
+			}
+			responseURL, err = s.generatePluginConnectionURL(r, ws, pluginName, action, connectionType, resolvedContext, namespace)
+			responseType = connectionType
 		}
-		if _, ok := s.pluginClients[pluginName]; !ok {
-			WriteKubernetesError(w, http.StatusBadRequest, "plugin endpoints not configured. Please configure controller.plugins in helm values")
-			return
-		}
-		responseURL, err = s.generatePluginConnectionURL(r, ws, pluginName, action, connectionType, resolvedContext, namespace)
-		responseType = connectionType
 	}
 
 	if err != nil {
@@ -335,14 +406,16 @@ func validateWorkspaceConnectionRequest(req *connectionv1alpha1.WorkspaceConnect
 
 	connectionType := req.Spec.WorkspaceConnectionType
 
-	// Accept web-ui, known remote types, and any *-remote pattern
+	// Accept web-ui, websocket, known remote types, and any *-remote pattern
 	switch {
 	case connectionType == connectionv1alpha1.ConnectionTypeWebUI:
+		// valid
+	case connectionType == connectionv1alpha1.ConnectionTypeWebSocket:
 		// valid
 	case isRemoteConnectionType(connectionType):
 		// valid — known or unknown remote types are accepted
 	default:
-		return fmt.Errorf("invalid workspaceConnectionType: '%s'. Must be 'web-ui' or follow the '{ide}-remote' pattern (e.g. 'vscode-remote', 'kiro-remote', 'cursor-remote')", connectionType)
+		return fmt.Errorf("invalid workspaceConnectionType: '%s'. Must be 'web-ui', 'ssh-over-websocket', or follow the '{ide}-remote' pattern (e.g. 'vscode-remote', 'kiro-remote', 'cursor-remote')", connectionType)
 	}
 
 	return nil

--- a/internal/extensionapi/serverroute_connection_test.go
+++ b/internal/extensionapi/serverroute_connection_test.go
@@ -31,6 +31,8 @@ import (
 )
 
 const testUser = "test-user"
+const testWorkspaceMyWorkspace = "myworkspace"
+const testStrategyWebSocket = "ws-strategy"
 
 // mockSignerFactory for testing
 type mockSignerFactory struct {
@@ -128,7 +130,7 @@ func TestGenerateBearerTokenURL(t *testing.T) {
 
 func TestGenerateBearerTokenURL_SubdomainRouting(t *testing.T) {
 	workspace := &workspacev1alpha1.Workspace{
-		ObjectMeta: metav1.ObjectMeta{Name: "myworkspace", Namespace: namespaceDefault},
+		ObjectMeta: metav1.ObjectMeta{Name: testWorkspaceMyWorkspace, Namespace: namespaceDefault},
 		Spec: workspacev1alpha1.WorkspaceSpec{
 			AccessStrategy: &workspacev1alpha1.AccessStrategyRef{Name: "subdomain-strategy"},
 		},
@@ -902,7 +904,7 @@ func TestValidateWorkspaceConnectionRequest(t *testing.T) {
 				},
 			},
 			expectError: true,
-			errorMsg:    "invalid workspaceConnectionType: 'invalid-type'. Must be 'web-ui' or follow the '{ide}-remote' pattern (e.g. 'vscode-remote', 'kiro-remote', 'cursor-remote')",
+			errorMsg:    "invalid workspaceConnectionType: 'invalid-type'. Must be 'web-ui', 'ssh-over-websocket', or follow the '{ide}-remote' pattern (e.g. 'vscode-remote', 'kiro-remote', 'cursor-remote')",
 		},
 		{
 			name: "invalid connection type - bare remote",
@@ -913,7 +915,7 @@ func TestValidateWorkspaceConnectionRequest(t *testing.T) {
 				},
 			},
 			expectError: true,
-			errorMsg:    "invalid workspaceConnectionType: '-remote'. Must be 'web-ui' or follow the '{ide}-remote' pattern (e.g. 'vscode-remote', 'kiro-remote', 'cursor-remote')",
+			errorMsg:    "invalid workspaceConnectionType: '-remote'. Must be 'web-ui', 'ssh-over-websocket', or follow the '{ide}-remote' pattern (e.g. 'vscode-remote', 'kiro-remote', 'cursor-remote')",
 		},
 	}
 
@@ -1086,5 +1088,158 @@ func TestIsRemoteConnectionType(t *testing.T) {
 				t.Errorf("isRemoteConnectionType(%q) = %v, want %v", tt.connectionType, result, tt.expected)
 			}
 		})
+	}
+}
+
+// --- generateWebSocketConnectionURL tests ---
+
+func TestGenerateWebSocketConnectionURL_Success(t *testing.T) {
+	workspace := &workspacev1alpha1.Workspace{
+		ObjectMeta: metav1.ObjectMeta{Name: testWorkspaceMyWorkspace, Namespace: namespaceDefault},
+		Spec: workspacev1alpha1.WorkspaceSpec{
+			AccessStrategy: &workspacev1alpha1.AccessStrategyRef{Name: testStrategyWebSocket},
+		},
+	}
+
+	accessStrategy := &workspacev1alpha1.WorkspaceAccessStrategy{
+		ObjectMeta: metav1.ObjectMeta{Name: testStrategyWebSocket, Namespace: namespaceDefault},
+		Spec: workspacev1alpha1.WorkspaceAccessStrategySpec{
+			BearerAuthURLTemplate: "https://myworkspace-default.example.com/ssh-ws",
+		},
+	}
+
+	server := &ExtensionServer{
+		config:        &ExtensionConfig{},
+		signerFactory: &mockSignerFactory{signer: &mockSigner{token: testToken}},
+	}
+
+	req := httptest.NewRequest("POST", "/test", nil)
+	req.Header.Set("X-Remote-User", testUser)
+
+	connURL, err := server.generateWebSocketConnectionURL(req, workspace, accessStrategy)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.HasPrefix(connURL, "wss://") {
+		t.Errorf("expected wss:// scheme, got: %s", connURL)
+	}
+	if !strings.Contains(connURL, "token="+testToken) {
+		t.Errorf("expected token in URL, got: %s", connURL)
+	}
+	if !strings.Contains(connURL, "myworkspace-default.example.com") {
+		t.Errorf("expected host in URL, got: %s", connURL)
+	}
+}
+
+func TestGenerateWebSocketConnectionURL_StripsBearerAuth(t *testing.T) {
+	workspace := &workspacev1alpha1.Workspace{
+		ObjectMeta: metav1.ObjectMeta{Name: testWorkspaceMyWorkspace, Namespace: namespaceDefault},
+		Spec: workspacev1alpha1.WorkspaceSpec{
+			AccessStrategy: &workspacev1alpha1.AccessStrategyRef{Name: testStrategyWebSocket},
+		},
+	}
+
+	// Template with /bearer-auth suffix (shared with web UI)
+	accessStrategy := &workspacev1alpha1.WorkspaceAccessStrategy{
+		ObjectMeta: metav1.ObjectMeta{Name: testStrategyWebSocket, Namespace: namespaceDefault},
+		Spec: workspacev1alpha1.WorkspaceAccessStrategySpec{
+			BearerAuthURLTemplate: "https://myworkspace-default.example.com/bearer-auth",
+		},
+	}
+
+	server := &ExtensionServer{
+		config:        &ExtensionConfig{},
+		signerFactory: &mockSignerFactory{signer: &mockSigner{token: testToken}},
+	}
+
+	req := httptest.NewRequest("POST", "/test", nil)
+	req.Header.Set("X-Remote-User", testUser)
+
+	url, err := server.generateWebSocketConnectionURL(req, workspace, accessStrategy)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should strip /bearer-auth from the URL
+	if strings.Contains(url, "/bearer-auth") {
+		t.Errorf("expected /bearer-auth to be stripped, got: %s", url)
+	}
+	if !strings.HasPrefix(url, "wss://") {
+		t.Errorf("expected wss:// scheme, got: %s", url)
+	}
+}
+
+func TestGenerateWebSocketConnectionURL_NoAccessStrategy(t *testing.T) {
+	workspace := &workspacev1alpha1.Workspace{
+		ObjectMeta: metav1.ObjectMeta{Name: testWorkspaceMyWorkspace, Namespace: namespaceDefault},
+	}
+
+	server := &ExtensionServer{
+		config:        &ExtensionConfig{},
+		signerFactory: &mockSignerFactory{signer: &mockSigner{token: testToken}},
+	}
+
+	req := httptest.NewRequest("POST", "/test", nil)
+	req.Header.Set("X-Remote-User", testUser)
+
+	_, err := server.generateWebSocketConnectionURL(req, workspace, nil)
+
+	if err == nil {
+		t.Error("expected error for nil access strategy")
+	}
+}
+
+func TestGenerateWebSocketConnectionURL_MissingUser(t *testing.T) {
+	workspace := &workspacev1alpha1.Workspace{
+		ObjectMeta: metav1.ObjectMeta{Name: testWorkspaceMyWorkspace, Namespace: namespaceDefault},
+	}
+
+	accessStrategy := &workspacev1alpha1.WorkspaceAccessStrategy{
+		ObjectMeta: metav1.ObjectMeta{Name: testStrategyWebSocket, Namespace: namespaceDefault},
+		Spec: workspacev1alpha1.WorkspaceAccessStrategySpec{
+			BearerAuthURLTemplate: "https://myworkspace-default.example.com/ssh-ws",
+		},
+	}
+
+	server := &ExtensionServer{
+		config:        &ExtensionConfig{},
+		signerFactory: &mockSignerFactory{signer: &mockSigner{token: testToken}},
+	}
+
+	req := httptest.NewRequest("POST", "/test", nil)
+	// No X-Remote-User header
+
+	_, err := server.generateWebSocketConnectionURL(req, workspace, accessStrategy)
+
+	if err == nil {
+		t.Error("expected error for missing user")
+	}
+}
+
+func TestGenerateWebSocketConnectionURL_MissingTemplate(t *testing.T) {
+	workspace := &workspacev1alpha1.Workspace{
+		ObjectMeta: metav1.ObjectMeta{Name: testWorkspaceMyWorkspace, Namespace: namespaceDefault},
+	}
+
+	accessStrategy := &workspacev1alpha1.WorkspaceAccessStrategy{
+		ObjectMeta: metav1.ObjectMeta{Name: testStrategyWebSocket, Namespace: namespaceDefault},
+		Spec:       workspacev1alpha1.WorkspaceAccessStrategySpec{},
+	}
+
+	server := &ExtensionServer{
+		config:        &ExtensionConfig{},
+		signerFactory: &mockSignerFactory{signer: &mockSigner{token: testToken}},
+	}
+
+	req := httptest.NewRequest("POST", "/test", nil)
+	req.Header.Set("X-Remote-User", testUser)
+
+	_, err := server.generateWebSocketConnectionURL(req, workspace, accessStrategy)
+
+	if err == nil {
+		t.Error("expected error for missing BearerAuthURLTemplate")
 	}
 }

--- a/internal/webhook/v1alpha1/idle_shutdown_validator.go
+++ b/internal/webhook/v1alpha1/idle_shutdown_validator.go
@@ -1,0 +1,143 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package v1alpha1
+
+import (
+	"fmt"
+	"reflect"
+
+	workspacev1alpha1 "github.com/jupyter-infra/jupyter-k8s/api/v1alpha1"
+)
+
+// validateIdleShutdownOverrides enforces the template's idleShutdownOverrides policy.
+//
+// The policy has two orthogonal knobs:
+//
+//   - Allow governs the STRUCTURE. When Allow=false, the workspace may not deviate from the
+//     template's defaultIdleShutdown: every field must match the default EXCEPT
+//     idleTimeoutInMinutes. When Allow is unset or true (the kubebuilder default), the
+//     workspace may freely choose its idle shutdown config, including disabling it.
+//
+//   - MinIdleTimeoutInMinutes/MaxIdleTimeoutInMinutes bound the timeout VALUE. Declared bounds
+//     are enforced whenever the workspace has idle shutdown enabled, regardless of Allow — so
+//     an admin can permit overrides yet still cap the timeout.
+//
+// Missing-bound fallback differs by intent:
+//
+//   - Allow=false (locked window): an unset bound falls back to the default timeout, pinning
+//     the unspecified side to the default ("the only wiggle room is what I explicitly granted").
+//   - Allow=true/unset (permissive): an unset bound means unbounded on that side.
+//
+// The structural lock requires a defaultIdleShutdown to compare against; without one there is
+// no baseline to match, so only the timeout bounds apply.
+func validateIdleShutdownOverrides(workspace *workspacev1alpha1.Workspace, template *workspacev1alpha1.WorkspaceTemplate) []TemplateViolation {
+	policy := template.Spec.IdleShutdownOverrides
+	if policy == nil {
+		return nil
+	}
+
+	allowOverride := policy.Allow == nil || *policy.Allow
+	def := template.Spec.DefaultIdleShutdown
+	ws := workspace.Spec.IdleShutdown
+
+	var violations []TemplateViolation
+
+	// Structural lock: when overrides are not allowed, the workspace must match the template
+	// default on every field except the timeout. Requires a default baseline to compare against.
+	if !allowOverride && def != nil {
+		if ws == nil {
+			// Overrides are not allowed but the workspace carries no idle shutdown config,
+			// which drops the template's policy entirely.
+			return []TemplateViolation{{
+				Type:    ViolationTypeIdleShutdownOverrideNotAllowed,
+				Field:   "spec.idleShutdown",
+				Message: fmt.Sprintf("Template '%s' does not allow overriding idle shutdown; idleShutdown must match the template default", template.Name),
+				Allowed: "match template defaultIdleShutdown",
+				Actual:  "unset",
+			}}
+		}
+
+		// Compare copies with the timeout zeroed so a permitted timeout difference doesn't trip
+		// the equality check.
+		wsCopy := ws.DeepCopy()
+		defCopy := def.DeepCopy()
+		wsCopy.IdleTimeoutInMinutes = 0
+		defCopy.IdleTimeoutInMinutes = 0
+		if !reflect.DeepEqual(wsCopy, defCopy) {
+			violations = append(violations, TemplateViolation{
+				Type:    ViolationTypeIdleShutdownOverrideNotAllowed,
+				Field:   "spec.idleShutdown",
+				Message: fmt.Sprintf("Template '%s' does not allow overriding idle shutdown; only idleTimeoutInMinutes may differ from the template default", template.Name),
+				Allowed: "match template defaultIdleShutdown (except idleTimeoutInMinutes)",
+				Actual:  "differs from template default",
+			})
+		}
+	}
+
+	// Timeout bounds apply whenever the workspace has idle shutdown enabled: a disabled or absent
+	// idle shutdown has no active timeout to bound.
+	if ws != nil && ws.Enabled {
+		if violation := validateIdleTimeoutBounds(ws.IdleTimeoutInMinutes, policy, def, allowOverride, template.Name); violation != nil {
+			violations = append(violations, *violation)
+		}
+	}
+
+	return violations
+}
+
+// validateIdleTimeoutBounds checks the workspace idle timeout against the policy's declared
+// bounds, applying the missing-bound fallback appropriate to the Allow setting. Returns nil when
+// the timeout is within bounds (or no bound applies to the relevant side).
+func validateIdleTimeoutBounds(
+	timeout int,
+	policy *workspacev1alpha1.IdleShutdownOverridePolicy,
+	def *workspacev1alpha1.IdleShutdownSpec,
+	allowOverride bool,
+	templateName string,
+) *TemplateViolation {
+	minTimeout, hasMin := 0, false
+	if policy.MinIdleTimeoutInMinutes != nil {
+		minTimeout, hasMin = *policy.MinIdleTimeoutInMinutes, true
+	}
+	maxTimeout, hasMax := 0, false
+	if policy.MaxIdleTimeoutInMinutes != nil {
+		maxTimeout, hasMax = *policy.MaxIdleTimeoutInMinutes, true
+	}
+
+	// When overrides are locked, an unset bound falls back to the default timeout, pinning the
+	// unspecified side to the default. When overrides are allowed, an unset bound stays unbounded.
+	if !allowOverride && def != nil {
+		if !hasMin {
+			minTimeout, hasMin = def.IdleTimeoutInMinutes, true
+		}
+		if !hasMax {
+			maxTimeout, hasMax = def.IdleTimeoutInMinutes, true
+		}
+	}
+
+	belowMin := hasMin && timeout < minTimeout
+	aboveMax := hasMax && timeout > maxTimeout
+	if !belowMin && !aboveMax {
+		return nil
+	}
+
+	minStr := "unbounded"
+	if hasMin {
+		minStr = fmt.Sprintf("%d", minTimeout)
+	}
+	maxStr := "unbounded"
+	if hasMax {
+		maxStr = fmt.Sprintf("%d", maxTimeout)
+	}
+
+	return &TemplateViolation{
+		Type:    ViolationTypeIdleShutdownTimeoutOutOfBounds,
+		Field:   "spec.idleShutdown.idleTimeoutInMinutes",
+		Message: fmt.Sprintf("Idle timeout %d minutes is outside the range [%s, %s] allowed by template '%s'", timeout, minStr, maxStr, templateName),
+		Allowed: fmt.Sprintf("min: %s, max: %s", minStr, maxStr),
+		Actual:  fmt.Sprintf("%d", timeout),
+	}
+}

--- a/internal/webhook/v1alpha1/idle_shutdown_validator_test.go
+++ b/internal/webhook/v1alpha1/idle_shutdown_validator_test.go
@@ -1,0 +1,244 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package v1alpha1
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	workspacev1alpha1 "github.com/jupyter-infra/jupyter-k8s/api/v1alpha1"
+)
+
+// transportPodExecValue is the non-default detection transport used to represent a divergence
+// from the template default in idle shutdown override tests.
+const transportPodExecValue = "podExec"
+
+var _ = Describe("Idle Shutdown Validator", func() {
+	var (
+		template  *workspacev1alpha1.WorkspaceTemplate
+		workspace *workspacev1alpha1.Workspace
+	)
+
+	boolPtr := func(b bool) *bool { return &b }
+	intPtr := func(i int) *int { return &i }
+
+	// defaultIdleShutdown returns a fresh idle shutdown config matching the template default.
+	defaultIdleShutdown := func() *workspacev1alpha1.IdleShutdownSpec {
+		return &workspacev1alpha1.IdleShutdownSpec{
+			Enabled:              true,
+			IdleTimeoutInMinutes: 30,
+			Detection: workspacev1alpha1.IdleDetectionSpec{
+				HTTPGet: &workspacev1alpha1.IdleHTTPGetAction{
+					Transport: "network",
+				},
+			},
+		}
+	}
+
+	BeforeEach(func() {
+		template = &workspacev1alpha1.WorkspaceTemplate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testTemplateName,
+				Namespace: testDefaultNamespace,
+			},
+			Spec: workspacev1alpha1.WorkspaceTemplateSpec{
+				DefaultIdleShutdown: defaultIdleShutdown(),
+				IdleShutdownOverrides: &workspacev1alpha1.IdleShutdownOverridePolicy{
+					Allow:                   boolPtr(false),
+					MinIdleTimeoutInMinutes: intPtr(15),
+					MaxIdleTimeoutInMinutes: intPtr(60),
+				},
+			},
+		}
+		workspace = &workspacev1alpha1.Workspace{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-ws", Namespace: testDefaultNamespace},
+			Spec: workspacev1alpha1.WorkspaceSpec{
+				IdleShutdown: defaultIdleShutdown(),
+			},
+		}
+	})
+
+	Context("when the policy is absent", func() {
+		It("should not enforce anything when the policy is nil", func() {
+			template.Spec.IdleShutdownOverrides = nil
+			workspace.Spec.IdleShutdown.Enabled = false
+			workspace.Spec.IdleShutdown.IdleTimeoutInMinutes = 999
+			Expect(validateIdleShutdownOverrides(workspace, template)).To(BeEmpty())
+		})
+	})
+
+	Context("when overrides are permitted (Allow true or unset)", func() {
+		BeforeEach(func() {
+			template.Spec.IdleShutdownOverrides.Allow = boolPtr(true)
+		})
+
+		It("should not enforce structure: disabling and diverging is allowed", func() {
+			workspace.Spec.IdleShutdown.Enabled = false
+			workspace.Spec.IdleShutdown.Detection.HTTPGet.Transport = transportPodExecValue
+			workspace.Spec.IdleShutdown.IdleTimeoutInMinutes = 999
+			Expect(validateIdleShutdownOverrides(workspace, template)).To(BeEmpty())
+		})
+
+		It("should treat unset Allow the same as true", func() {
+			template.Spec.IdleShutdownOverrides.Allow = nil
+			workspace.Spec.IdleShutdown.Enabled = false
+			workspace.Spec.IdleShutdown.Detection.HTTPGet.Transport = transportPodExecValue
+			Expect(validateIdleShutdownOverrides(workspace, template)).To(BeEmpty())
+		})
+
+		It("should still enforce declared timeout bounds when enabled", func() {
+			workspace.Spec.IdleShutdown.IdleTimeoutInMinutes = 45
+			Expect(validateIdleShutdownOverrides(workspace, template)).To(BeEmpty())
+
+			workspace.Spec.IdleShutdown.IdleTimeoutInMinutes = 5
+			violations := validateIdleShutdownOverrides(workspace, template)
+			Expect(violations).To(HaveLen(1))
+			Expect(violations[0].Type).To(Equal(ViolationTypeIdleShutdownTimeoutOutOfBounds))
+
+			workspace.Spec.IdleShutdown.IdleTimeoutInMinutes = 120
+			violations = validateIdleShutdownOverrides(workspace, template)
+			Expect(violations).To(HaveLen(1))
+			Expect(violations[0].Type).To(Equal(ViolationTypeIdleShutdownTimeoutOutOfBounds))
+		})
+
+		It("should skip timeout bounds when idle shutdown is disabled", func() {
+			workspace.Spec.IdleShutdown.Enabled = false
+			workspace.Spec.IdleShutdown.IdleTimeoutInMinutes = 999
+			Expect(validateIdleShutdownOverrides(workspace, template)).To(BeEmpty())
+		})
+
+		It("should leave a side unbounded when its bound is unset", func() {
+			template.Spec.IdleShutdownOverrides.MinIdleTimeoutInMinutes = nil
+			// No lower bound: a tiny timeout is fine; the upper bound still applies.
+			workspace.Spec.IdleShutdown.IdleTimeoutInMinutes = 1
+			Expect(validateIdleShutdownOverrides(workspace, template)).To(BeEmpty())
+
+			workspace.Spec.IdleShutdown.IdleTimeoutInMinutes = 120
+			Expect(validateIdleShutdownOverrides(workspace, template)).To(HaveLen(1))
+		})
+
+		It("should enforce nothing on the timeout when no bounds are declared", func() {
+			template.Spec.IdleShutdownOverrides.MinIdleTimeoutInMinutes = nil
+			template.Spec.IdleShutdownOverrides.MaxIdleTimeoutInMinutes = nil
+			workspace.Spec.IdleShutdown.IdleTimeoutInMinutes = 99999
+			Expect(validateIdleShutdownOverrides(workspace, template)).To(BeEmpty())
+		})
+	})
+
+	Context("when overrides are not allowed but there is no template default", func() {
+		It("should skip the structural lock but still enforce timeout bounds", func() {
+			template.Spec.DefaultIdleShutdown = nil
+			// Structure can't be checked without a baseline, but declared bounds still apply.
+			workspace.Spec.IdleShutdown.Enabled = false
+			workspace.Spec.IdleShutdown.Detection.HTTPGet.Transport = transportPodExecValue
+			workspace.Spec.IdleShutdown.IdleTimeoutInMinutes = 45
+			Expect(validateIdleShutdownOverrides(workspace, template)).To(BeEmpty())
+
+			workspace.Spec.IdleShutdown.Enabled = true
+			workspace.Spec.IdleShutdown.IdleTimeoutInMinutes = 120
+			violations := validateIdleShutdownOverrides(workspace, template)
+			Expect(violations).To(HaveLen(1))
+			Expect(violations[0].Type).To(Equal(ViolationTypeIdleShutdownTimeoutOutOfBounds))
+		})
+	})
+
+	Context("when overrides are not allowed", func() {
+		It("should allow a workspace matching the default with an in-bounds timeout", func() {
+			workspace.Spec.IdleShutdown.IdleTimeoutInMinutes = 45
+			Expect(validateIdleShutdownOverrides(workspace, template)).To(BeEmpty())
+		})
+
+		It("should allow a timeout equal to the default when it also equals bounds edges", func() {
+			workspace.Spec.IdleShutdown.IdleTimeoutInMinutes = 15
+			Expect(validateIdleShutdownOverrides(workspace, template)).To(BeEmpty())
+			workspace.Spec.IdleShutdown.IdleTimeoutInMinutes = 60
+			Expect(validateIdleShutdownOverrides(workspace, template)).To(BeEmpty())
+		})
+
+		It("should reject a workspace with no idle shutdown config", func() {
+			workspace.Spec.IdleShutdown = nil
+			violations := validateIdleShutdownOverrides(workspace, template)
+			Expect(violations).To(HaveLen(1))
+			Expect(violations[0].Type).To(Equal(ViolationTypeIdleShutdownOverrideNotAllowed))
+			Expect(violations[0].Field).To(Equal("spec.idleShutdown"))
+		})
+
+		It("should reject disabling idle shutdown", func() {
+			workspace.Spec.IdleShutdown.Enabled = false
+			violations := validateIdleShutdownOverrides(workspace, template)
+			Expect(violations).To(HaveLen(1))
+			Expect(violations[0].Type).To(Equal(ViolationTypeIdleShutdownOverrideNotAllowed))
+		})
+
+		It("should reject changing a non-timeout field like detection transport", func() {
+			workspace.Spec.IdleShutdown.Detection.HTTPGet.Transport = transportPodExecValue
+			violations := validateIdleShutdownOverrides(workspace, template)
+			Expect(violations).To(HaveLen(1))
+			Expect(violations[0].Type).To(Equal(ViolationTypeIdleShutdownOverrideNotAllowed))
+		})
+
+		It("should reject a timeout below the minimum", func() {
+			workspace.Spec.IdleShutdown.IdleTimeoutInMinutes = 5
+			violations := validateIdleShutdownOverrides(workspace, template)
+			Expect(violations).To(HaveLen(1))
+			Expect(violations[0].Type).To(Equal(ViolationTypeIdleShutdownTimeoutOutOfBounds))
+			Expect(violations[0].Field).To(Equal("spec.idleShutdown.idleTimeoutInMinutes"))
+		})
+
+		It("should reject a timeout above the maximum", func() {
+			workspace.Spec.IdleShutdown.IdleTimeoutInMinutes = 120
+			violations := validateIdleShutdownOverrides(workspace, template)
+			Expect(violations).To(HaveLen(1))
+			Expect(violations[0].Type).To(Equal(ViolationTypeIdleShutdownTimeoutOutOfBounds))
+		})
+
+		It("should report both an override and an out-of-bounds violation", func() {
+			// Enabled (so bounds apply) but a non-timeout field diverges and the timeout is
+			// out of range: both the structural lock and the bounds check fire.
+			workspace.Spec.IdleShutdown.Detection.HTTPGet.Transport = transportPodExecValue
+			workspace.Spec.IdleShutdown.IdleTimeoutInMinutes = 120
+			violations := validateIdleShutdownOverrides(workspace, template)
+			Expect(violations).To(HaveLen(2))
+		})
+	})
+
+	Context("bound fallbacks when min or max is unset", func() {
+		It("should use the default timeout as the min when min is unset", func() {
+			template.Spec.IdleShutdownOverrides.MinIdleTimeoutInMinutes = nil
+			// default timeout is 30, so anything below 30 must be rejected
+			workspace.Spec.IdleShutdown.IdleTimeoutInMinutes = 20
+			violations := validateIdleShutdownOverrides(workspace, template)
+			Expect(violations).To(HaveLen(1))
+			Expect(violations[0].Type).To(Equal(ViolationTypeIdleShutdownTimeoutOutOfBounds))
+
+			workspace.Spec.IdleShutdown.IdleTimeoutInMinutes = 45
+			Expect(validateIdleShutdownOverrides(workspace, template)).To(BeEmpty())
+		})
+
+		It("should use the default timeout as the max when max is unset", func() {
+			template.Spec.IdleShutdownOverrides.MaxIdleTimeoutInMinutes = nil
+			// default timeout is 30, so anything above 30 must be rejected
+			workspace.Spec.IdleShutdown.IdleTimeoutInMinutes = 45
+			violations := validateIdleShutdownOverrides(workspace, template)
+			Expect(violations).To(HaveLen(1))
+			Expect(violations[0].Type).To(Equal(ViolationTypeIdleShutdownTimeoutOutOfBounds))
+
+			workspace.Spec.IdleShutdown.IdleTimeoutInMinutes = 20
+			Expect(validateIdleShutdownOverrides(workspace, template)).To(BeEmpty())
+		})
+
+		It("should pin the timeout to the default when both bounds are unset", func() {
+			template.Spec.IdleShutdownOverrides.MinIdleTimeoutInMinutes = nil
+			template.Spec.IdleShutdownOverrides.MaxIdleTimeoutInMinutes = nil
+			workspace.Spec.IdleShutdown.IdleTimeoutInMinutes = 30
+			Expect(validateIdleShutdownOverrides(workspace, template)).To(BeEmpty())
+
+			workspace.Spec.IdleShutdown.IdleTimeoutInMinutes = 31
+			Expect(validateIdleShutdownOverrides(workspace, template)).To(HaveLen(1))
+		})
+	})
+})

--- a/internal/webhook/v1alpha1/image_validator.go
+++ b/internal/webhook/v1alpha1/image_validator.go
@@ -37,3 +37,33 @@ func validateImageAllowed(image string, template *workspacev1alpha1.WorkspaceTem
 		Actual:  image,
 	}
 }
+
+// validateTemplateImageConsistency rejects a template whose own defaultImage would be
+// un-creatable under its own image policy. When allowedImages is non-empty and custom images
+// are not allowed, defaultImage must be a member of allowedImages: otherwise the workspace
+// defaulter fills image=defaultImage for a workspace that omits one, and validateImageAllowed
+// then rejects that same image, making the template's default impossible to use (see #440).
+//
+// When allowedImages is empty, validateImageAllowed falls back to [defaultImage], so the
+// default is always creatable and no consistency check is needed.
+func validateTemplateImageConsistency(template *workspacev1alpha1.WorkspaceTemplate) error {
+	if template.Spec.AllowCustomImages != nil && *template.Spec.AllowCustomImages {
+		return nil
+	}
+
+	if len(template.Spec.AllowedImages) == 0 {
+		return nil
+	}
+
+	for _, allowed := range template.Spec.AllowedImages {
+		if template.Spec.DefaultImage == allowed {
+			return nil
+		}
+	}
+
+	return fmt.Errorf(
+		"defaultImage %q is not in allowedImages %v: the template default would be rejected by its own "+
+			"image policy, making it un-creatable (template %q)",
+		template.Spec.DefaultImage, template.Spec.AllowedImages, template.GetName(),
+	)
+}

--- a/internal/webhook/v1alpha1/resource_validator.go
+++ b/internal/webhook/v1alpha1/resource_validator.go
@@ -103,6 +103,28 @@ func validateResourceListBounds(
 	return violations
 }
 
+// validateTemplateResourceBoundsConsistency rejects a template whose resource bounds are
+// self-contradictory (min > max for any resource). Such a bound can never admit any workspace
+// value for that resource. CEL cannot express this on resource.Quantity, so it is enforced at
+// template admission.
+func validateTemplateResourceBoundsConsistency(template *workspacev1alpha1.WorkspaceTemplate) error {
+	bounds := template.Spec.ResourceBounds
+	if bounds == nil || bounds.Resources == nil {
+		return nil
+	}
+
+	for resourceName, resourceRange := range bounds.Resources {
+		if resourceRange.Min.Cmp(resourceRange.Max) > 0 {
+			return fmt.Errorf(
+				"resourceBounds for %q has min %s greater than max %s: no value can satisfy these bounds (template %q)",
+				resourceName, resourceRange.Min.String(), resourceRange.Max.String(), template.GetName(),
+			)
+		}
+	}
+
+	return nil
+}
+
 // resourcesEqual compares two ResourceRequirements for equality
 func resourcesEqual(old, new *corev1.ResourceRequirements) bool {
 	if old == nil && new == nil {

--- a/internal/webhook/v1alpha1/storage_validator.go
+++ b/internal/webhook/v1alpha1/storage_validator.go
@@ -6,12 +6,102 @@ Distributed under the terms of the MIT license
 package v1alpha1
 
 import (
+	"context"
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	workspacev1alpha1 "github.com/jupyter-infra/jupyter-k8s/api/v1alpha1"
+	"github.com/jupyter-infra/jupyter-k8s/internal/controller"
 )
+
+// StorageValidator handles storage validation that needs cluster state (the workspace's PVC).
+type StorageValidator struct {
+	client client.Client
+}
+
+// NewStorageValidator creates a new StorageValidator.
+func NewStorageValidator(k8sClient client.Client) *StorageValidator {
+	return &StorageValidator{
+		client: k8sClient,
+	}
+}
+
+// ValidateStorageSizeNotShrinking rejects a storage size decrease below what the workspace's PVC
+// already requests. Kubernetes does not support shrinking a PVC below its current size, so a
+// resize-down otherwise passes admission (including dryRun=All) and then silently fails to
+// reconcile. Rejecting it here makes admission authoritative for the shrink case.
+//
+// The check is anchored on the live PVC, not the old workspace spec:
+//   - If no PVC exists yet (workspace never started, or storage never provisioned), there is
+//     nothing Kubernetes can reject at reconcile, so any size is allowed.
+//   - If the PVC exists, the new size must be >= the PVC's current requested size. Comparing to
+//     the PVC (rather than the old spec) tracks what the API will actually accept, including the
+//     narrow RecoverVolumeExpansionFailure path where a request may be lowered toward capacity.
+//
+// PVC lookup failures fail closed, matching the workspace validating webhook's failurePolicy=fail
+// stance that admission is mandatory, not best-effort: a webhook that is up but blind (missing RBAC,
+// API outage) must not silently wave shrinks through. Only NotFound is treated as success - it is
+// the legitimate "no PVC yet, nothing to shrink" case (workspace never started or no storage
+// provisioned). A transient error blocks the update and the caller retries, as with any
+// failurePolicy=fail rejection.
+//
+// Growth is intentionally not blocked here: whether an increase succeeds depends on the
+// StorageClass's allowVolumeExpansion, which the webhook does not resolve; that gotcha still
+// surfaces at reconcile time.
+func (sv *StorageValidator) ValidateStorageSizeNotShrinking(ctx context.Context, workspace *workspacev1alpha1.Workspace) error {
+	if workspace.Spec.Storage == nil || workspace.Spec.Storage.Size.IsZero() {
+		return nil
+	}
+	newSize := workspace.Spec.Storage.Size
+
+	pvc := &corev1.PersistentVolumeClaim{}
+	err := sv.client.Get(ctx, types.NamespacedName{
+		Name:      controller.GeneratePVCName(workspace.Name),
+		Namespace: workspace.Namespace,
+	}, pvc)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			// No PVC yet: nothing provisioned to shrink.
+			return nil
+		}
+		// Fail closed: we cannot confirm the current size, so we do not let the update through.
+		workspacelog.Error(err, "Failed to get PVC for storage shrink validation; rejecting update",
+			"workspace", workspace.GetName(), "namespace", workspace.GetNamespace())
+		return fmt.Errorf("unable to validate storage size against existing volume: %w", err)
+	}
+
+	if violation := validateStorageSizeNotBelowProvisioned(newSize, pvc); violation != nil {
+		return fmt.Errorf("workspace violates storage constraints: %s", violation.Message)
+	}
+	return nil
+}
+
+// validateStorageSizeNotBelowProvisioned returns a violation when newSize is smaller than the
+// PVC's current requested storage. A PVC with no storage request recorded cannot be shrunk below
+// an unknown value, so it is treated as allowed.
+func validateStorageSizeNotBelowProvisioned(newSize resource.Quantity, pvc *corev1.PersistentVolumeClaim) *TemplateViolation {
+	provisioned, ok := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
+	if !ok || provisioned.IsZero() {
+		return nil
+	}
+
+	if newSize.Cmp(provisioned) < 0 {
+		return &TemplateViolation{
+			Type:    ViolationTypeStorageExceeded,
+			Field:   fieldStorageSize,
+			Message: fmt.Sprintf("Storage size cannot be decreased from %s to %s: Kubernetes does not support shrinking a volume below its current size", provisioned.String(), newSize.String()),
+			Allowed: fmt.Sprintf("size >= %s", provisioned.String()),
+			Actual:  newSize.String(),
+		}
+	}
+
+	return nil
+}
 
 // validateStorageSize checks if storage size is within template bounds
 func validateStorageSize(size resource.Quantity, template *workspacev1alpha1.WorkspaceTemplate) *TemplateViolation {
@@ -23,7 +113,7 @@ func validateStorageSize(size resource.Quantity, template *workspacev1alpha1.Wor
 	if config.MinSize != nil && size.Cmp(*config.MinSize) < 0 {
 		return &TemplateViolation{
 			Type:    ViolationTypeStorageExceeded,
-			Field:   "spec.storage.size",
+			Field:   fieldStorageSize,
 			Message: fmt.Sprintf("Storage size %s is below minimum %s required by template '%s'", size.String(), config.MinSize.String(), template.Name),
 			Allowed: fmt.Sprintf("min: %s", config.MinSize.String()),
 			Actual:  size.String(),
@@ -33,7 +123,7 @@ func validateStorageSize(size resource.Quantity, template *workspacev1alpha1.Wor
 	if config.MaxSize != nil && size.Cmp(*config.MaxSize) > 0 {
 		return &TemplateViolation{
 			Type:    ViolationTypeStorageExceeded,
-			Field:   "spec.storage.size",
+			Field:   fieldStorageSize,
 			Message: fmt.Sprintf("Storage size %s exceeds maximum %s allowed by template '%s'", size.String(), config.MaxSize.String(), template.Name),
 			Allowed: fmt.Sprintf("max: %s", config.MaxSize.String()),
 			Actual:  size.String(),
@@ -43,14 +133,21 @@ func validateStorageSize(size resource.Quantity, template *workspacev1alpha1.Wor
 	return nil
 }
 
-// storageEqual compares two StorageSpec for equality
-func storageEqual(old, new *workspacev1alpha1.StorageSpec) bool {
-	if old == nil && new == nil {
-		return true
-	}
-	if old == nil || new == nil {
-		return false
+// validateTemplateStorageConsistency rejects a template whose primaryStorage bounds are
+// self-contradictory (minSize > maxSize). Such a template can never admit any workspace storage
+// size. CEL cannot express this on resource.Quantity, so it is enforced at template admission.
+func validateTemplateStorageConsistency(template *workspacev1alpha1.WorkspaceTemplate) error {
+	config := template.Spec.PrimaryStorage
+	if config == nil || config.MinSize == nil || config.MaxSize == nil {
+		return nil
 	}
 
-	return old.Size.Equal(new.Size) && old.MountPath == new.MountPath
+	if config.MinSize.Cmp(*config.MaxSize) > 0 {
+		return fmt.Errorf(
+			"primaryStorage.minSize %s is greater than primaryStorage.maxSize %s: no storage size can satisfy these bounds (template %q)",
+			config.MinSize.String(), config.MaxSize.String(), template.GetName(),
+		)
+	}
+
+	return nil
 }

--- a/internal/webhook/v1alpha1/storage_validator_test.go
+++ b/internal/webhook/v1alpha1/storage_validator_test.go
@@ -1,0 +1,192 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package v1alpha1
+
+import (
+	"context"
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	workspacev1alpha1 "github.com/jupyter-infra/jupyter-k8s/api/v1alpha1"
+	"github.com/jupyter-infra/jupyter-k8s/internal/controller"
+)
+
+var _ = Describe("StorageValidator", func() {
+	var (
+		ctx    context.Context
+		scheme *runtime.Scheme
+	)
+
+	const (
+		wsName      = "storage-ws"
+		wsNs        = "default"
+		pvcSize     = "2Gi"
+		smaller     = "1Gi"
+		larger      = "5Gi"
+		sameAsPVC   = "2Gi"
+		pvcResource = "persistentvolumeclaims"
+	)
+
+	// makeWorkspace builds a workspace requesting the given storage size ("" means no storage).
+	makeWorkspace := func(size string) *workspacev1alpha1.Workspace {
+		ws := &workspacev1alpha1.Workspace{
+			ObjectMeta: metav1.ObjectMeta{Name: wsName, Namespace: wsNs},
+		}
+		if size != "" {
+			ws.Spec.Storage = &workspacev1alpha1.StorageSpec{Size: resource.MustParse(size)}
+		}
+		return ws
+	}
+
+	// existingPVC builds the workspace's PVC with the given requested storage size.
+	existingPVC := func(size string) *corev1.PersistentVolumeClaim {
+		return &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      controller.GeneratePVCName(wsName),
+				Namespace: wsNs,
+			},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse(size)},
+				},
+			},
+		}
+	}
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		scheme = runtime.NewScheme()
+		Expect(corev1.AddToScheme(scheme)).To(Succeed())
+		Expect(workspacev1alpha1.AddToScheme(scheme)).To(Succeed())
+	})
+
+	Context("when no PVC exists", func() {
+		It("allows any requested size (fake client returns NotFound)", func() {
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+			sv := NewStorageValidator(fakeClient)
+			Expect(sv.ValidateStorageSizeNotShrinking(ctx, makeWorkspace(smaller))).To(Succeed())
+		})
+	})
+
+	Context("when storage is not requested", func() {
+		It("skips the lookup entirely and allows", func() {
+			// A client whose Get always fails proves the lookup is never reached.
+			failingClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(context.Context, client.WithWatch, client.ObjectKey, client.Object, ...client.GetOption) error {
+						return errors.New("Get should not be called when storage is unset")
+					},
+				}).
+				Build()
+			sv := NewStorageValidator(failingClient)
+
+			Expect(sv.ValidateStorageSizeNotShrinking(ctx, makeWorkspace(""))).To(Succeed())
+
+			zero := makeWorkspace("")
+			zero.Spec.Storage = &workspacev1alpha1.StorageSpec{} // size is the zero quantity
+			Expect(sv.ValidateStorageSizeNotShrinking(ctx, zero)).To(Succeed())
+		})
+	})
+
+	Context("when the PVC exists", func() {
+		It("rejects shrinking below the provisioned size", func() {
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(existingPVC(pvcSize)).
+				Build()
+			sv := NewStorageValidator(fakeClient)
+
+			err := sv.ValidateStorageSizeNotShrinking(ctx, makeWorkspace(smaller))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("shrinking"))
+		})
+
+		It("allows keeping the same size", func() {
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(existingPVC(pvcSize)).
+				Build()
+			sv := NewStorageValidator(fakeClient)
+			Expect(sv.ValidateStorageSizeNotShrinking(ctx, makeWorkspace(sameAsPVC))).To(Succeed())
+		})
+
+		It("allows growing beyond the provisioned size", func() {
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(existingPVC(pvcSize)).
+				Build()
+			sv := NewStorageValidator(fakeClient)
+			Expect(sv.ValidateStorageSizeNotShrinking(ctx, makeWorkspace(larger))).To(Succeed())
+		})
+	})
+
+	Context("when retrieving the PVC fails", func() {
+		// getErrorClient returns a fake client whose PVC Get always fails with the given error.
+		getErrorClient := func(getErr error) client.Client {
+			return fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+						if _, ok := obj.(*corev1.PersistentVolumeClaim); ok {
+							return getErr
+						}
+						return errors.New("unexpected Get for non-PVC object")
+					},
+				}).
+				Build()
+		}
+
+		// The webhook fails closed on lookup errors it cannot classify as NotFound: a blind
+		// webhook must not silently wave a shrink through, matching failurePolicy=fail.
+
+		It("fails closed on a Forbidden (RBAC) error", func() {
+			forbidden := apierrors.NewForbidden(
+				schema.GroupResource{Resource: pvcResource}, controller.GeneratePVCName(wsName),
+				errors.New("not allowed"))
+			sv := NewStorageValidator(getErrorClient(forbidden))
+
+			err := sv.ValidateStorageSizeNotShrinking(ctx, makeWorkspace(smaller))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("unable to validate storage size"))
+		})
+
+		It("fails closed on a ServerTimeout (API outage) error", func() {
+			timeout := apierrors.NewServerTimeout(
+				schema.GroupResource{Resource: pvcResource}, "get", 1)
+			sv := NewStorageValidator(getErrorClient(timeout))
+
+			err := sv.ValidateStorageSizeNotShrinking(ctx, makeWorkspace(smaller))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("unable to validate storage size"))
+		})
+
+		It("fails closed on an arbitrary non-status error", func() {
+			sv := NewStorageValidator(getErrorClient(errors.New("connection refused")))
+			err := sv.ValidateStorageSizeNotShrinking(ctx, makeWorkspace(smaller))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("unable to validate storage size"))
+		})
+
+		It("still allows the update when the error is NotFound (no PVC yet)", func() {
+			notFound := apierrors.NewNotFound(
+				schema.GroupResource{Resource: pvcResource}, controller.GeneratePVCName(wsName))
+			sv := NewStorageValidator(getErrorClient(notFound))
+			Expect(sv.ValidateStorageSizeNotShrinking(ctx, makeWorkspace(smaller))).To(Succeed())
+		})
+	})
+})

--- a/internal/webhook/v1alpha1/template_validator.go
+++ b/internal/webhook/v1alpha1/template_validator.go
@@ -133,6 +133,11 @@ func (tv *TemplateValidator) ValidateCreateWorkspace(ctx context.Context, worksp
 		violations = append(violations, envViolations...)
 	}
 
+	// Validate idle shutdown against the template's override policy
+	if idleViolations := validateIdleShutdownOverrides(workspace, template); len(idleViolations) > 0 {
+		violations = append(violations, idleViolations...)
+	}
+
 	if len(violations) > 0 {
 		return fmt.Errorf("workspace violates template '%s' constraints: %s", workspace.Spec.TemplateRef.Name, formatViolations(violations))
 	}

--- a/internal/webhook/v1alpha1/template_validator_test.go
+++ b/internal/webhook/v1alpha1/template_validator_test.go
@@ -180,6 +180,105 @@ var _ = Describe("TemplateValidator", func() {
 		})
 	})
 
+	// These exercise the full ValidateCreateWorkspace/ValidateUpdateWorkspace path (template fetch +
+	// violation formatting) to confirm the idle shutdown override policy is wired into the webhook,
+	// not just the standalone validateIdleShutdownOverrides unit.
+	Context("Idle shutdown override enforcement", func() {
+		boolPtr := func(b bool) *bool { return &b }
+		intPtr := func(i int) *int { return &i }
+
+		templateIdleDefault := func() *workspacev1alpha1.IdleShutdownSpec {
+			return &workspacev1alpha1.IdleShutdownSpec{
+				Enabled:              true,
+				IdleTimeoutInMinutes: 30,
+				Detection: workspacev1alpha1.IdleDetectionSpec{
+					HTTPGet: &workspacev1alpha1.IdleHTTPGetAction{Transport: "network"},
+				},
+			}
+		}
+
+		// enforcingTemplate locks idle shutdown (allow: false) with a [15, 60] timeout window.
+		enforcingTemplate := func() *workspacev1alpha1.WorkspaceTemplate {
+			return &workspacev1alpha1.WorkspaceTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: testSharedTemplate, Namespace: testSharedNamespace},
+				Spec: workspacev1alpha1.WorkspaceTemplateSpec{
+					DefaultImage:        testValidBaseNotebook,
+					DisplayName:         "Idle Enforcing Template",
+					DefaultIdleShutdown: templateIdleDefault(),
+					IdleShutdownOverrides: &workspacev1alpha1.IdleShutdownOverridePolicy{
+						Allow:                   boolPtr(false),
+						MinIdleTimeoutInMinutes: intPtr(15),
+						MaxIdleTimeoutInMinutes: intPtr(60),
+					},
+				},
+			}
+		}
+
+		workspaceWithIdle := func(idle *workspacev1alpha1.IdleShutdownSpec) *workspacev1alpha1.Workspace {
+			return &workspacev1alpha1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{Name: "ws", Namespace: testNamespaceTeamA},
+				Spec: workspacev1alpha1.WorkspaceSpec{
+					TemplateRef: &workspacev1alpha1.TemplateRef{
+						Name:      testSharedTemplate,
+						Namespace: testSharedNamespace,
+					},
+					IdleShutdown: idle,
+				},
+			}
+		}
+
+		It("should accept a workspace whose timeout is within the enforced bounds", func() {
+			validator := buildValidator(testSharedNamespace, enforcingTemplate())
+
+			idle := templateIdleDefault()
+			idle.IdleTimeoutInMinutes = 45
+			workspace := workspaceWithIdle(idle)
+
+			Expect(validator.ValidateCreateWorkspace(ctx, workspace)).To(Succeed())
+		})
+
+		It("should reject a workspace that disables idle shutdown and surface the violation", func() {
+			validator := buildValidator(testSharedNamespace, enforcingTemplate())
+
+			idle := templateIdleDefault()
+			idle.Enabled = false
+			workspace := workspaceWithIdle(idle)
+
+			err := validator.ValidateCreateWorkspace(ctx, workspace)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(testSharedTemplate))
+			Expect(err.Error()).To(ContainSubstring("does not allow overriding idle shutdown"))
+		})
+
+		It("should reject a workspace whose timeout is outside the enforced bounds", func() {
+			validator := buildValidator(testSharedNamespace, enforcingTemplate())
+
+			idle := templateIdleDefault()
+			idle.IdleTimeoutInMinutes = 120
+			workspace := workspaceWithIdle(idle)
+
+			err := validator.ValidateCreateWorkspace(ctx, workspace)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("outside the range"))
+		})
+
+		It("should reject an update that pushes the timeout out of the enforced bounds", func() {
+			validator := buildValidator(testSharedNamespace, enforcingTemplate())
+
+			oldIdle := templateIdleDefault()
+			oldIdle.IdleTimeoutInMinutes = 45
+			oldWorkspace := workspaceWithIdle(oldIdle)
+
+			newIdle := templateIdleDefault()
+			newIdle.IdleTimeoutInMinutes = 120
+			newWorkspace := workspaceWithIdle(newIdle)
+
+			err := validator.ValidateUpdateWorkspace(ctx, oldWorkspace, newWorkspace)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("outside the range"))
+		})
+	})
+
 	// ValidateNamespaceScope is the namespace-only gate the mutating webhook calls before stamping a
 	// protection finalizer. Unlike ValidateCreateWorkspace it must NOT fetch the template, so it
 	// enforces scope even when the template does not exist and never reports a missing-template error.

--- a/internal/webhook/v1alpha1/template_webhook.go
+++ b/internal/webhook/v1alpha1/template_webhook.go
@@ -120,6 +120,11 @@ func (v *WorkspaceTemplateCustomValidator) ValidateCreate(ctx context.Context, t
 		return nil, err
 	}
 
+	// Enforce that an idle-shutdown-locking policy has a default to enforce against.
+	if err := validateIdleShutdownPolicyConsistency(template); err != nil {
+		return nil, err
+	}
+
 	return nil, nil
 }
 
@@ -130,6 +135,11 @@ func (v *WorkspaceTemplateCustomValidator) ValidateUpdate(ctx context.Context, o
 	// Enforce that the referenced access strategy is in an allowed namespace, so the template
 	// cannot make referencing workspaces fail their own admission webhook.
 	if err := v.accessStrategyValidator.ValidateUpdateTemplate(oldTemplate, newTemplate); err != nil {
+		return nil, err
+	}
+
+	// Enforce that an idle-shutdown-locking policy has a default to enforce against.
+	if err := validateIdleShutdownPolicyConsistency(newTemplate); err != nil {
 		return nil, err
 	}
 
@@ -240,6 +250,27 @@ func maxStorageSizeChanged(oldStorage, newStorage *workspacev1alpha1.StorageConf
 	}
 
 	return false
+}
+
+// validateIdleShutdownPolicyConsistency rejects a template whose idle shutdown policy locks
+// overrides (Allow=false) without a DefaultIdleShutdown baseline. Without a default there is
+// nothing for the workspace webhook to enforce the lock against, so the policy would silently
+// do nothing - a misconfiguration we surface at template admission instead.
+func validateIdleShutdownPolicyConsistency(template *workspacev1alpha1.WorkspaceTemplate) error {
+	policy := template.Spec.IdleShutdownOverrides
+	if policy == nil || policy.Allow == nil || *policy.Allow {
+		return nil
+	}
+
+	if template.Spec.DefaultIdleShutdown == nil {
+		return fmt.Errorf(
+			"idleShutdownOverrides.allow is false but defaultIdleShutdown is not set: "+
+				"a locked idle shutdown policy requires a defaultIdleShutdown for workspaces to match (template %q)",
+			template.GetName(),
+		)
+	}
+
+	return nil
 }
 
 // idleShutdownAllowOverrideChanged checks if Allow setting changed

--- a/internal/webhook/v1alpha1/template_webhook.go
+++ b/internal/webhook/v1alpha1/template_webhook.go
@@ -120,8 +120,9 @@ func (v *WorkspaceTemplateCustomValidator) ValidateCreate(ctx context.Context, t
 		return nil, err
 	}
 
-	// Enforce that an idle-shutdown-locking policy has a default to enforce against.
-	if err := validateIdleShutdownPolicyConsistency(template); err != nil {
+	// Enforce that the template's own constraints are internally consistent, so it cannot make
+	// its own defaults or any workspace value un-admittable.
+	if err := validateTemplateConsistency(template); err != nil {
 		return nil, err
 	}
 
@@ -138,8 +139,9 @@ func (v *WorkspaceTemplateCustomValidator) ValidateUpdate(ctx context.Context, o
 		return nil, err
 	}
 
-	// Enforce that an idle-shutdown-locking policy has a default to enforce against.
-	if err := validateIdleShutdownPolicyConsistency(newTemplate); err != nil {
+	// Enforce that the template's own constraints are internally consistent, so it cannot make
+	// its own defaults or any workspace value un-admittable.
+	if err := validateTemplateConsistency(newTemplate); err != nil {
 		return nil, err
 	}
 
@@ -252,22 +254,79 @@ func maxStorageSizeChanged(oldStorage, newStorage *workspacev1alpha1.StorageConf
 	return false
 }
 
-// validateIdleShutdownPolicyConsistency rejects a template whose idle shutdown policy locks
-// overrides (Allow=false) without a DefaultIdleShutdown baseline. Without a default there is
-// nothing for the workspace webhook to enforce the lock against, so the policy would silently
-// do nothing - a misconfiguration we surface at template admission instead.
+// validateTemplateConsistency rejects a template whose own constraints are internally
+// inconsistent - contradictions that would make the template's defaults or any workspace value
+// un-admittable, silently self-defeating the template. These checks run on create and update.
+func validateTemplateConsistency(template *workspacev1alpha1.WorkspaceTemplate) error {
+	// defaultImage must be creatable under the template's own image policy (#440).
+	if err := validateTemplateImageConsistency(template); err != nil {
+		return err
+	}
+
+	// primaryStorage minSize must not exceed maxSize.
+	if err := validateTemplateStorageConsistency(template); err != nil {
+		return err
+	}
+
+	// resourceBounds min must not exceed max for any resource.
+	if err := validateTemplateResourceBoundsConsistency(template); err != nil {
+		return err
+	}
+
+	// idleShutdownOverrides bounds must be consistent, and a locked policy needs a default.
+	return validateIdleShutdownPolicyConsistency(template)
+}
+
+// validateIdleShutdownPolicyConsistency rejects a template whose idle shutdown policy is
+// self-defeating: bounds that no timeout can satisfy, a locked policy with no default to enforce
+// against, or a default timeout that its own bounds would reject. All are surfaced at template
+// admission instead of silently making the template's default un-creatable.
 func validateIdleShutdownPolicyConsistency(template *workspacev1alpha1.WorkspaceTemplate) error {
 	policy := template.Spec.IdleShutdownOverrides
-	if policy == nil || policy.Allow == nil || *policy.Allow {
+	if policy == nil {
 		return nil
 	}
 
-	if template.Spec.DefaultIdleShutdown == nil {
+	// The timeout bounds must be internally consistent regardless of the Allow setting: a
+	// min greater than max can never admit any workspace timeout.
+	if policy.MinIdleTimeoutInMinutes != nil && policy.MaxIdleTimeoutInMinutes != nil &&
+		*policy.MinIdleTimeoutInMinutes > *policy.MaxIdleTimeoutInMinutes {
+		return fmt.Errorf(
+			"idleShutdownOverrides.minIdleTimeoutInMinutes %d is greater than maxIdleTimeoutInMinutes %d: "+
+				"no idle timeout can satisfy these bounds (template %q)",
+			*policy.MinIdleTimeoutInMinutes, *policy.MaxIdleTimeoutInMinutes, template.GetName(),
+		)
+	}
+
+	// A locked policy (allow=false) needs a default for workspaces to match against.
+	if policy.Allow != nil && !*policy.Allow && template.Spec.DefaultIdleShutdown == nil {
 		return fmt.Errorf(
 			"idleShutdownOverrides.allow is false but defaultIdleShutdown is not set: "+
 				"a locked idle shutdown policy requires a defaultIdleShutdown for workspaces to match (template %q)",
 			template.GetName(),
 		)
+	}
+
+	// The default timeout must satisfy the declared bounds, regardless of the Allow setting: the
+	// defaulter applies defaultIdleShutdown to any workspace that omits idleShutdown, and the
+	// workspace webhook then enforces the bounds on that enabled default. A default outside the
+	// bounds would make the template's own default un-creatable.
+	def := template.Spec.DefaultIdleShutdown
+	if def != nil && def.Enabled {
+		if policy.MinIdleTimeoutInMinutes != nil && def.IdleTimeoutInMinutes < *policy.MinIdleTimeoutInMinutes {
+			return fmt.Errorf(
+				"defaultIdleShutdown.idleTimeoutInMinutes %d is below idleShutdownOverrides.minIdleTimeoutInMinutes %d: "+
+					"the template default would be rejected by its own bounds (template %q)",
+				def.IdleTimeoutInMinutes, *policy.MinIdleTimeoutInMinutes, template.GetName(),
+			)
+		}
+		if policy.MaxIdleTimeoutInMinutes != nil && def.IdleTimeoutInMinutes > *policy.MaxIdleTimeoutInMinutes {
+			return fmt.Errorf(
+				"defaultIdleShutdown.idleTimeoutInMinutes %d is above idleShutdownOverrides.maxIdleTimeoutInMinutes %d: "+
+					"the template default would be rejected by its own bounds (template %q)",
+				def.IdleTimeoutInMinutes, *policy.MaxIdleTimeoutInMinutes, template.GetName(),
+			)
+		}
 	}
 
 	return nil

--- a/internal/webhook/v1alpha1/template_webhook_test.go
+++ b/internal/webhook/v1alpha1/template_webhook_test.go
@@ -10,6 +10,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -19,6 +21,13 @@ import (
 
 	workspacev1alpha1 "github.com/jupyter-infra/jupyter-k8s/api/v1alpha1"
 	workspaceutil "github.com/jupyter-infra/jupyter-k8s/internal/workspace"
+)
+
+const (
+	testImageA   = "image-a"
+	testImgA     = "img-a"
+	testImgB     = "img-b"
+	testImgDeflt = "img-default"
 )
 
 var _ = Describe("WorkspaceTemplate Defaulter", func() {
@@ -179,13 +188,15 @@ var _ = Describe("WorkspaceTemplate Validator", func() {
 			oldTemplate := &workspacev1alpha1.WorkspaceTemplate{
 				ObjectMeta: metav1.ObjectMeta{Name: testTemplateNameTmpl, Namespace: testNamespaceTeamA},
 				Spec: workspacev1alpha1.WorkspaceTemplateSpec{
-					AllowedImages: []string{"image-a"},
+					DefaultImage:  testImageA,
+					AllowedImages: []string{testImageA},
 				},
 			}
 			newTemplate := &workspacev1alpha1.WorkspaceTemplate{
 				ObjectMeta: metav1.ObjectMeta{Name: testTemplateNameTmpl, Namespace: testNamespaceTeamA},
 				Spec: workspacev1alpha1.WorkspaceTemplateSpec{
-					AllowedImages: []string{"image-a", "image-b"},
+					DefaultImage:  testImageA,
+					AllowedImages: []string{testImageA, "image-b"},
 				},
 			}
 			warnings, err := validator.ValidateUpdate(ctx, oldTemplate, newTemplate)
@@ -259,6 +270,205 @@ var _ = Describe("WorkspaceTemplate Validator", func() {
 
 		It("allows a nil policy without a defaultIdleShutdown", func() {
 			_, err := validator.ValidateCreate(ctx, templateWithIdle(nil, nil))
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("Idle shutdown timeout bounds consistency", func() {
+		intPtr := func(i int) *int { return &i }
+
+		templateWithBounds := func(min, max *int) *workspacev1alpha1.WorkspaceTemplate {
+			return &workspacev1alpha1.WorkspaceTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: testTemplateNameTmpl, Namespace: testNamespaceTeamA},
+				Spec: workspacev1alpha1.WorkspaceTemplateSpec{
+					IdleShutdownOverrides: &workspacev1alpha1.IdleShutdownOverridePolicy{
+						MinIdleTimeoutInMinutes: min,
+						MaxIdleTimeoutInMinutes: max,
+					},
+				},
+			}
+		}
+
+		It("rejects create when min timeout exceeds max timeout", func() {
+			_, err := validator.ValidateCreate(ctx, templateWithBounds(intPtr(60), intPtr(30)))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("minIdleTimeoutInMinutes"))
+		})
+
+		It("allows min equal to max", func() {
+			_, err := validator.ValidateCreate(ctx, templateWithBounds(intPtr(30), intPtr(30)))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("allows only one bound set", func() {
+			_, err := validator.ValidateCreate(ctx, templateWithBounds(intPtr(30), nil))
+			Expect(err).NotTo(HaveOccurred())
+			_, err = validator.ValidateCreate(ctx, templateWithBounds(nil, intPtr(30)))
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("Idle shutdown default within bounds consistency", func() {
+		intPtr := func(i int) *int { return &i }
+		boolPtr := func(b bool) *bool { return &b }
+
+		// templateWithDefaultAndBounds builds a template whose enabled default has the given timeout
+		// and whose override policy declares the given bounds (nil = unset) and allow flag.
+		templateWithDefaultAndBounds := func(defaultTimeout int, min, max *int, allow *bool) *workspacev1alpha1.WorkspaceTemplate {
+			return &workspacev1alpha1.WorkspaceTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: testTemplateNameTmpl, Namespace: testNamespaceTeamA},
+				Spec: workspacev1alpha1.WorkspaceTemplateSpec{
+					DefaultIdleShutdown: &workspacev1alpha1.IdleShutdownSpec{
+						Enabled:              true,
+						IdleTimeoutInMinutes: defaultTimeout,
+					},
+					IdleShutdownOverrides: &workspacev1alpha1.IdleShutdownOverridePolicy{
+						Allow:                   allow,
+						MinIdleTimeoutInMinutes: min,
+						MaxIdleTimeoutInMinutes: max,
+					},
+				},
+			}
+		}
+
+		It("rejects a default timeout below the minimum (allow: false)", func() {
+			_, err := validator.ValidateCreate(ctx, templateWithDefaultAndBounds(30, intPtr(60), intPtr(120), boolPtr(false)))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("below idleShutdownOverrides.minIdleTimeoutInMinutes"))
+		})
+
+		It("rejects a default timeout below the minimum (allow: true)", func() {
+			_, err := validator.ValidateCreate(ctx, templateWithDefaultAndBounds(30, intPtr(60), intPtr(120), boolPtr(true)))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("below idleShutdownOverrides.minIdleTimeoutInMinutes"))
+		})
+
+		It("rejects a default timeout above the maximum", func() {
+			_, err := validator.ValidateCreate(ctx, templateWithDefaultAndBounds(240, intPtr(15), intPtr(120), boolPtr(true)))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("above idleShutdownOverrides.maxIdleTimeoutInMinutes"))
+		})
+
+		It("rejects a default outside a one-sided (min-only) bound", func() {
+			_, err := validator.ValidateCreate(ctx, templateWithDefaultAndBounds(30, intPtr(60), nil, boolPtr(false)))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("below idleShutdownOverrides.minIdleTimeoutInMinutes"))
+		})
+
+		It("allows a default within the bounds", func() {
+			_, err := validator.ValidateCreate(ctx, templateWithDefaultAndBounds(60, intPtr(15), intPtr(120), boolPtr(true)))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("allows a default equal to a bound", func() {
+			_, err := validator.ValidateCreate(ctx, templateWithDefaultAndBounds(15, intPtr(15), intPtr(120), boolPtr(false)))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("ignores the bounds when the default is disabled", func() {
+			tmpl := templateWithDefaultAndBounds(30, intPtr(60), intPtr(120), boolPtr(true))
+			tmpl.Spec.DefaultIdleShutdown.Enabled = false
+			_, err := validator.ValidateCreate(ctx, tmpl)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("Image policy consistency", func() {
+		boolPtr := func(b bool) *bool { return &b }
+
+		templateWithImages := func(defaultImage string, allowed []string, allowCustom *bool) *workspacev1alpha1.WorkspaceTemplate {
+			return &workspacev1alpha1.WorkspaceTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: testTemplateNameTmpl, Namespace: testNamespaceTeamA},
+				Spec: workspacev1alpha1.WorkspaceTemplateSpec{
+					DefaultImage:      defaultImage,
+					AllowedImages:     allowed,
+					AllowCustomImages: allowCustom,
+				},
+			}
+		}
+
+		It("rejects a defaultImage absent from a non-empty allowedImages", func() {
+			_, err := validator.ValidateCreate(ctx, templateWithImages(testImgDeflt, []string{testImgA, testImgB}, nil))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("defaultImage"))
+			Expect(err.Error()).To(ContainSubstring("allowedImages"))
+		})
+
+		It("allows a defaultImage present in allowedImages", func() {
+			_, err := validator.ValidateCreate(ctx, templateWithImages(testImgA, []string{testImgA, testImgB}, nil))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("allows an empty allowedImages (falls back to defaultImage)", func() {
+			_, err := validator.ValidateCreate(ctx, templateWithImages(testImgDeflt, nil, nil))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("allows a mismatch when custom images are permitted", func() {
+			_, err := validator.ValidateCreate(ctx, templateWithImages(testImgDeflt, []string{testImgA}, boolPtr(true)))
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("Storage bounds consistency", func() {
+		qtyPtr := func(s string) *resource.Quantity {
+			q := resource.MustParse(s)
+			return &q
+		}
+
+		templateWithStorage := func(min, max *resource.Quantity) *workspacev1alpha1.WorkspaceTemplate {
+			return &workspacev1alpha1.WorkspaceTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: testTemplateNameTmpl, Namespace: testNamespaceTeamA},
+				Spec: workspacev1alpha1.WorkspaceTemplateSpec{
+					PrimaryStorage: &workspacev1alpha1.StorageConfig{MinSize: min, MaxSize: max},
+				},
+			}
+		}
+
+		It("rejects minSize greater than maxSize", func() {
+			_, err := validator.ValidateCreate(ctx, templateWithStorage(qtyPtr("20Gi"), qtyPtr("10Gi")))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("minSize"))
+		})
+
+		It("allows minSize equal to maxSize", func() {
+			_, err := validator.ValidateCreate(ctx, templateWithStorage(qtyPtr("10Gi"), qtyPtr("10Gi")))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("allows only one bound set", func() {
+			_, err := validator.ValidateCreate(ctx, templateWithStorage(qtyPtr("10Gi"), nil))
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("Resource bounds consistency", func() {
+		templateWithResourceBounds := func(min, max string) *workspacev1alpha1.WorkspaceTemplate {
+			return &workspacev1alpha1.WorkspaceTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: testTemplateNameTmpl, Namespace: testNamespaceTeamA},
+				Spec: workspacev1alpha1.WorkspaceTemplateSpec{
+					ResourceBounds: &workspacev1alpha1.ResourceBounds{
+						Resources: map[corev1.ResourceName]workspacev1alpha1.ResourceRange{
+							corev1.ResourceCPU: {Min: resource.MustParse(min), Max: resource.MustParse(max)},
+						},
+					},
+				},
+			}
+		}
+
+		It("rejects a resource min greater than max", func() {
+			_, err := validator.ValidateCreate(ctx, templateWithResourceBounds("4", "2"))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("resourceBounds"))
+		})
+
+		It("allows a resource min equal to max", func() {
+			_, err := validator.ValidateCreate(ctx, templateWithResourceBounds("2", "2"))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("allows a valid resource range", func() {
+			_, err := validator.ValidateCreate(ctx, templateWithResourceBounds("1", "4"))
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})

--- a/internal/webhook/v1alpha1/template_webhook_test.go
+++ b/internal/webhook/v1alpha1/template_webhook_test.go
@@ -210,6 +210,59 @@ var _ = Describe("WorkspaceTemplate Validator", func() {
 
 	})
 
+	Context("Idle shutdown policy consistency", func() {
+		boolPtr := func(b bool) *bool { return &b }
+
+		lockingPolicy := func() *workspacev1alpha1.IdleShutdownOverridePolicy {
+			return &workspacev1alpha1.IdleShutdownOverridePolicy{Allow: boolPtr(false)}
+		}
+		idleDefault := func() *workspacev1alpha1.IdleShutdownSpec {
+			return &workspacev1alpha1.IdleShutdownSpec{Enabled: true, IdleTimeoutInMinutes: 30}
+		}
+		templateWithIdle := func(
+			policy *workspacev1alpha1.IdleShutdownOverridePolicy,
+			def *workspacev1alpha1.IdleShutdownSpec,
+		) *workspacev1alpha1.WorkspaceTemplate {
+			return &workspacev1alpha1.WorkspaceTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: testTemplateNameTmpl, Namespace: testNamespaceTeamA},
+				Spec: workspacev1alpha1.WorkspaceTemplateSpec{
+					IdleShutdownOverrides: policy,
+					DefaultIdleShutdown:   def,
+				},
+			}
+		}
+
+		It("rejects create when allow is false and defaultIdleShutdown is nil", func() {
+			_, err := validator.ValidateCreate(ctx, templateWithIdle(lockingPolicy(), nil))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("defaultIdleShutdown is not set"))
+		})
+
+		It("rejects update when allow is false and defaultIdleShutdown is nil", func() {
+			oldTemplate := templateWithIdle(lockingPolicy(), idleDefault())
+			newTemplate := templateWithIdle(lockingPolicy(), nil)
+			_, err := validator.ValidateUpdate(ctx, oldTemplate, newTemplate)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("defaultIdleShutdown is not set"))
+		})
+
+		It("allows allow: false when a defaultIdleShutdown is set", func() {
+			_, err := validator.ValidateCreate(ctx, templateWithIdle(lockingPolicy(), idleDefault()))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("allows allow: true without a defaultIdleShutdown", func() {
+			_, err := validator.ValidateCreate(ctx, templateWithIdle(
+				&workspacev1alpha1.IdleShutdownOverridePolicy{Allow: boolPtr(true)}, nil))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("allows a nil policy without a defaultIdleShutdown", func() {
+			_, err := validator.ValidateCreate(ctx, templateWithIdle(nil, nil))
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
 	Context("ValidateDelete", func() {
 		It("allows deletion and returns no warnings", func() {
 			warnings, err := validator.ValidateDelete(ctx, templateWithAS(testNamespaceTeamB))

--- a/internal/webhook/v1alpha1/validation_types.go
+++ b/internal/webhook/v1alpha1/validation_types.go
@@ -43,3 +43,6 @@ const (
 
 // labelValueTrue is the string value used for boolean-style Kubernetes labels.
 const labelValueTrue = "true"
+
+// fieldStorageSize is the spec path for the primary storage size, used in violation field paths.
+const fieldStorageSize = "spec.storage.size"

--- a/internal/webhook/v1alpha1/workspace_webhook.go
+++ b/internal/webhook/v1alpha1/workspace_webhook.go
@@ -216,6 +216,7 @@ func SetupWorkspaceWebhookWithManager(mgr ctrl.Manager, defaultTemplateNamespace
 	serviceAccountValidator := NewServiceAccountValidator(mgr.GetClient())
 	serviceAccountDefaulter := NewServiceAccountDefaulter(mgr.GetClient())
 	volumeValidator := NewVolumeValidator(mgr.GetClient())
+	storageValidator := NewStorageValidator(mgr.GetClient())
 
 	return ctrl.NewWebhookManagedBy(mgr, &workspacev1alpha1.Workspace{}).
 		WithValidator(&WorkspaceCustomValidator{
@@ -223,6 +224,7 @@ func SetupWorkspaceWebhookWithManager(mgr ctrl.Manager, defaultTemplateNamespace
 			accessStrategyValidator: accessStrategyValidator,
 			serviceAccountValidator: serviceAccountValidator,
 			volumeValidator:         volumeValidator,
+			storageValidator:        storageValidator,
 		}).
 		WithDefaulter(&WorkspaceCustomDefaulter{
 			templateDefaulter:       templateDefaulter,
@@ -356,6 +358,7 @@ type WorkspaceCustomValidator struct {
 	accessStrategyValidator *AccessStrategyValidator
 	serviceAccountValidator *ServiceAccountValidator
 	volumeValidator         *VolumeValidator
+	storageValidator        *StorageValidator
 }
 
 var _ admission.Validator[*workspacev1alpha1.Workspace] = &WorkspaceCustomValidator{}
@@ -446,6 +449,14 @@ func (v *WorkspaceCustomValidator) ValidateUpdate(ctx context.Context, oldWorksp
 
 	// Validate template constraints for new workspace (only changed fields)
 	if err := v.templateValidator.ValidateUpdateWorkspace(ctx, oldWorkspace, newWorkspace); err != nil {
+		return nil, err
+	}
+
+	// Reject shrinking storage below the workspace's provisioned PVC size: Kubernetes cannot
+	// shrink a volume, so a resize-down would pass admission and then silently fail to reconcile
+	// (#439). Anchored on the live PVC, so a workspace with no PVC yet is unaffected. Applies to
+	// all workspaces, template-backed or standalone.
+	if err := v.storageValidator.ValidateStorageSizeNotShrinking(ctx, newWorkspace); err != nil {
 		return nil, err
 	}
 

--- a/internal/webhook/v1alpha1/workspace_webhook_test.go
+++ b/internal/webhook/v1alpha1/workspace_webhook_test.go
@@ -778,47 +778,7 @@ var _ = Describe("Workspace Webhook", func() {
 			})
 		})
 
-		Context("storageEqual", func() {
-			It("should return true for nil storages", func() {
-				Expect(storageEqual(nil, nil)).To(BeTrue())
-			})
-
-			It("should return false when one is nil", func() {
-				storage := &workspacev1alpha1.StorageSpec{Size: resource.MustParse("1Gi")}
-				Expect(storageEqual(nil, storage)).To(BeFalse())
-				Expect(storageEqual(storage, nil)).To(BeFalse())
-			})
-
-			It("should return true for equal storages", func() {
-				storage1 := &workspacev1alpha1.StorageSpec{
-					Size:      resource.MustParse("1Gi"),
-					MountPath: testDataMountPath,
-				}
-				storage2 := &workspacev1alpha1.StorageSpec{
-					Size:      resource.MustParse("1Gi"),
-					MountPath: testDataMountPath,
-				}
-				Expect(storageEqual(storage1, storage2)).To(BeTrue())
-			})
-
-			It("should return false for different sizes", func() {
-				storage1 := &workspacev1alpha1.StorageSpec{Size: resource.MustParse("1Gi")}
-				storage2 := &workspacev1alpha1.StorageSpec{Size: resource.MustParse("2Gi")}
-				Expect(storageEqual(storage1, storage2)).To(BeFalse())
-			})
-
-			It("should return false for different mount paths", func() {
-				storage1 := &workspacev1alpha1.StorageSpec{
-					Size:      resource.MustParse("1Gi"),
-					MountPath: "/data1",
-				}
-				storage2 := &workspacev1alpha1.StorageSpec{
-					Size:      resource.MustParse("1Gi"),
-					MountPath: "/data2",
-				}
-				Expect(storageEqual(storage1, storage2)).To(BeFalse())
-			})
-		})
+		// StorageValidator storage-shrink validation is covered in storage_validator_test.go.
 	})
 
 	Context("isControllerOrAdminUser", func() {

--- a/test/e2e/static/template-enforce-idle-shutdown/allow-override-disabled-workspace.yaml
+++ b/test/e2e/static/template-enforce-idle-shutdown/allow-override-disabled-workspace.yaml
@@ -1,0 +1,19 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: Workspace
+metadata:
+  name: allow-override-disabled-workspace
+  namespace: default
+spec:
+  displayName: "Allow Override Disabled"
+  templateRef:
+    name: allow-override-idle-template
+    namespace: jupyter-k8s-shared
+  # Disabled: permitted because allow is true, and bounds don't apply when disabled.
+  idleShutdown:
+    enabled: false
+    idleTimeoutInMinutes: 999
+    detection:
+      httpGet:
+        path: /api/status
+        port: 8888
+        transport: network

--- a/test/e2e/static/template-enforce-idle-shutdown/allow-override-enabled-out-of-bounds-workspace.yaml
+++ b/test/e2e/static/template-enforce-idle-shutdown/allow-override-enabled-out-of-bounds-workspace.yaml
@@ -1,0 +1,20 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: Workspace
+metadata:
+  name: allow-override-enabled-out-of-bounds-workspace
+  namespace: default
+spec:
+  displayName: "Allow Override Enabled Out Of Bounds"
+  templateRef:
+    name: allow-override-idle-template
+    namespace: jupyter-k8s-shared
+  # allow: true lets the workspace diverge structurally, but declared bounds still cap the
+  # timeout when idle shutdown is enabled: 999 exceeds max 60, so this is rejected.
+  idleShutdown:
+    enabled: true
+    idleTimeoutInMinutes: 999
+    detection:
+      httpGet:
+        path: /custom/idle
+        port: 8888
+        transport: podExec

--- a/test/e2e/static/template-enforce-idle-shutdown/allow-override-idle-template.yaml
+++ b/test/e2e/static/template-enforce-idle-shutdown/allow-override-idle-template.yaml
@@ -1,0 +1,28 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: WorkspaceTemplate
+metadata:
+  name: allow-override-idle-template
+  namespace: jupyter-k8s-shared
+spec:
+  displayName: "Allow-Override Idle Shutdown Template"
+  defaultImage: jk8s-application-jupyter-uv:latest
+  defaultResources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  defaultIdleShutdown:
+    enabled: true
+    idleTimeoutInMinutes: 30
+    detection:
+      httpGet:
+        path: /api/status
+        port: 8888
+        transport: network
+  idleShutdownOverrides:
+    # allow: true means bounds are advisory only; workspaces may override freely.
+    allow: true
+    minIdleTimeoutInMinutes: 15
+    maxIdleTimeoutInMinutes: 60

--- a/test/e2e/static/template-enforce-idle-shutdown/enforce-idle-template.yaml
+++ b/test/e2e/static/template-enforce-idle-shutdown/enforce-idle-template.yaml
@@ -1,0 +1,27 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: WorkspaceTemplate
+metadata:
+  name: enforce-idle-template
+  namespace: jupyter-k8s-shared
+spec:
+  displayName: "Enforced Idle Shutdown Template"
+  defaultImage: jk8s-application-jupyter-uv:latest
+  defaultResources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  defaultIdleShutdown:
+    enabled: true
+    idleTimeoutInMinutes: 30
+    detection:
+      httpGet:
+        path: /api/status
+        port: 8888
+        transport: network
+  idleShutdownOverrides:
+    allow: false
+    minIdleTimeoutInMinutes: 15
+    maxIdleTimeoutInMinutes: 60

--- a/test/e2e/static/template-enforce-idle-shutdown/invalid-default-out-of-bounds-template.yaml
+++ b/test/e2e/static/template-enforce-idle-shutdown/invalid-default-out-of-bounds-template.yaml
@@ -1,0 +1,24 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: WorkspaceTemplate
+metadata:
+  name: invalid-default-out-of-bounds-template
+  namespace: jupyter-k8s-shared
+spec:
+  displayName: "Invalid Default Out Of Bounds Idle Shutdown Template"
+  defaultImage: jk8s-application-jupyter-uv:latest
+  # The enabled default timeout (5) is below minIdleTimeoutInMinutes (15). The defaulter would
+  # stamp this default onto any workspace that omits idleShutdown, and the workspace webhook would
+  # then reject it against the same bounds - making the template's own default un-creatable.
+  # The template admission webhook must reject this misconfiguration.
+  defaultIdleShutdown:
+    enabled: true
+    idleTimeoutInMinutes: 5
+    detection:
+      httpGet:
+        path: /api/status
+        port: 8888
+        transport: network
+  idleShutdownOverrides:
+    allow: true
+    minIdleTimeoutInMinutes: 15
+    maxIdleTimeoutInMinutes: 60

--- a/test/e2e/static/template-enforce-idle-shutdown/invalid-locking-no-default-template.yaml
+++ b/test/e2e/static/template-enforce-idle-shutdown/invalid-locking-no-default-template.yaml
@@ -1,0 +1,14 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: WorkspaceTemplate
+metadata:
+  name: invalid-locking-no-default-template
+  namespace: jupyter-k8s-shared
+spec:
+  displayName: "Invalid Locking Idle Shutdown Template"
+  defaultImage: jk8s-application-jupyter-uv:latest
+  # allow: false locks idle shutdown, but there is no defaultIdleShutdown to enforce against.
+  # The template admission webhook must reject this misconfiguration.
+  idleShutdownOverrides:
+    allow: false
+    minIdleTimeoutInMinutes: 15
+    maxIdleTimeoutInMinutes: 60

--- a/test/e2e/static/template-enforce-idle-shutdown/permissive-disable-idle-workspace.yaml
+++ b/test/e2e/static/template-enforce-idle-shutdown/permissive-disable-idle-workspace.yaml
@@ -1,0 +1,18 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: Workspace
+metadata:
+  name: permissive-disable-idle-workspace
+  namespace: default
+spec:
+  displayName: "Permissive Disable Idle"
+  templateRef:
+    name: permissive-idle-template
+    namespace: jupyter-k8s-shared
+  idleShutdown:
+    enabled: false
+    idleTimeoutInMinutes: 30
+    detection:
+      httpGet:
+        path: /api/status
+        port: 8888
+        transport: network

--- a/test/e2e/static/template-enforce-idle-shutdown/permissive-idle-template.yaml
+++ b/test/e2e/static/template-enforce-idle-shutdown/permissive-idle-template.yaml
@@ -1,0 +1,24 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: WorkspaceTemplate
+metadata:
+  name: permissive-idle-template
+  namespace: jupyter-k8s-shared
+spec:
+  displayName: "Permissive Idle Shutdown Template"
+  defaultImage: jk8s-application-jupyter-uv:latest
+  defaultResources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  defaultIdleShutdown:
+    enabled: true
+    idleTimeoutInMinutes: 30
+    detection:
+      httpGet:
+        path: /api/status
+        port: 8888
+        transport: network
+  # No idleShutdownOverrides policy: workspaces may freely override idle shutdown.

--- a/test/e2e/static/template-enforce-idle-shutdown/reject-disable-idle-workspace.yaml
+++ b/test/e2e/static/template-enforce-idle-shutdown/reject-disable-idle-workspace.yaml
@@ -1,0 +1,19 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: Workspace
+metadata:
+  name: reject-disable-idle-workspace
+  namespace: default
+spec:
+  displayName: "Reject Disable Idle"
+  templateRef:
+    name: enforce-idle-template
+    namespace: jupyter-k8s-shared
+  # enabled: false is a forbidden override when the template locks idle shutdown.
+  idleShutdown:
+    enabled: false
+    idleTimeoutInMinutes: 30
+    detection:
+      httpGet:
+        path: /api/status
+        port: 8888
+        transport: network

--- a/test/e2e/static/template-enforce-idle-shutdown/reject-modified-detection-workspace.yaml
+++ b/test/e2e/static/template-enforce-idle-shutdown/reject-modified-detection-workspace.yaml
@@ -1,0 +1,20 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: Workspace
+metadata:
+  name: reject-modified-detection-workspace
+  namespace: default
+spec:
+  displayName: "Reject Modified Detection"
+  templateRef:
+    name: enforce-idle-template
+    namespace: jupyter-k8s-shared
+  # Timeout is within bounds, but a non-timeout field (detection path/transport)
+  # diverges from the template default, which is a forbidden override.
+  idleShutdown:
+    enabled: true
+    idleTimeoutInMinutes: 45
+    detection:
+      httpGet:
+        path: /custom/idle
+        port: 8888
+        transport: podExec

--- a/test/e2e/static/template-enforce-idle-shutdown/reject-timeout-out-of-bounds-workspace.yaml
+++ b/test/e2e/static/template-enforce-idle-shutdown/reject-timeout-out-of-bounds-workspace.yaml
@@ -1,0 +1,19 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: Workspace
+metadata:
+  name: reject-timeout-out-of-bounds-workspace
+  namespace: default
+spec:
+  displayName: "Reject Timeout Out Of Bounds"
+  templateRef:
+    name: enforce-idle-template
+    namespace: jupyter-k8s-shared
+  # All fields match the default, but timeout 120 exceeds max 60.
+  idleShutdown:
+    enabled: true
+    idleTimeoutInMinutes: 120
+    detection:
+      httpGet:
+        path: /api/status
+        port: 8888
+        transport: network

--- a/test/e2e/static/template-enforce-idle-shutdown/valid-timeout-within-bounds-workspace.yaml
+++ b/test/e2e/static/template-enforce-idle-shutdown/valid-timeout-within-bounds-workspace.yaml
@@ -1,0 +1,18 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: Workspace
+metadata:
+  name: valid-timeout-within-bounds-workspace
+  namespace: default
+spec:
+  displayName: "Valid Timeout Within Bounds"
+  templateRef:
+    name: enforce-idle-template
+    namespace: jupyter-k8s-shared
+  idleShutdown:
+    enabled: true
+    idleTimeoutInMinutes: 45
+    detection:
+      httpGet:
+        path: /api/status
+        port: 8888
+        transport: network

--- a/test/e2e/static/template-validation/inconsistent-default-image-template.yaml
+++ b/test/e2e/static/template-validation/inconsistent-default-image-template.yaml
@@ -1,0 +1,14 @@
+# Self-inconsistent template: defaultImage is not a member of a non-empty allowedImages
+# (with allowCustomImages unset/false). The template webhook must reject this because the
+# template's own default would be un-creatable under its own image policy (issue #440).
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: WorkspaceTemplate
+metadata:
+  name: inconsistent-default-image-template
+  namespace: jupyter-k8s-shared
+spec:
+  displayName: "Inconsistent Default Image Template"
+  defaultImage: jk8s-application-jupyter-uv:latest
+  allowedImages:
+    - some-other-image:latest
+    - yet-another-image:latest

--- a/test/e2e/template_enforce_idle_shutdown_test.go
+++ b/test/e2e/template_enforce_idle_shutdown_test.go
@@ -183,6 +183,26 @@ var _ = Describe("Template Idle Shutdown Enforcement", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(output).To(BeEmpty(), "template should not exist after webhook rejection")
 		})
+
+		It("should reject a template whose default idle timeout is outside its own bounds", func() {
+			templateFilename := "invalid-default-out-of-bounds-template"
+			templateName := "invalid-default-out-of-bounds-template"
+
+			By("attempting to create a template whose enabled default timeout is below the minimum")
+			path := BuildTestResourcePath(templateFilename, groupDir, "")
+			cmd := exec.Command("kubectl", "apply", "-f", path)
+			output, err := utils.Run(cmd)
+			Expect(err).To(HaveOccurred(), "template webhook should reject a default outside its own bounds")
+			Expect(output).To(ContainSubstring("below idleShutdownOverrides.minIdleTimeoutInMinutes"),
+				"rejection should explain the default is below the minimum bound")
+
+			By("verifying the template was not created")
+			cmd = exec.Command("kubectl", verbGet, "workspacetemplate", templateName,
+				"-n", SharedNamespace, "--ignore-not-found")
+			output, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).To(BeEmpty(), "template should not exist after webhook rejection")
+		})
 	})
 })
 

--- a/test/e2e/template_enforce_idle_shutdown_test.go
+++ b/test/e2e/template_enforce_idle_shutdown_test.go
@@ -1,0 +1,202 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package e2e
+
+import (
+	"os/exec"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jupyter-infra/jupyter-k8s/internal/controller"
+	"github.com/jupyter-infra/jupyter-k8s/test/utils"
+)
+
+var _ = Describe("Template Idle Shutdown Enforcement", Ordered, func() {
+	const (
+		workspaceNamespace = "default"
+		groupDir           = "template-enforce-idle-shutdown"
+
+		enforceTemplate       = "enforce-idle-template"
+		permissiveTemplate    = "permissive-idle-template"
+		allowOverrideTemplate = "allow-override-idle-template"
+	)
+
+	AfterEach(func() {
+		deleteResourcesForTemplateEnforceIdleTest()
+	})
+
+	Context("when the template does not enforce idle shutdown", func() {
+		It("should accept a workspace disabling idle shutdown when no override policy is set", func() {
+			workspace := "permissive-disable-idle-workspace"
+
+			By("creating a template with defaultIdleShutdown but no idleShutdownOverrides policy")
+			createTemplateForTest(permissiveTemplate, groupDir, "")
+
+			By("creating a workspace that disables idle shutdown")
+			createWorkspaceForTest(workspace, groupDir, "")
+
+			By("verifying the workspace was accepted with idle shutdown disabled")
+			output, err := kubectlGet("workspace", workspace, workspaceNamespace, "{.spec.idleShutdown.enabled}")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).To(Equal("false"))
+		})
+
+		It("should accept a disabled override when allow is true (bounds skipped when disabled)", func() {
+			workspace := "allow-override-disabled-workspace"
+
+			By("creating a template with allow: true and timeout bounds")
+			createTemplateForTest(allowOverrideTemplate, groupDir, "")
+
+			By("creating a workspace that disables idle shutdown with an out-of-bounds timeout")
+			createWorkspaceForTest(workspace, groupDir, "")
+
+			By("verifying the workspace was accepted unchanged")
+			enabled, err := kubectlGet("workspace", workspace, workspaceNamespace, "{.spec.idleShutdown.enabled}")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(enabled).To(Equal("false"))
+
+			timeout, err := kubectlGet("workspace", workspace, workspaceNamespace,
+				"{.spec.idleShutdown.idleTimeoutInMinutes}")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(timeout).To(Equal("999"))
+		})
+	})
+
+	Context("when the template allows overrides but declares timeout bounds", func() {
+		It("should reject an enabled timeout outside the declared bounds even when allow is true", func() {
+			workspace := "allow-override-enabled-out-of-bounds-workspace"
+
+			By("creating a template with allow: true and bounds [15, 60]")
+			createTemplateForTest(allowOverrideTemplate, groupDir, "")
+
+			By("attempting to create an enabled workspace with a timeout of 999")
+			VerifyCreateWorkspaceRejectedByWebhook(workspace, groupDir, "", workspace, workspaceNamespace)
+		})
+	})
+
+	Context("when the template enforces idle shutdown (allow: false)", func() {
+		It("should accept a workspace that changes only the timeout within bounds", func() {
+			workspace := "valid-timeout-within-bounds-workspace"
+
+			By("creating a template with allow: false and bounds [15, 60]")
+			createTemplateForTest(enforceTemplate, groupDir, "")
+
+			By("creating a workspace matching the default with an in-bounds timeout of 45")
+			createWorkspaceForTest(workspace, groupDir, "")
+
+			By("verifying the workspace becomes available")
+			WaitForWorkspaceToReachCondition(
+				workspace,
+				workspaceNamespace,
+				controller.ConditionTypeAvailable,
+				ConditionTrue,
+			)
+
+			By("verifying the timeout override was accepted")
+			timeout, err := kubectlGet("workspace", workspace, workspaceNamespace,
+				"{.spec.idleShutdown.idleTimeoutInMinutes}")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(timeout).To(Equal("45"))
+		})
+
+		It("should reject a workspace that disables idle shutdown", func() {
+			workspace := "reject-disable-idle-workspace"
+
+			By("creating a template with allow: false")
+			createTemplateForTest(enforceTemplate, groupDir, "")
+
+			By("attempting to create a workspace with idle shutdown disabled")
+			VerifyCreateWorkspaceRejectedByWebhook(workspace, groupDir, "", workspace, workspaceNamespace)
+		})
+
+		It("should reject a workspace that modifies a non-timeout idle shutdown setting", func() {
+			workspace := "reject-modified-detection-workspace"
+
+			By("creating a template with allow: false")
+			createTemplateForTest(enforceTemplate, groupDir, "")
+
+			By("attempting to create a workspace that changes detection path/transport")
+			VerifyCreateWorkspaceRejectedByWebhook(workspace, groupDir, "", workspace, workspaceNamespace)
+		})
+
+		It("should reject a workspace whose timeout is outside the bounds", func() {
+			workspace := "reject-timeout-out-of-bounds-workspace"
+
+			By("creating a template with allow: false and bounds [15, 60]")
+			createTemplateForTest(enforceTemplate, groupDir, "")
+
+			By("attempting to create a workspace with a timeout of 120")
+			VerifyCreateWorkspaceRejectedByWebhook(workspace, groupDir, "", workspace, workspaceNamespace)
+		})
+
+		It("should reject an update that pushes the timeout out of bounds", func() {
+			workspace := "valid-timeout-within-bounds-workspace"
+
+			By("creating a template with allow: false and bounds [15, 60]")
+			createTemplateForTest(enforceTemplate, groupDir, "")
+
+			By("creating a valid workspace with an in-bounds timeout")
+			createWorkspaceForTest(workspace, groupDir, "")
+
+			By("verifying the workspace becomes available")
+			WaitForWorkspaceToReachCondition(
+				workspace,
+				workspaceNamespace,
+				controller.ConditionTypeAvailable,
+				ConditionTrue,
+			)
+
+			By("patching the workspace to a timeout above the maximum")
+			patchCmd := `{"spec":{"idleShutdown":{"idleTimeoutInMinutes":120}}}`
+			cmd := exec.Command("kubectl", "patch", "workspace", workspace,
+				"-n", workspaceNamespace, "--type=merge", "-p", patchCmd)
+			_, err := utils.Run(cmd)
+			Expect(err).To(HaveOccurred(), "expected webhook to reject out-of-bounds timeout update")
+		})
+	})
+
+	Context("template-level policy consistency", func() {
+		It("should reject a template that locks idle shutdown without a defaultIdleShutdown", func() {
+			templateFilename := "invalid-locking-no-default-template"
+			templateName := "invalid-locking-no-default-template"
+
+			By("attempting to create a template with allow: false and no defaultIdleShutdown")
+			path := BuildTestResourcePath(templateFilename, groupDir, "")
+			cmd := exec.Command("kubectl", "apply", "-f", path)
+			output, err := utils.Run(cmd)
+			Expect(err).To(HaveOccurred(), "template webhook should reject a locking policy with no default")
+			Expect(output).To(ContainSubstring("defaultIdleShutdown is not set"),
+				"rejection should explain the missing defaultIdleShutdown")
+
+			By("verifying the template was not created")
+			cmd = exec.Command("kubectl", verbGet, "workspacetemplate", templateName,
+				"-n", SharedNamespace, "--ignore-not-found")
+			output, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).To(BeEmpty(), "template should not exist after webhook rejection")
+		})
+	})
+})
+
+func deleteResourcesForTemplateEnforceIdleTest() {
+	By("cleaning up workspaces")
+	cmd := exec.Command("kubectl", "delete", "workspace", "--all", "-n", "default",
+		"--ignore-not-found", "--wait=true", "--timeout=120s")
+	_, _ = utils.Run(cmd)
+
+	By("cleaning up templates")
+	cmd = exec.Command("kubectl", "delete", "workspacetemplate", "--all", "-n", SharedNamespace,
+		"--ignore-not-found", "--wait=true", "--timeout=60s")
+	_, _ = utils.Run(cmd)
+
+	By("waiting an arbitrary fixed time for resources to be fully deleted")
+	time.Sleep(1 * time.Second)
+}

--- a/test/e2e/workspace_storage_test.go
+++ b/test/e2e/workspace_storage_test.go
@@ -167,6 +167,31 @@ var _ = Describe("Workspace Storage", Ordered, func() {
 				"workspace-storage", "/home/jovyan/data")
 		})
 
+		It("should reject shrinking storage size on update", func() {
+			workspaceFilename := baseWorkspaceName
+			workspaceName := baseWorkspaceName
+
+			By("creating a workspace with 2Gi storage")
+			createWorkspaceForTest(workspaceFilename, group, baseSubgroup)
+
+			By("waiting for the workspace to become Available (provisions the PVC at 2Gi)")
+			WaitForWorkspaceToReachCondition(
+				workspaceName,
+				workspaceNamespace,
+				ConditionTypeAvailable,
+				ConditionTrue,
+			)
+
+			By("attempting to shrink the storage size to 1Gi")
+			patchCmd := `{"spec":{"storage":{"size":"1Gi"}}}`
+			cmd := exec.Command("kubectl", "patch", "workspace", workspaceName,
+				"-n", workspaceNamespace, "--type=merge", "-p", patchCmd)
+			output, err := utils.Run(cmd)
+			Expect(err).To(HaveOccurred(), "expected webhook to reject a storage size shrink")
+			Expect(output).To(ContainSubstring("shrinking"),
+				"rejection should explain that the storage size cannot shrink")
+		})
+
 		It("should delete pvc when workspace is deleted", func() {
 			workspaceFilename := baseWorkspaceName
 			workspaceName := baseWorkspaceName

--- a/test/e2e/workspace_template_test.go
+++ b/test/e2e/workspace_template_test.go
@@ -422,6 +422,28 @@ var _ = Describe("Workspace Template", Ordered, func() {
 		})
 	})
 
+	Context("Self-consistency", func() {
+		It("should reject a template whose defaultImage is not in a non-empty allowedImages", func() {
+			templateFilename := "inconsistent-default-image-template"
+			templateName := "inconsistent-default-image-template"
+
+			By("attempting to create a template whose default image would be un-creatable")
+			path := BuildTestResourcePath(templateFilename, groupDir, subgroupValidation)
+			cmd := exec.Command("kubectl", "apply", "-f", path)
+			output, err := utils.Run(cmd)
+			Expect(err).To(HaveOccurred(), "template webhook should reject a self-inconsistent image policy")
+			Expect(output).To(ContainSubstring("defaultImage"),
+				"rejection should explain the defaultImage / allowedImages inconsistency")
+
+			By("verifying the template was not created")
+			cmd = exec.Command("kubectl", verbGet, "workspacetemplate", templateName,
+				"-n", SharedNamespace, "--ignore-not-found")
+			output, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).To(BeEmpty(), "template should not exist after webhook rejection")
+		})
+	})
+
 	Context("Mutability and Deletion Protection", func() {
 		It("should prevent template deletion when workspace is using it", func() {
 			workspaceName := "deletion-protection-workspace"

--- a/test/helm/crd-only/extension_api_auth_test.go
+++ b/test/helm/crd-only/extension_api_auth_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package crdonly_test
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Extension API Auth RBAC", func() {
+
+	It("should use ClusterRole and ClusterRoleBinding instead of kube-system RoleBinding", func() {
+		rootDir, err := filepath.Abs("../../..")
+		Expect(err).NotTo(HaveOccurred())
+
+		templatePath := filepath.Join(rootDir, "dist", "chart", "templates", "rbac", "extension-api-auth-binding.yaml")
+		data, err := os.ReadFile(templatePath)
+		Expect(err).NotTo(HaveOccurred(), "Failed to read extension-api-auth-binding.yaml")
+
+		content := string(data)
+
+		By("not creating resources in kube-system namespace")
+		Expect(content).NotTo(ContainSubstring("namespace: kube-system"),
+			"extension-api-auth-binding should not create resources in kube-system; "+
+				"EKS addon framework cannot create cross-namespace resources")
+
+		By("using ClusterRole for configmap access")
+		Expect(content).To(ContainSubstring("kind: ClusterRole"),
+			"should use ClusterRole instead of referencing kube-system Role")
+
+		By("using ClusterRoleBinding")
+		Expect(content).To(ContainSubstring("kind: ClusterRoleBinding"),
+			"should use ClusterRoleBinding instead of RoleBinding in kube-system")
+
+		By("granting read access to extension-apiserver-authentication configmap")
+		Expect(content).To(ContainSubstring("extension-apiserver-authentication"),
+			"should reference the extension-apiserver-authentication configmap")
+
+		By("being gated on extensionApi.enable")
+		Expect(content).To(ContainSubstring(".Values.extensionApi.enable"),
+			"should be conditional on extensionApi.enable")
+	})
+})


### PR DESCRIPTION
## What

Brings the `ray-clusters` integration feature branch current with `main`. Merges in the 5 commits `main` had that `ray-clusters` lacked:

- `#449` feat: WebSocket connection type for k8s-native remote connections
- `#442` feat: support Authorization Bearer header in `handleBearerAuth`
- `#443` fix: template admission
- `#438` fix: idle shutdown enforcement
- `#434` fix: use ClusterRole for extension-apiserver-authentication access

## Conflict resolution

One conflict, in `internal/webhook/v1alpha1/workspace_webhook.go`: `main` added `storageValidator` and the feature branch added `integrationTemplateRefValidator` to `WorkspaceCustomValidator`. Resolved by **keeping both** — both the constructor wiring and the struct fields. Both are consumed (integration validation in `ValidateCreate`/`ValidateUpdate`, storage validation in the update path). Everything else auto-merged.

## Verification (local, on the merge commit)

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./internal/webhook/... ./internal/controller/...` — green (envtest)
- Focused e2e (`Workspace Integration`, kind) — **16 Passed | 0 Failed**, including the two-phase freeze/no-restart drift proof and the admission suite on top of #443's merged changes

CI will run the full suite (incl. the idle-shutdown e2e added by #438).
