### PR TITLE
test: gpu and lifecycle e2e coverage

### DIFF
--- a/test/e2e/helpers_gpu.go
+++ b/test/e2e/helpers_gpu.go
@@ -1,0 +1,152 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/jupyter-infra/jupyter-k8s/internal/controller"
+	"github.com/jupyter-infra/jupyter-k8s/test/utils"
+)
+
+// Helpers for the Workspace GPU e2e suite (workspace_gpu_test.go). Kind nodes have no GPUs, so the
+// suite advertises nvidia.com/gpu on a node through the status subresource — the documented way to
+// advertise an extended resource without a device plugin. The scheduler fits pods against the
+// patched allocatable and the kubelet runs them; only CUDA itself would need real hardware.
+
+const (
+	// fakeGPUResourceName is the extended resource advertised on the fake GPU node.
+	fakeGPUResourceName = "nvidia.com/gpu"
+	// fakeGPUNodeLabel marks the advertising node; the GPU template's defaultNodeSelector targets it.
+	fakeGPUNodeLabel = "e2e.jupyter.org/fake-gpu"
+	// fakeGPUCapacity leaves headroom over the largest single request (2) so a pod still
+	// terminating from the previous spec cannot make the next one unschedulable.
+	fakeGPUCapacity = "4"
+)
+
+// fakeGPUResource is fakeGPUResourceName as a typed key into ResourceList maps.
+var fakeGPUResource = corev1.ResourceName(fakeGPUResourceName)
+
+// setupFakeGPUNode advertises fake GPU capacity on the cluster's first node and labels it for
+// nodeSelector-based placement. Returns the node name. Capacity and allocatable are patched
+// together: the kubelet only recomputes allocatable from capacity on its periodic status sync,
+// too slow for a test to wait on.
+func setupFakeGPUNode() string {
+	ginkgo.GinkgoHelper()
+
+	nodeName, err := kubectlGet("nodes", "", "", "{.items[0].metadata.name}")
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Expect(nodeName).NotTo(gomega.BeEmpty(), "expected at least one node in the cluster")
+
+	ginkgo.By(fmt.Sprintf("advertising %s=%s on node %s", fakeGPUResourceName, fakeGPUCapacity, nodeName))
+	patch := fmt.Sprintf(
+		`[{"op":"add","path":"/status/capacity/%[1]s","value":"%[2]s"},`+
+			`{"op":"add","path":"/status/allocatable/%[1]s","value":"%[2]s"}]`,
+		jsonPatchEscapedGPUResource(), fakeGPUCapacity)
+	cmd := exec.Command("kubectl", "patch", "node", nodeName,
+		"--subresource=status", "--type=json", "-p", patch)
+	_, err = utils.Run(cmd)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	ginkgo.By("verifying the node reports the fake GPU allocatable")
+	var node corev1.Node
+	gomega.Expect(kubectlGetInto("node", nodeName, "", &node)).To(gomega.Succeed())
+	gomega.Expect(node.Status.Allocatable).To(gomega.HaveKey(fakeGPUResource))
+
+	ginkgo.By(fmt.Sprintf("labeling node %s with %s=true", nodeName, fakeGPUNodeLabel))
+	cmd = exec.Command("kubectl", "label", "--overwrite", "node", nodeName, fakeGPUNodeLabel+"=true")
+	_, err = utils.Run(cmd)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	return nodeName
+}
+
+// teardownFakeGPUNode removes the fake GPU advertisement and label. Best-effort: CI deletes the
+// Kind cluster after the suite; this matters for reruns against a kept dev cluster.
+func teardownFakeGPUNode(nodeName string) {
+	ginkgo.GinkgoHelper()
+	if nodeName == "" {
+		return
+	}
+	patch := fmt.Sprintf(
+		`[{"op":"remove","path":"/status/capacity/%[1]s"},`+
+			`{"op":"remove","path":"/status/allocatable/%[1]s"}]`,
+		jsonPatchEscapedGPUResource())
+	cmd := exec.Command("kubectl", "patch", "node", nodeName,
+		"--subresource=status", "--type=json", "-p", patch)
+	_, _ = utils.Run(cmd)
+	cmd = exec.Command("kubectl", "label", "node", nodeName, fakeGPUNodeLabel+"-")
+	_, _ = utils.Run(cmd)
+}
+
+// jsonPatchEscapedGPUResource returns fakeGPUResourceName with '/' escaped as '~1' (RFC 6901).
+func jsonPatchEscapedGPUResource() string {
+	return strings.ReplaceAll(fakeGPUResourceName, "/", "~1")
+}
+
+// gpuQuantity returns the nvidia.com/gpu value in a resource list and whether the key is present.
+func gpuQuantity(list corev1.ResourceList) (int64, bool) {
+	q, ok := list[fakeGPUResource]
+	if !ok {
+		return 0, false
+	}
+	return q.Value(), true
+}
+
+// hasToleration reports whether tolerations contains an exact key/operator/effect match.
+func hasToleration(
+	tolerations []corev1.Toleration,
+	key string,
+	op corev1.TolerationOperator,
+	effect corev1.TaintEffect,
+) bool {
+	for _, t := range tolerations {
+		if t.Key == key && t.Operator == op && t.Effect == effect {
+			return true
+		}
+	}
+	return false
+}
+
+// workspacePod returns the workspace's pod, decoded.
+func workspacePod(workspaceName, namespace string) *corev1.Pod {
+	ginkgo.GinkgoHelper()
+	podName, err := kubectlGetByLabels("pod",
+		fmt.Sprintf("%s=%s", controller.LabelWorkspaceName, workspaceName),
+		namespace, "{.items[0].metadata.name}")
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Expect(podName).NotTo(gomega.BeEmpty())
+	var pod corev1.Pod
+	gomega.Expect(kubectlGetInto("pod", podName, namespace, &pod)).To(gomega.Succeed())
+	return &pod
+}
+
+// deleteResourcesForGPUTest removes only the objects this Ordered suite creates, by explicit name,
+// so it can never nuke unrelated objects sharing the "default" namespace.
+func deleteResourcesForGPUTest(workspaceNamespace string) {
+	ginkgo.GinkgoHelper()
+
+	ginkgo.By("cleaning up GPU test workspaces")
+	cmd := exec.Command("kubectl", "delete", "workspace",
+		"gpu-default-workspace", "gpu-override-workspace", "gpu-exceed-workspace",
+		"gpu-cpu-only-workspace", "gpu-no-template-workspace",
+		"-n", workspaceNamespace, "--ignore-not-found", "--wait=true", "--timeout=120s")
+	_, _ = utils.Run(cmd)
+
+	ginkgo.By("cleaning up the GPU template")
+	cmd = exec.Command("kubectl", "delete", "workspacetemplate", "gpu-template",
+		"-n", SharedNamespace, "--ignore-not-found", "--wait=true", "--timeout=60s")
+	_, _ = utils.Run(cmd)
+}

--- a/test/e2e/helpers_gpu.go
+++ b/test/e2e/helpers_gpu.go
@@ -22,7 +22,7 @@ import (
 )
 
 // Helpers for the Workspace GPU e2e suite (workspace_gpu_test.go). Kind nodes have no GPUs, so the
-// suite advertises nvidia.com/gpu on a node through the status subresource — the documented way to
+// suite advertises nvidia.com/gpu on a node through the status subresource, the documented way to
 // advertise an extended resource without a device plugin. The scheduler fits pods against the
 // patched allocatable and the kubelet runs them; only CUDA itself would need real hardware.
 

--- a/test/e2e/static/drift/workspace-drift.yaml
+++ b/test/e2e/static/drift/workspace-drift.yaml
@@ -1,0 +1,15 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: Workspace
+metadata:
+  name: workspace-drift
+spec:
+  displayName: "Drift Repair Test"
+  image: jk8s-application-jupyter-uv:latest
+  desiredStatus: Running
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi

--- a/test/e2e/static/gpu/gpu-cpu-only-workspace.yaml
+++ b/test/e2e/static/gpu/gpu-cpu-only-workspace.yaml
@@ -1,0 +1,17 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: Workspace
+metadata:
+  name: gpu-cpu-only-workspace
+spec:
+  displayName: "GPU Opt-Out Test"
+  templateRef:
+    name: gpu-template
+    namespace: jupyter-k8s-shared
+  ownershipType: Public
+  resources:
+    requests:
+      cpu: 200m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi

--- a/test/e2e/static/gpu/gpu-default-workspace.yaml
+++ b/test/e2e/static/gpu/gpu-default-workspace.yaml
@@ -1,0 +1,10 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: Workspace
+metadata:
+  name: gpu-default-workspace
+spec:
+  displayName: "GPU Defaults Test"
+  templateRef:
+    name: gpu-template
+    namespace: jupyter-k8s-shared
+  ownershipType: Public

--- a/test/e2e/static/gpu/gpu-exceed-workspace.yaml
+++ b/test/e2e/static/gpu/gpu-exceed-workspace.yaml
@@ -1,0 +1,20 @@
+# cpu/memory stay within bounds so the rejection is attributable to the GPU
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: Workspace
+metadata:
+  name: gpu-exceed-workspace
+spec:
+  displayName: "GPU Bounds Test"
+  templateRef:
+    name: gpu-template
+    namespace: jupyter-k8s-shared
+  ownershipType: Public
+  resources:
+    requests:
+      cpu: 200m
+      memory: 256Mi
+      nvidia.com/gpu: "3"  # Exceeds the template max of 2
+    limits:
+      cpu: 500m
+      memory: 512Mi
+      nvidia.com/gpu: "3"

--- a/test/e2e/static/gpu/gpu-no-template-workspace.yaml
+++ b/test/e2e/static/gpu/gpu-no-template-workspace.yaml
@@ -1,0 +1,8 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: Workspace
+metadata:
+  name: gpu-no-template-workspace
+spec:
+  displayName: "GPU Off Path Test"
+  image: jk8s-application-jupyter-uv:latest
+  desiredStatus: Running

--- a/test/e2e/static/gpu/gpu-override-workspace.yaml
+++ b/test/e2e/static/gpu/gpu-override-workspace.yaml
@@ -1,0 +1,19 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: Workspace
+metadata:
+  name: gpu-override-workspace
+spec:
+  displayName: "GPU Override Test"
+  templateRef:
+    name: gpu-template
+    namespace: jupyter-k8s-shared
+  ownershipType: Public
+  resources:
+    requests:
+      cpu: 200m
+      memory: 256Mi
+      nvidia.com/gpu: "2"  # At the template max of 2
+    limits:
+      cpu: 500m
+      memory: 512Mi
+      nvidia.com/gpu: "2"

--- a/test/e2e/static/gpu/gpu-template.yaml
+++ b/test/e2e/static/gpu/gpu-template.yaml
@@ -1,0 +1,40 @@
+# GPU workspace template: bounded nvidia.com/gpu resources plus placement
+# defaults pinning pods to the fake-GPU node (see helpers_gpu.go)
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: WorkspaceTemplate
+metadata:
+  name: gpu-template
+  namespace: jupyter-k8s-shared
+spec:
+  displayName: "GPU Jupyter Notebook"
+  description: "Notebook with bounded GPU resources, pinned to GPU nodes"
+  defaultImage: jk8s-application-jupyter-uv:latest
+  defaultResources:
+    requests:
+      cpu: 200m
+      memory: 256Mi
+      nvidia.com/gpu: "1"
+    limits:
+      cpu: 500m
+      memory: 512Mi
+      nvidia.com/gpu: "1"
+  resourceBounds:
+    resources:
+      cpu:
+        min: 100m
+        max: 2
+      memory:
+        min: 128Mi
+        max: 4Gi
+      nvidia.com/gpu:
+        min: "0"
+        max: "2"
+  defaultNodeSelector:
+    e2e.jupyter.org/fake-gpu: "true"
+  defaultTolerations:
+    - key: nvidia.com/gpu
+      operator: Exists
+      effect: NoSchedule
+  primaryStorage:
+    defaultSize: 1Gi
+  appType: jupyter

--- a/test/e2e/workspace_drift_test.go
+++ b/test/e2e/workspace_drift_test.go
@@ -1,0 +1,120 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"os/exec"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jupyter-infra/jupyter-k8s/internal/controller"
+	"github.com/jupyter-infra/jupyter-k8s/test/utils"
+)
+
+// Workspace Drift Repair: the controller watches the Deployment and Service it owns
+// (Owns() in SetupWithManager), so out-of-band changes trigger a reconcile that repairs
+// them: a deleted owned resource is recreated, and a mutated pod template is rewritten
+// to the workspace-defined spec.
+var _ = Describe("Workspace Drift Repair", Ordered, func() {
+	const (
+		workspaceNamespace = "default"
+		groupDir           = "drift"
+		workspaceName      = "workspace-drift"
+	)
+
+	AfterEach(func() {
+		deleteResourcesForDriftTest(workspaceNamespace)
+	})
+
+	It("should recreate the Service after an out-of-band deletion", func() {
+		By("creating a running workspace")
+		createWorkspaceForTest(workspaceName, groupDir, "")
+
+		By("waiting for the workspace to become Available")
+		WaitForWorkspaceToReachCondition(
+			workspaceName, workspaceNamespace, controller.ConditionTypeAvailable, ConditionTrue)
+
+		serviceName := GetWorkspaceServiceName(workspaceName, workspaceNamespace)
+
+		By("capturing the service UID before deletion")
+		oldUID, err := kubectlGet("service", serviceName, workspaceNamespace, "{.metadata.uid}")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(oldUID).NotTo(BeEmpty())
+
+		By("deleting the service out of band")
+		cmd := exec.Command("kubectl", "delete", "service", serviceName,
+			"-n", workspaceNamespace, "--wait=true")
+		_, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("verifying the operator recreates the service")
+		Eventually(func(g Gomega) {
+			newUID, err := kubectlGet("service", serviceName, workspaceNamespace, "{.metadata.uid}")
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(newUID).NotTo(BeEmpty())
+			g.Expect(newUID).NotTo(Equal(oldUID), "the service must be a new object")
+		}).WithTimeout(60 * time.Second).WithPolling(2 * time.Second).Should(Succeed())
+
+		By("verifying the workspace settles Available with the recreated service")
+		WaitForWorkspaceToReachCondition(
+			workspaceName, workspaceNamespace, controller.ConditionTypeAvailable, ConditionTrue)
+	})
+
+	It("should revert an out-of-band mutation of the deployment pod template", func() {
+		By("creating a running workspace")
+		createWorkspaceForTest(workspaceName, groupDir, "")
+
+		By("waiting for the workspace to become Available")
+		WaitForWorkspaceToReachCondition(
+			workspaceName, workspaceNamespace, controller.ConditionTypeAvailable, ConditionTrue)
+
+		deploymentName, err := kubectlGet("workspace", workspaceName, workspaceNamespace,
+			"{.status.deploymentName}")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(deploymentName).NotTo(BeEmpty())
+
+		imageJSONPath := fmt.Sprintf("{.spec.template.spec.containers[?(@.name=='%s')].image}",
+			controller.PrimaryContainerName)
+		originalImage, err := kubectlGet("deployment", deploymentName, workspaceNamespace, imageJSONPath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(originalImage).NotTo(BeEmpty())
+
+		By("mutating the primary container image out of band")
+		patch := fmt.Sprintf(
+			`{"spec":{"template":{"spec":{"containers":[{"name":"%s","image":"drifted-image:latest"}]}}}}`,
+			controller.PrimaryContainerName)
+		cmd := exec.Command("kubectl", "patch", "deployment", deploymentName,
+			"-n", workspaceNamespace, "--type=strategic", "-p", patch)
+		_, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("verifying the operator reverts the image to the workspace-defined one")
+		Eventually(func(g Gomega) {
+			image, err := kubectlGet("deployment", deploymentName, workspaceNamespace, imageJSONPath)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(image).To(Equal(originalImage))
+		}).WithTimeout(60 * time.Second).WithPolling(2 * time.Second).Should(Succeed())
+
+		By("verifying the workspace settles Available after the revert")
+		WaitForWorkspaceToReachCondition(
+			workspaceName, workspaceNamespace, controller.ConditionTypeAvailable, ConditionTrue)
+	})
+})
+
+// deleteResourcesForDriftTest removes only the objects this Ordered suite creates, by
+// explicit name, so it can never nuke unrelated objects sharing the "default" namespace.
+func deleteResourcesForDriftTest(workspaceNamespace string) {
+	By("cleaning up the drift test workspace")
+	cmd := exec.Command("kubectl", "delete", "workspace", "workspace-drift",
+		"-n", workspaceNamespace, "--ignore-not-found", "--wait=true", "--timeout=120s")
+	_, _ = utils.Run(cmd)
+}

--- a/test/e2e/workspace_gpu_test.go
+++ b/test/e2e/workspace_gpu_test.go
@@ -1,0 +1,218 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright (c) Amazon Web Services
+Distributed under the terms of the MIT license
+*/
+
+package e2e
+
+import (
+	"os/exec"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	workspacev1alpha1 "github.com/jupyter-infra/jupyter-k8s/api/v1alpha1"
+	"github.com/jupyter-infra/jupyter-k8s/internal/controller"
+	"github.com/jupyter-infra/jupyter-k8s/test/utils"
+)
+
+// Workspace GPU: template-driven GPU resources and placement, end to end on a fake GPU node.
+//
+// Kind has no GPUs, so the suite advertises nvidia.com/gpu on the node (helpers_gpu.go) and
+// exercises the operator's contract: template defaultResources, defaultNodeSelector and
+// defaultTolerations reach the workspace pod, the pod schedules against the advertised capacity,
+// resourceBounds reject out-of-bounds GPU requests, and non-GPU workspaces stay GPU-free.
+var _ = Describe("Workspace GPU", Ordered, func() {
+	const (
+		workspaceNamespace = "default"
+		groupDir           = "gpu"
+		gpuTemplateName    = "gpu-template"
+	)
+
+	var gpuNodeName string
+
+	BeforeAll(func() {
+		gpuNodeName = setupFakeGPUNode()
+	})
+
+	AfterAll(func() {
+		teardownFakeGPUNode(gpuNodeName)
+	})
+
+	AfterEach(func() {
+		deleteResourcesForGPUTest(workspaceNamespace)
+	})
+
+	Context("Template propagation", func() {
+		It("should propagate template GPU defaults and placement to the pod and schedule it", func() {
+			workspaceName := "gpu-default-workspace"
+
+			By("creating the GPU template")
+			createTemplateForTest(gpuTemplateName, groupDir, "")
+
+			By("creating a workspace with no resources or scheduling fields")
+			createWorkspaceForTest(workspaceName, groupDir, "")
+
+			By("waiting for the workspace to become available")
+			WaitForWorkspaceToReachCondition(
+				workspaceName, workspaceNamespace, controller.ConditionTypeAvailable, ConditionTrue)
+
+			By("verifying Available=True, Progressing=False, Degraded=False, Stopped=False")
+			VerifyWorkspaceConditions(workspaceName, workspaceNamespace, map[string]string{
+				controller.ConditionTypeProgressing: ConditionFalse,
+				controller.ConditionTypeDegraded:    ConditionFalse,
+				controller.ConditionTypeAvailable:   ConditionTrue,
+				controller.ConditionTypeStopped:     ConditionFalse,
+				ConditionTypeDeleting:               ConditionFalse,
+			})
+
+			By("verifying defaulting copied GPU resources and placement onto the workspace")
+			var ws workspacev1alpha1.Workspace
+			Expect(kubectlGetInto("workspace", workspaceName, workspaceNamespace, &ws)).To(Succeed())
+			Expect(ws.Spec.Resources).NotTo(BeNil(), "defaulting must copy the template defaultResources")
+			gpus, ok := gpuQuantity(ws.Spec.Resources.Requests)
+			Expect(ok).To(BeTrue(), "defaulting must copy the template GPU request")
+			Expect(gpus).To(Equal(int64(1)))
+			gpus, ok = gpuQuantity(ws.Spec.Resources.Limits)
+			Expect(ok).To(BeTrue(), "defaulting must copy the template GPU limit")
+			Expect(gpus).To(Equal(int64(1)))
+			Expect(ws.Spec.NodeSelector).To(HaveKeyWithValue(fakeGPUNodeLabel, valueTrue),
+				"defaulting must copy the template defaultNodeSelector")
+			Expect(hasToleration(ws.Spec.Tolerations, fakeGPUResourceName,
+				corev1.TolerationOpExists, corev1.TaintEffectNoSchedule)).To(BeTrue(),
+				"defaulting must copy the template defaultTolerations")
+
+			By("verifying GPU resources and placement reached the pod")
+			pod := workspacePod(workspaceName, workspaceNamespace)
+			primary := containerByName(pod.Spec, controller.PrimaryContainerName)
+			Expect(primary).NotTo(BeNil())
+			gpus, ok = gpuQuantity(primary.Resources.Requests)
+			Expect(ok).To(BeTrue(), "the pod must request the GPU")
+			Expect(gpus).To(Equal(int64(1)))
+			gpus, ok = gpuQuantity(primary.Resources.Limits)
+			Expect(ok).To(BeTrue(), "the pod must limit the GPU")
+			Expect(gpus).To(Equal(int64(1)))
+			Expect(pod.Spec.NodeSelector).To(HaveKeyWithValue(fakeGPUNodeLabel, valueTrue))
+			Expect(hasToleration(pod.Spec.Tolerations, fakeGPUResourceName,
+				corev1.TolerationOpExists, corev1.TaintEffectNoSchedule)).To(BeTrue())
+
+			By("verifying the pod scheduled onto the GPU-advertising node")
+			Expect(pod.Spec.NodeName).To(Equal(gpuNodeName))
+			Expect(pod.Status.Phase).To(Equal(corev1.PodRunning))
+		})
+
+		It("should honor a workspace GPU request within template bounds", func() {
+			workspaceName := "gpu-override-workspace"
+
+			By("creating the GPU template")
+			createTemplateForTest(gpuTemplateName, groupDir, "")
+
+			By("creating a workspace requesting 2 GPUs (the template max)")
+			createWorkspaceForTest(workspaceName, groupDir, "")
+
+			By("waiting for the workspace to become available")
+			WaitForWorkspaceToReachCondition(
+				workspaceName, workspaceNamespace, controller.ConditionTypeAvailable, ConditionTrue)
+
+			By("verifying the pod carries the overridden GPU request and limit")
+			pod := workspacePod(workspaceName, workspaceNamespace)
+			primary := containerByName(pod.Spec, controller.PrimaryContainerName)
+			Expect(primary).NotTo(BeNil())
+			gpus, ok := gpuQuantity(primary.Resources.Requests)
+			Expect(ok).To(BeTrue())
+			Expect(gpus).To(Equal(int64(2)), "the workspace override must win over the template default")
+			gpus, ok = gpuQuantity(primary.Resources.Limits)
+			Expect(ok).To(BeTrue())
+			Expect(gpus).To(Equal(int64(2)))
+
+			By("verifying the pod scheduled onto the GPU-advertising node")
+			Expect(pod.Spec.NodeName).To(Equal(gpuNodeName))
+		})
+	})
+
+	Context("Validation", func() {
+		It("should reject a workspace requesting GPUs above the template bound", func() {
+			workspaceName := "gpu-exceed-workspace"
+
+			By("creating the GPU template")
+			createTemplateForTest(gpuTemplateName, groupDir, "")
+
+			By("attempting to create a workspace requesting 3 GPUs (bounds max is 2)")
+			path := BuildTestResourcePath(workspaceName, groupDir, "")
+			cmd := exec.Command("kubectl", "apply", "-f", path)
+			output, err := utils.Run(cmd)
+			Expect(err).To(HaveOccurred(), "webhook should reject a GPU request above the template max")
+			Expect(output).To(ContainSubstring(fakeGPUResourceName),
+				"the rejection should name the violating GPU resource")
+
+			By("verifying the workspace was not created")
+			cmd = exec.Command("kubectl", verbGet, "workspace", workspaceName,
+				"-n", workspaceNamespace, "--ignore-not-found")
+			output, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).To(BeEmpty(), "workspace should not exist after webhook rejection")
+		})
+	})
+
+	Context("GPU-off path", func() {
+		It("should not inject GPU defaults when a workspace overrides resources with CPU-only values", func() {
+			workspaceName := "gpu-cpu-only-workspace"
+
+			By("creating the GPU template")
+			createTemplateForTest(gpuTemplateName, groupDir, "")
+
+			By("creating a workspace overriding resources with cpu/memory only")
+			createWorkspaceForTest(workspaceName, groupDir, "")
+
+			By("waiting for the workspace to become available")
+			WaitForWorkspaceToReachCondition(
+				workspaceName, workspaceNamespace, controller.ConditionTypeAvailable, ConditionTrue)
+
+			By("verifying the pod has no GPU in requests or limits")
+			pod := workspacePod(workspaceName, workspaceNamespace)
+			primary := containerByName(pod.Spec, controller.PrimaryContainerName)
+			Expect(primary).NotTo(BeNil())
+			_, ok := gpuQuantity(primary.Resources.Requests)
+			Expect(ok).To(BeFalse(),
+				"resource defaulting is all-or-nothing; explicit CPU-only resources must not gain a GPU")
+			_, ok = gpuQuantity(primary.Resources.Limits)
+			Expect(ok).To(BeFalse())
+		})
+
+		It("should leave a workspace without a template free of GPU resources and placement", func() {
+			workspaceName := "gpu-no-template-workspace"
+
+			By("creating a workspace with no template reference")
+			createWorkspaceForTest(workspaceName, groupDir, "")
+
+			By("waiting for the workspace to become available")
+			WaitForWorkspaceToReachCondition(
+				workspaceName, workspaceNamespace, controller.ConditionTypeAvailable, ConditionTrue)
+
+			By("verifying the deployment pod template has no GPU resources or placement fields")
+			deploymentName, err := kubectlGet("workspace", workspaceName, workspaceNamespace,
+				"{.status.deploymentName}")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(deploymentName).NotTo(BeEmpty())
+
+			// Assert on the deployment, not the pod: pod admission injects cluster-default
+			// tolerations (not-ready/unreachable) that would defeat an emptiness check.
+			var deploy appsv1.Deployment
+			Expect(kubectlGetInto("deployment", deploymentName, workspaceNamespace, &deploy)).To(Succeed())
+			podSpec := deploy.Spec.Template.Spec
+			Expect(podSpec.NodeSelector).To(BeEmpty())
+			Expect(podSpec.Tolerations).To(BeEmpty())
+			primary := containerByName(podSpec, controller.PrimaryContainerName)
+			Expect(primary).NotTo(BeNil())
+			_, ok := gpuQuantity(primary.Resources.Requests)
+			Expect(ok).To(BeFalse())
+			_, ok = gpuQuantity(primary.Resources.Limits)
+			Expect(ok).To(BeFalse())
+		})
+	})
+})

--- a/test/e2e/workspace_storage_test.go
+++ b/test/e2e/workspace_storage_test.go
@@ -9,6 +9,7 @@ Distributed under the terms of the MIT license
 package e2e
 
 import (
+	"fmt"
 	"os/exec"
 	"time"
 
@@ -256,6 +257,83 @@ var _ = Describe("Workspace Storage", Ordered, func() {
 			RestartWorkspacePod(workspaceName, workspaceNamespace)
 
 			By("verifying the data was persisted")
+			VerifyHomeVolumeDataPersisted(workspaceName, workspaceNamespace)
+		})
+
+		It("should retain the PVC and persist data across Stopped and back to Running", func() {
+			workspaceFilename := baseWorkspaceName
+			workspaceName := baseWorkspaceName
+
+			By("creating a workspace with a pvc")
+			createWorkspaceForTest(workspaceFilename, group, baseSubgroup)
+
+			By("waiting for the workspace to become Available")
+			WaitForWorkspaceToReachCondition(
+				workspaceName,
+				workspaceNamespace,
+				ConditionTypeAvailable,
+				ConditionTrue,
+			)
+
+			By("capturing the deployment and service names before stopping")
+			deploymentName, err := kubectlGet("workspace", workspaceName, workspaceNamespace,
+				"{.status.deploymentName}")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(deploymentName).NotTo(BeEmpty())
+			serviceName, err := kubectlGet("workspace", workspaceName, workspaceNamespace,
+				"{.status.serviceName}")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(serviceName).NotTo(BeEmpty())
+
+			By("writing data to the home volume")
+			VerifyPodCanAccessHomeVolume(workspaceName, workspaceNamespace)
+
+			By("changing desiredStatus to Stopped")
+			UpdateWorkspaceDesiredState(workspaceName, workspaceNamespace, "Stopped")
+
+			By("waiting for the Stopped condition to become True")
+			WaitForWorkspaceToReachCondition(
+				workspaceName,
+				workspaceNamespace,
+				ConditionTypeStopped,
+				ConditionTrue,
+			)
+
+			By("verifying the deployment and service are deleted")
+			WaitForResourceToNotExist("deployment", deploymentName, workspaceNamespace,
+				60*time.Second, 3*time.Second)
+			WaitForResourceToNotExist("service", serviceName, workspaceNamespace,
+				60*time.Second, 3*time.Second)
+
+			By("verifying no pods remain")
+			Eventually(func(g Gomega) {
+				output, err := kubectlGetByLabels("pod",
+					fmt.Sprintf("%s=%s", WorkspaceLabelName, workspaceName),
+					workspaceNamespace, "{.items[*].metadata.name}")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(BeEmpty())
+			}).WithTimeout(60 * time.Second).WithPolling(3 * time.Second).Should(Succeed())
+
+			By("verifying the PVC is retained and still bound")
+			pvcName := controller.GeneratePVCName(workspaceName)
+			Expect(ResourceExists("pvc", pvcName, workspaceNamespace, "{.metadata.name}")).
+				To(BeTrue(), "the PVC must survive the Stopped state")
+			phase, err := kubectlGet("pvc", pvcName, workspaceNamespace, jsonPathStatusPhase)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(phase).To(Equal(phaseBound))
+
+			By("changing desiredStatus back to Running")
+			UpdateWorkspaceDesiredState(workspaceName, workspaceNamespace, "Running")
+
+			By("waiting for the workspace to become Available again")
+			WaitForWorkspaceToReachCondition(
+				workspaceName,
+				workspaceNamespace,
+				ConditionTypeAvailable,
+				ConditionTrue,
+			)
+
+			By("verifying the data written before the stop is still there")
 			VerifyHomeVolumeDataPersisted(workspaceName, workspaceNamespace)
 		})
 	})


### PR DESCRIPTION
GPU contract e2e that runs on plain Kind, plus lifecycle coverage for data persistence and out-of-band drift. Scheduling and resource propagation are API-server and scheduler behavior, so a node that merely advertises fake GPU capacity exercises them without hardware; only CUDA itself needs a real GPU, and that lives in jupyter-deploy's EKS e2e.

### Implementation

1. `test/e2e/helpers_gpu.go`: `setupFakeGPUNode` labels the cluster's first node and patches `nvidia.com/gpu` into its status capacity and allocatable together. Patching both matters: the kubelet only recomputes allocatable from capacity on its periodic status update, so patching capacity alone leaves the two inconsistent for the scheduler. Teardown restores the node.
2. `test/e2e/workspace_gpu_test.go` pins the GPU contracts against a bounded GPU template fixture: template GPU defaults and placement (nodeSelector, toleration) propagate to the pod and it schedules onto the advertising node; a workspace GPU request within template bounds is honored; a request above the bound is rejected by validation and the error names the GPU resource; a CPU-only resource override gains no injected GPU defaults; and a workspace without a template stays free of GPU resources and placement.
3. `test/e2e/workspace_storage_test.go` adds the stop/start data-persistence spec: write a file, stop (pod deleted, PVC retained and Bound), start on a fresh pod, and the file is still there.
4. `test/e2e/workspace_drift_test.go`: deleting the workspace's Service out of band gets it recreated as a new object, and an out-of-band mutation of the deployment's pod template is reverted, both driven by the controller's watch on the resources it owns.
5. Fixtures under `test/e2e/static/gpu/` and `test/e2e/static/drift/`.

### Testing

Adds eight e2e specs: the five GPU contract specs, the stop/start persistence spec, and the two drift-repair specs. They compile into the existing Kind e2e lane and run on every PR; no workflow changes.
